### PR TITLE
shorter message for outdated price warning

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/ItemPriceInformation.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/ItemPriceInformation.java
@@ -74,7 +74,7 @@ public class ItemPriceInformation {
             long lastUpdate = NotEnoughUpdates.INSTANCE.manager.auctionManager.getLastLowestBinUpdateTime();
             //check if info is older than 10 minutes
             if (currentTime - lastUpdate > 600 * 1000) {
-                tooltip.add(EnumChatFormatting.RED + "[NEU] Price info is outdated by more than 10 minutes.\nIt will updated again as soon as the server can be reached again.");
+                tooltip.add(EnumChatFormatting.RED + "[NEU] Price info is outdated.");
             }
         }
 


### PR DESCRIPTION
The old one looked weird sometimes because of the `\n` and was a bit long.