### PR TITLE
Load wiki pages asynchronously

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -9,7 +9,6 @@ import io.github.moulberry.notenoughupdates.core.BackgroundBlur;
 import io.github.moulberry.notenoughupdates.core.GuiScreenElementWrapper;
 import io.github.moulberry.notenoughupdates.core.util.lerp.LerpingInteger;
 import io.github.moulberry.notenoughupdates.infopanes.DevInfoPane;
-import io.github.moulberry.notenoughupdates.infopanes.HTMLInfoPane;
 import io.github.moulberry.notenoughupdates.infopanes.InfoPane;
 import io.github.moulberry.notenoughupdates.infopanes.TextInfoPane;
 import io.github.moulberry.notenoughupdates.itemeditor.NEUItemEditor;
@@ -50,7 +49,6 @@ import net.minecraft.util.Matrix4f;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.client.ClientCommandHandler;
-import org.apache.commons.lang3.StringUtils;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
@@ -61,6 +59,7 @@ import java.awt.*;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -158,6 +157,8 @@ public class NEUOverlay extends Gui {
     private int lastScreenWidth;
     private int lastScreenHeight;
     private int lastScale;
+
+    private CompletableFuture<Void> infoPaneLoadingJob = CompletableFuture.completedFuture(null);
 
     private List<String> textToDisplay = null;
 
@@ -628,6 +629,7 @@ public class NEUOverlay extends Gui {
         searchBarHasFocus = false;
         if (!(searchMode || (NotEnoughUpdates.INSTANCE.config.itemlist.keepopen && itemPaneOpen))) {
             itemPaneOpen = false;
+            displayInformationPane(null);
             itemPaneOffsetFactor.setValue(1);
             itemPaneTabOffset.setValue(20);
         }
@@ -641,24 +643,19 @@ public class NEUOverlay extends Gui {
     public void showInfo(JsonObject item) {
         if (item.has("info") && item.has("infoType")) {
             JsonArray lore = item.get("info").getAsJsonArray();
-            String[] loreA = new String[lore.size()];
-            for (int i = 0; i < lore.size(); i++) loreA[i] = lore.get(i).getAsString();
-            String loreS = StringUtils.join(loreA, "\n");
-
+            StringBuilder loreBuilder = new StringBuilder();
+            for (int i = 0; i < lore.size(); i++) {
+                loreBuilder.append(lore.get(i).getAsString());
+                if (i != lore.size() - 1)
+                    loreBuilder.append("\n");
+            }
+            String infoText = loreBuilder.toString();
             String internalname = item.get("internalname").getAsString();
             String name = item.get("displayname").getAsString();
-            switch (item.get("infoType").getAsString()) {
-                case "WIKI_URL":
-                    displayInformationPane(HTMLInfoPane.createFromWikiUrl(this, manager, name, loreS));
-                    return;
-                case "WIKI":
-                    displayInformationPane(HTMLInfoPane.createFromWiki(this, manager, name, internalname, loreS));
-                    return;
-                case "HTML":
-                    displayInformationPane(new HTMLInfoPane(this, manager, name, internalname, loreS));
-                    return;
-            }
-            displayInformationPane(new TextInfoPane(this, manager, name, loreS));
+            String infoType = item.get("infoType").getAsString();
+            displayInformationPane(new TextInfoPane(this, manager, "Loading", "Loading your requested information about " + name + "."));
+            infoPaneLoadingJob = InfoPane.create(this, manager, infoType, name, internalname, infoText)
+                    .thenAccept(this::displayInformationPane);
         }
     }
 
@@ -882,6 +879,7 @@ public class NEUOverlay extends Gui {
      * Sets the activeInfoPane and sets the target of the infoPaneOffsetFactor to make the infoPane "slide" out.
      */
     public void displayInformationPane(InfoPane pane) {
+        infoPaneLoadingJob.cancel(false);
         if (pane == null) {
             infoPaneOffsetFactor.setTarget(0);
         } else {

--- a/src/main/java/io/github/moulberry/notenoughupdates/infopanes/InfoPane.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/infopanes/InfoPane.java
@@ -8,6 +8,7 @@ import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.ScaledResolution;
 
 import java.awt.*;
+import java.util.concurrent.CompletableFuture;
 
 public abstract class InfoPane extends Gui {
 
@@ -46,6 +47,23 @@ public abstract class InfoPane extends Gui {
                 boxRight - boxLeft, height - overlay.getBoxPadding() * 2 + 10, true);
         drawRect(boxLeft, overlay.getBoxPadding() - 5, boxRight,
                 height - overlay.getBoxPadding() + 5, bg.getRGB());
+    }
+
+    public static CompletableFuture<? extends InfoPane> create(NEUOverlay overlay, NEUManager manager, String infoType,
+                                                               String name, String internalName, String infoText) {
+        switch (infoType.intern()) {
+            case "WIKI_URL":
+                return HTMLInfoPane.createFromWikiUrl(overlay, manager, name, infoText);
+            case "WIKI":
+                return CompletableFuture.completedFuture(
+                        HTMLInfoPane.createFromWikiText(overlay, manager, name, internalName, infoText));
+            case "HTML":
+                return CompletableFuture.completedFuture(
+                        new HTMLInfoPane(overlay, manager, name, internalName, infoText));
+            default:
+                return CompletableFuture.completedFuture(
+                        new TextInfoPane(overlay, manager, name, infoText));
+        }
     }
 
 }


### PR DESCRIPTION
Previous to this commit, wiki pages would be downloaded on the main
rendering thread, preventing all rendering and user interaction while
the download was occuring. This has now been shifted to the common
forkpool provided by the JVM.