### PR TITLE
Fix crash in profile viewer

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/GuiProfileViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/GuiProfileViewer.java
@@ -3910,7 +3910,7 @@ public class GuiProfileViewer extends GuiScreen {
     private String getTimeSinceString(JsonObject profileInfo, String path) {
         JsonElement lastSaveElement = Utils.getElement(profileInfo, path);
 
-        if (lastSaveElement.isJsonPrimitive()) {
+        if (lastSaveElement != null && lastSaveElement.isJsonPrimitive()) {
 
             Instant lastSave = Instant.ofEpochMilli(lastSaveElement.getAsLong());
             LocalDateTime lastSaveTime = LocalDateTime.ofInstant(lastSave, TimeZone.getDefault().toZoneId());


### PR DESCRIPTION
Add a null check to fix this crash I hit a couple times in a row:

java.lang.NullPointerException: Rendering screen
	at io.github.moulberry.notenoughupdates.profileviewer.GuiProfileViewer.getTimeSinceString(GuiProfileViewer.java:3883)
	at io.github.moulberry.notenoughupdates.profileviewer.GuiProfileViewer.drawExtraPage(GuiProfileViewer.java:2603)
	at io.github.moulberry.notenoughupdates.profileviewer.GuiProfileViewer.func_73863_a(GuiProfileViewer.java:268)
	at net.minecraftforge.client.ForgeHooksClient.drawScreen(ForgeHooksClient.java:311)
	at net.minecraft.client.renderer.EntityRenderer.func_181560_a(EntityRenderer.java:1436)
	at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1051)
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:349)
	at net.minecraft.client.main.Main.main(SourceFile:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
