### PR TITLE
Hide SlayerOverlay when not at a suitable location, made pet in inv force disabled and made new option to hide tooltip of pet

### DIFF
--- a/Update Notes/2.1.md
+++ b/Update Notes/2.1.md
@@ -7,8 +7,8 @@
 - Added slayer overlay
 - [Added mining tab in /pv](https://cdn.discordapp.com/attachments/832652653292027904/903619242384056370/unknown.png)
 - Big thanks to kwev1n for some math and jani for the texture
-- Added blocking clicks back to the enchanting minigames (because apparently its not bannable?)
-- [Donpireso replied to an sba dev's email about some of sba features and it seems to imply that blocking clicks in guis arent bannable](https://cdn.discordapp.com/attachments/823769568933576764/906101631861526559/unknown.png)
+- Added blocking clicks back to the enchanting minigames (because apparently, it's not bannable?)
+- [Donpireso replied to a sba dev's email about some of sba features, and it seems to imply that blocking clicks in guis aren't bannable](https://cdn.discordapp.com/attachments/823769568933576764/906101631861526559/unknown.png)
 - Fixed pet overlay not updating when going into /pets
 - [Added an armor overlay for the new armor slots](https://cdn.discordapp.com/attachments/832652653292027904/922399046528794634/unknown.png) 
 - Added a pet overlay that shows your active pet in your inventory
@@ -24,7 +24,7 @@
 - Added a toggle for enchant glint in storage gui (ty ery for texture)
 - Added fairy souls option to /neu misc
 - Make it so fairy souls are tracked independently for each profile - Lulonaut
-- Added a button in storage menu to open the settings
+- Added a button in the storage gui to open the settings
 - Added an option to change the click names for /pv to /ah
 - Added a help menu to /neuec
 - Made it so treecap shows foraging xp instead of farming xp on the farming overlay
@@ -42,7 +42,7 @@
 - Made /neustats modlist show normal /neustats if under 15 mods
 - Added max enchant book to /neuec - Dokm
 - [Added bingo and Stranded profile icons to /pv](https://cdn.discordapp.com/attachments/832652653292027904/915844465372065842/unknown.png)
-- Added an icon if neu doesnt know about a gamemode in /pv
+- Added an icon if neu doesn't know about a gamemode in /pv
 - Fixed pet overlay not resetting pet when making new profile
 - Added a warning in the tooltip when price info couldn't be found/is outdated - Lulonaut
 - Added "Has Advanced Tab" to /neustats

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
@@ -2580,7 +2580,7 @@ public class NEUEventListener {
     public void onItemTooltip(ItemTooltipEvent event) {
         if (!neu.isOnSkyblock()) return;
         //Render the pet inventory display tooltip to the left to avoid things from other mods rendering over the tooltip
-        if (event.itemStack.getTagCompound().getBoolean("NEUPETINVDISPLAY")) {
+        if (event.itemStack.getTagCompound() != null && event.itemStack.getTagCompound().getBoolean("NEUPETINVDISPLAY")) {
             GlStateManager.translate(-200, 0, 0);
         }
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
@@ -2474,6 +2474,9 @@ public class NEUEventListener {
             ItemPriceInformation.addToTooltip(event.toolTip, internalname, event.itemStack);
         }
 
+        if (event.itemStack.getTagCompound().getBoolean("NEUHIDEPETTOOLTIP") && NotEnoughUpdates.INSTANCE.config.petOverlay.hidePetTooltip) {
+            event.toolTip.clear();
+        }
     }
 
     private final Pattern xpLevelPattern = Pattern.compile("(.*) (\\xA7e(.*)\\xA76/\\xA7e(.*))");

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
@@ -2474,7 +2474,7 @@ public class NEUEventListener {
             ItemPriceInformation.addToTooltip(event.toolTip, internalname, event.itemStack);
         }
 
-        if (event.itemStack.getTagCompound().getBoolean("NEUHIDEPETTOOLTIP") && NotEnoughUpdates.INSTANCE.config.petOverlay.hidePetTooltip) {
+        if (event.itemStack.getTagCompound() != null && event.itemStack.getTagCompound().getBoolean("NEUHIDEPETTOOLTIP") && NotEnoughUpdates.INSTANCE.config.petOverlay.hidePetTooltip) {
             event.toolTip.clear();
         }
     }

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -1956,6 +1956,7 @@ public class NEUOverlay extends Gui {
                         NotEnoughUpdates.INSTANCE.manager.getItemInformation().get(
                                 PetInfoOverlay.getCurrentPet().petType + ";" + PetInfoOverlay.getCurrentPet().rarity.petId));
                 petSlot.getTagCompound().setBoolean("NEUPETINVDISPLAY", true);
+                petSlot.getTagCompound().setBoolean("NEUHIDEPETTOOLTIP", NotEnoughUpdates.INSTANCE.config.petOverlay.hidePetTooltip);
                 ItemStack petInfo = petSlot;
 
                 if (guiScreen instanceof GuiInventory) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -2024,6 +2024,7 @@ public class NEUOverlay extends Gui {
                     }
                 }
             }
+        }
 
             SunTzu.setEnabled(textField.getText().toLowerCase().startsWith("potato"));
 
@@ -2381,7 +2382,6 @@ public class NEUOverlay extends Gui {
                 searchMode = false;
             }
         }
-    }
 
     /**
      * Used in SettingsInfoPane to redraw the items when a setting changes.

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -1950,11 +1950,19 @@ public class NEUOverlay extends Gui {
         }
         if (PetInfoOverlay.getCurrentPet() != null) {
             if (NotEnoughUpdates.INSTANCE.config.petOverlay.petInvDisplay
-                    && NotEnoughUpdates.INSTANCE.manager.jsonToStack(NotEnoughUpdates.INSTANCE.manager.getItemInformation().get(PetInfoOverlay.getCurrentPet().petType + ";" + PetInfoOverlay.getCurrentPet().rarity.petId)).hasDisplayName()
+                    && (NotEnoughUpdates.INSTANCE.manager.jsonToStack(NotEnoughUpdates.INSTANCE.manager.getItemInformation().get(PetInfoOverlay.getCurrentPet().petType + ";" + PetInfoOverlay.getCurrentPet().rarity.petId)).hasDisplayName()
+                    || NotEnoughUpdates.INSTANCE.manager.jsonToStack(NotEnoughUpdates.INSTANCE.manager.getItemInformation().get(PetInfoOverlay.getCurrentPet().petType + ";" + (PetInfoOverlay.getCurrentPet().rarity.petId - 1))).hasDisplayName())
                     && NotEnoughUpdates.INSTANCE.config.misc.hidePotionEffect && NotEnoughUpdates.INSTANCE.hasSkyblockScoreboard()) {
-                petSlot = NotEnoughUpdates.INSTANCE.manager.jsonToStack(
-                        NotEnoughUpdates.INSTANCE.manager.getItemInformation().get(
-                                PetInfoOverlay.getCurrentPet().petType + ";" + PetInfoOverlay.getCurrentPet().rarity.petId));
+                if (!NotEnoughUpdates.INSTANCE.manager.jsonToStack(
+                        NotEnoughUpdates.INSTANCE.manager.getItemInformation().get(PetInfoOverlay.getCurrentPet().petType + ";" + PetInfoOverlay.getCurrentPet().rarity.petId)).hasDisplayName()) {
+                    petSlot = NotEnoughUpdates.INSTANCE.manager.jsonToStack(
+                            NotEnoughUpdates.INSTANCE.manager.getItemInformation().get(
+                                    PetInfoOverlay.getCurrentPet().petType + ";" + (PetInfoOverlay.getCurrentPet().rarity.petId - 1)));
+                } else {
+                    petSlot = NotEnoughUpdates.INSTANCE.manager.jsonToStack(
+                            NotEnoughUpdates.INSTANCE.manager.getItemInformation().get(
+                                    PetInfoOverlay.getCurrentPet().petType + ";" + PetInfoOverlay.getCurrentPet().rarity.petId));
+                }
                 petSlot.getTagCompound().setBoolean("NEUPETINVDISPLAY", true);
                 petSlot.getTagCompound().setBoolean("NEUHIDEPETTOOLTIP", NotEnoughUpdates.INSTANCE.config.petOverlay.hidePetTooltip);
                 ItemStack petInfo = petSlot;

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -62,7 +62,7 @@ public class PetInfoOverlay extends TextOverlay {
         RARE(11, 2, 3, EnumChatFormatting.BLUE),
         EPIC(16, 3, 4, EnumChatFormatting.DARK_PURPLE),
         LEGENDARY(20, 4, 5, EnumChatFormatting.GOLD),
-        MYTHIC(20, 4, 5, EnumChatFormatting.LIGHT_PURPLE);
+        MYTHIC(20, 5, 5, EnumChatFormatting.LIGHT_PURPLE);
 
         public int petOffset;
         public EnumChatFormatting chatFormatting;
@@ -833,8 +833,11 @@ public class PetInfoOverlay extends TextOverlay {
         }
 
         if (!NotEnoughUpdates.INSTANCE.config.petOverlay.petOverlayIcon) return;
-
-        JsonObject petItem = NotEnoughUpdates.INSTANCE.manager.getItemInformation().get(currentPet.petType + ";" + currentPet.rarity.petId);
+        int mythicRarity = currentPet.rarity.petId;
+        if (currentPet.rarity.petId == 5) {
+            mythicRarity = 4;
+        }
+        JsonObject petItem = NotEnoughUpdates.INSTANCE.manager.getItemInformation().get(currentPet.petType + ";" + mythicRarity);
         if (petItem != null) {
             Vector2f position = getPosition(overlayWidth, overlayHeight);
             int x = (int) position.x;

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/PetOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/PetOverlay.java
@@ -78,7 +78,7 @@ public class PetOverlay {
             desc = "Shows an overlay in your inventory showing your current pet"
     )
     @ConfigEditorBoolean
-    public boolean petInvDisplay = true;
+    public boolean petInvDisplay = false;
 
     @Expose
     @ConfigOption(
@@ -97,4 +97,12 @@ public class PetOverlay {
     )
     @ConfigEditorBoolean
     public boolean sendPetsCommand = true;
+
+    @Expose
+    @ConfigOption(
+            name = "Hide Pet Inventory Tooltip",
+            desc = "Hides the tooltip of your active in your inventory"
+    )
+    @ConfigEditorBoolean
+    public boolean hidePetTooltip = true;
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/PetOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/PetOverlay.java
@@ -104,5 +104,5 @@ public class PetOverlay {
             desc = "Hides the tooltip of your active in your inventory"
     )
     @ConfigEditorBoolean
-    public boolean hidePetTooltip = true;
+    public boolean hidePetTooltip = false;
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/SlayerOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/SlayerOverlay.java
@@ -29,6 +29,14 @@ public class SlayerOverlay {
 
     @Expose
     @ConfigOption(
+            name = "Only show when relevant",
+            desc = "Only shows the overlay when you are in an area where your current Slayer can be completed"
+    )
+    @ConfigEditorBoolean
+    public boolean onlyShowWhenRelevant = true;
+
+    @Expose
+    @ConfigOption(
             name = "Slayer Text",
             desc = "\u00a7eDrag text to change the appearance of the overlay"
     )

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
@@ -39,8 +39,9 @@ public class SlayerOverlay extends TextOverlay {
     }
 
     private boolean shouldUpdate() {
+        if (!NotEnoughUpdates.INSTANCE.config.slayerOverlay.onlyShowWhenRelevant || SBInfo.getInstance().stranded)
+            return true;
         //Ignore if on stranded
-        if (SBInfo.getInstance().stranded) return true;
         String scoreboardLocation = SBInfo.getInstance().location;
         String locrawLocation = SBInfo.getInstance().getLocation();
         //In case something is broken still show the overlay
@@ -50,7 +51,7 @@ public class SlayerOverlay extends TextOverlay {
                 if (!locrawLocation.equals("combat_1")) return false;
                 break;
             case "Revenant":
-                if (!locrawLocation.equals("hub") || !revenantLocations.contains(scoreboardLocation)) return false;
+                if ((!locrawLocation.equals("hub") || !revenantLocations.contains(scoreboardLocation)) && !locrawLocation.equals("crystal_hollows")) return false;
                 break;
             case "Sven":
                 if ((!locrawLocation.equals("hub") || !scoreboardLocation.equals("Ruins")) && (!locrawLocation.equals("foraging_1") || !scoreboardLocation.equals("Howling Cave")))

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
@@ -8,9 +8,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.util.EnumChatFormatting;
 
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import java.util.function.Supplier;
 
 public class SlayerOverlay extends TextOverlay {
@@ -19,27 +17,59 @@ public class SlayerOverlay extends TextOverlay {
     public static boolean isSlain = false;
     public static String slayerLVL = "-1";
     public static String slayerXp = "0";
+    public static long unloadOverlayTimer = -1;
+    public static long timeSinceLastBoss = 0;
+    public static long timeSinceLastBoss2 = 0;
+    public static int slayerTier = 0;
+
     private static String slayerEXP = "0";
     private static int slayerIntXP;
     private static int untilNextSlayerLevel;
     private static int xpToLevelUp;
     private static boolean useSmallXpNext = true;
-    public static long timeSinceLastBoss = 0;
-    public static long timeSinceLastBoss2 = 0;
     private static long agvSlayerTime = 0;
     private static boolean isSlayerNine = false;
-    public static int slayerTier = 0;
     private static int xpPerBoss = 0;
     private static int bossesUntilNextLevel = 0;
-    public static long unloadOverlayTimer = -1;
+    private final HashSet<String> revenantLocations = new HashSet<>(Arrays.asList("Graveyard", "Coal Mine"));
+    private boolean shouldUpdate = true;
 
     public SlayerOverlay(Position position, Supplier<List<String>> dummyStrings, Supplier<TextOverlayStyle> styleSupplier) {
         super(position, dummyStrings, styleSupplier);
     }
 
+    private boolean shouldUpdate() {
+        //Ignore if on stranded
+        if (SBInfo.getInstance().stranded) return true;
+        String scoreboardLocation = SBInfo.getInstance().location;
+        String locrawLocation = SBInfo.getInstance().getLocation();
+        //In case something is broken still show the overlay
+        if (locrawLocation == null || scoreboardLocation == null) return true;
+        switch (SBInfo.getInstance().slayer) {
+            case "Tarantula":
+                if (!locrawLocation.equals("combat_1")) return false;
+                break;
+            case "Revenant":
+                if (!locrawLocation.equals("hub") || !revenantLocations.contains(scoreboardLocation)) return false;
+                break;
+            case "Sven":
+                if ((!locrawLocation.equals("hub") || !scoreboardLocation.equals("Ruins")) && (!locrawLocation.equals("foraging_1") || !scoreboardLocation.equals("Howling Cave")))
+                    return false;
+                break;
+            case "Enderman":
+                if (!locrawLocation.equals("combat_3")) return false;
+                break;
+            default:
+                //A new slayer would need an update (see SBInfo)
+                return false;
+        }
+        return true;
+    }
+
     @Override
     public void update() {
-        if (!NotEnoughUpdates.INSTANCE.config.slayerOverlay.slayerOverlay) {
+        shouldUpdate = shouldUpdate();
+        if (!NotEnoughUpdates.INSTANCE.config.slayerOverlay.slayerOverlay || !shouldUpdate) {
             overlayStrings = null;
             return;
         }
@@ -142,7 +172,7 @@ public class SlayerOverlay extends TextOverlay {
     public void updateFrequent() {
         super.updateFrequent();
 
-        if (!slayerQuest || !NotEnoughUpdates.INSTANCE.config.slayerOverlay.slayerOverlay) {
+        if (!slayerQuest || !NotEnoughUpdates.INSTANCE.config.slayerOverlay.slayerOverlay || !shouldUpdate) {
             overlayStrings = null;
         } else {
             HashMap<Integer, String> lineMap = new HashMap<>();
@@ -150,20 +180,18 @@ public class SlayerOverlay extends TextOverlay {
             NumberFormat format = NumberFormat.getIntegerInstance();
             //System.out.println(SBInfo.getInstance().isSlain);
             overlayStrings = new ArrayList<>();
-            lineMap.put(0, EnumChatFormatting.YELLOW + "Slayer: " + EnumChatFormatting.DARK_RED + SBInfo.getInstance().slayer
-                    + EnumChatFormatting.GREEN + (isSlain ? " (Killed) " : " ")/* + slayerTier*/);
+            lineMap.put(0, EnumChatFormatting.YELLOW + "Slayer: " + EnumChatFormatting.DARK_RED + SBInfo.getInstance().slayer + EnumChatFormatting.GREEN + (isSlain ? " (Killed) " : " ")/* + slayerTier*/);
 
-           if (!RNGMeter.equals("?")) {
-               lineMap.put(1, EnumChatFormatting.YELLOW + "RNG Meter: " + EnumChatFormatting.DARK_PURPLE + RNGMeter);
-           }
+            if (!RNGMeter.equals("?")) {
+                lineMap.put(1, EnumChatFormatting.YELLOW + "RNG Meter: " + EnumChatFormatting.DARK_PURPLE + RNGMeter);
+            }
 
             if (!slayerLVL.equals("-1")) {
                 lineMap.put(2, EnumChatFormatting.YELLOW + "Lvl: " + EnumChatFormatting.LIGHT_PURPLE + slayerLVL);
             }
 
             if (timeSinceLastBoss > 0) {
-                lineMap.put(3, EnumChatFormatting.YELLOW + "Kill time: " + EnumChatFormatting.RED
-                        + Utils.prettyTime((System.currentTimeMillis() - timeSinceLastBoss)));
+                lineMap.put(3, EnumChatFormatting.YELLOW + "Kill time: " + EnumChatFormatting.RED + Utils.prettyTime((System.currentTimeMillis() - timeSinceLastBoss)));
             }
 
             if (slayerIntXP > 0) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
@@ -46,6 +46,7 @@ public class SBInfo {
     public String time = "";
     public String objective = "";
     public String slayer = "";
+    public boolean stranded = false;
 
     public String mode = "";
 
@@ -70,9 +71,8 @@ public class SBInfo {
         if (event.gui instanceof GuiChest) {
             GuiChest chest = (GuiChest) event.gui;
             ContainerChest container = (ContainerChest) chest.inventorySlots;
-            String containerName = container.getLowerChestInventory().getDisplayName().getUnformattedText();
 
-            lastOpenContainerName = containerName;
+            lastOpenContainerName = container.getLowerChestInventory().getDisplayName().getUnformattedText();
         }
     }
 
@@ -194,8 +194,8 @@ public class SBInfo {
             }
             isInDungeon = tempIsInDungeon;
 
+            boolean containsStranded = false;
             for (String line : lines) { //Slayer stuff
-                //System.out.println(line);
                 if (line.contains("Tarantula Broodfather")) {
                     slayer = "Tarantula";
                 } else if (line.contains("Revenant Horror")) {
@@ -226,7 +226,9 @@ public class SBInfo {
                         SlayerOverlay.slayerTier = 5;
                     }
                 }
+                if (line.contains("☀ Stranded")) containsStranded = true;
             }
+            stranded = containsStranded;
 
             if (lines.size() >= 5) {
                 date = Utils.cleanColour(lines.get(1)).trim();


### PR DESCRIPTION
This hides the Slayer overlay when the player is not at a Location where they can actually complete the current Slayer. - Lulo
Added new option to hide the tooltip of your pet in your inventory. - jani
Force disable pet in inventory on first startup. - jani
Also few grammar fixes - jani