### PR TITLE
Go to the other end of the tab-completion List when hitting the end

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/AuctionSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/AuctionSearchOverlay.java
@@ -427,14 +427,9 @@ public class AuctionSearchOverlay {
         }
 
         if (Keyboard.getEventKeyState()) {
-            System.out.println("----------");
-            System.out.println(ignoreKey);
-            System.out.println(tabCompleted);
-            System.out.println("----------");
             if (tabCompleted) {
                 if (!ignoreKey) {
                     boolean success = updateTabCompletedSearch(Keyboard.getEventKey());
-                    System.out.println(success);
                     if (success) return;
                     textField.setFocus(true);
                     textField.setText(searchString);


### PR DESCRIPTION
When you hit the end of the list with the arrow keys (or tab) it will now go to the other end of the list. 
For example if you hit the bottom and keep going you will go back to the top again.