### PR TITLE
Make Tab key do the same as arrow key down in tab completion mode

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/DwarvenMinesWaypoints.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/DwarvenMinesWaypoints.java
@@ -208,10 +208,10 @@ public class DwarvenMinesWaypoints {
                 if (locWaypoint >= 2) {
                     RenderUtils.renderWayPoint(EnumChatFormatting.AQUA + entry.getKey(), entry.getValue(), event.partialTicks);
                 } else {
-                    String commissionLocation = entry.getKey().toLowerCase().replace("'", "");
+                    String commissionLocation = entry.getKey().toLowerCase();
                     for (String commissionName : MiningOverlay.commissionProgress.keySet()) {
                         if (NotEnoughUpdates.INSTANCE.config.mining.hideWaypointIfAtLocation)
-                            if (commissionLocation.equals(skyblockLocation)) continue;
+                            if (commissionLocation.replace("'", "").equals(skyblockLocation)) continue;
                         if (commissionName.toLowerCase().contains(commissionLocation)) {
                             if (commissionName.contains("Titanium")) {
                                 RenderUtils.renderWayPoint(EnumChatFormatting.WHITE + entry.getKey(), entry.getValue(), event.partialTicks);

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/AuctionSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/AuctionSearchOverlay.java
@@ -206,7 +206,6 @@ public class AuctionSearchOverlay {
     private static final AtomicInteger searchId = new AtomicInteger(0);
 
     private static String getItemIdAtIndex(int i) {
-        System.out.println(i);
         if (!autocompletedItems.isEmpty()) {
             if ((i > autocompletedItems.size() - 1) || i < 0 || i > 4) {
                 return "";


### PR DESCRIPTION
Currently when the search bar is in tab-completed mode pressing Tab will just reset it to the first position. 
With this pr I changed the handling of the keys slightly and while in tab-completed mode, pressing Tab will now do the same as pressing the down-arrow key.