### PR TITLE
Hide Hypixel reforge stats in Reforge Stone lore

### DIFF
--- a/Update Notes/2.1.md
+++ b/Update Notes/2.1.md
@@ -54,6 +54,7 @@
 - Added a way to include kismet feather to profit calculator - efefury
 - Added custom sounds for crystal hollow gemstones - nea89
 - Added custom biomes for crystal hollow areas - nopo
+- Added an option to hide the reforge stats for Legendary items Hypixel adds to the reforge stones - Lulonaut
 ### **Bug Fixes**
 - Fix wiki pages freezing the entire game - nea89
 - Made titanium overlay and waypoints work with dwarven overlay off

--- a/Update Notes/2.1.md
+++ b/Update Notes/2.1.md
@@ -17,7 +17,7 @@
 - Add built-in recipes for forge crafts - nea89
 - Add Stranded Villager Trades to the item list - nea89
 - Make cata xp in /pv be calculated on how many runs you have and shows master mode xp rates
-- Hide mine waypoints when at location setting - Lulonaut
+- Added a config option to hide Dwarven Mines waypoints when already at the location - Lulonaut
 - Added some info panels to some settings in /neu
 - Added /pv button in /neu 
 - Added pitch and coins/m as options in farming skill overlay
@@ -54,7 +54,7 @@
 - Added a way to include kismet feather to profit calculator - efefury
 - Added custom sounds for crystal hollow gemstones - nea89
 - Added custom biomes for crystal hollow areas - nopo
-- Added an option to hide the reforge stats for Legendary items Hypixel adds to the reforge stones - Lulonaut
+- Added a config option to hide the reforge stats for Legendary items from Hypixel on reforge stones - Lulonaut
 ### **Bug Fixes**
 - Fix wiki pages freezing the entire game - nea89
 - Made titanium overlay and waypoints work with dwarven overlay off

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
@@ -53,15 +53,14 @@ import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 
-import javax.swing.JOptionPane;
-import javax.swing.JTextField;
-import java.awt.Color;
-import java.awt.Toolkit;
+import javax.swing.*;
+import java.awt.*;
 import java.awt.datatransfer.StringSelection;
 import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.util.List;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -2575,14 +2574,42 @@ public class NEUEventListener {
     DecimalFormat myFormatter = new DecimalFormat("###,###.###");
 
     /**
-     * This makes it so that holding LCONTROL while hovering over an item with NBT will show the NBT of the item.
+     * This method does the following:
+     * Move the pet inventory display tooltip to the left to avoid conflicts
+     * Remove reforge stats for Legendary items from Hypixel if enabled
+     * Show NBT data when holding LCONTROL
      */
     @SubscribeEvent
     public void onItemTooltip(ItemTooltipEvent event) {
         if (!neu.isOnSkyblock()) return;
+        if (event.toolTip == null) return;
         //Render the pet inventory display tooltip to the left to avoid things from other mods rendering over the tooltip
         if (event.itemStack.getTagCompound() != null && event.itemStack.getTagCompound().getBoolean("NEUPETINVDISPLAY")) {
             GlStateManager.translate(-200, 0, 0);
+        }
+
+        if (event.toolTip.size() > 2 && NotEnoughUpdates.INSTANCE.config.tooltipTweaks.hideDefaultReforgeStats) {
+            String secondLine = StringUtils.stripControlCodes(event.toolTip.get(1));
+            if (secondLine.equals("Reforge Stone")) {
+                Integer startIndex = null;
+                Integer cutoffIndex = null;
+                //loop from the back of the List to find the wanted index sooner
+                for (int i = event.toolTip.size() - 1; i >= 0; i--) {
+                    //rarity
+                    String line = StringUtils.stripControlCodes(event.toolTip.get(i));
+                    if (line.contains("REFORGE STONE") || line.contains("Requires Mining Skill Level")) {
+                        cutoffIndex = i;
+                    }
+
+                    if (line.contains("(Legendary):")) {
+                        startIndex = i;
+                        break;
+                    }
+                }
+                if (startIndex != null && cutoffIndex != null && startIndex < cutoffIndex) {
+                    event.toolTip.subList(startIndex, cutoffIndex).clear();
+                }
+            }
         }
 
         if (Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) && NotEnoughUpdates.INSTANCE.config.hidden.dev &&

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
@@ -2595,12 +2595,13 @@ public class NEUEventListener {
                 Integer cutoffIndex = null;
                 //loop from the back of the List to find the wanted index sooner
                 for (int i = event.toolTip.size() - 1; i >= 0; i--) {
-                    //rarity
+                    //rarity or mining level requirement
                     String line = StringUtils.stripControlCodes(event.toolTip.get(i));
                     if (line.contains("REFORGE STONE") || line.contains("Requires Mining Skill Level")) {
                         cutoffIndex = i;
                     }
 
+                    //The line where the Hypixel stats start
                     if (line.contains("(Legendary):")) {
                         startIndex = i;
                         break;

--- a/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
@@ -39,7 +39,6 @@ import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
-import scala.collection.parallel.ParIterableLike;
 
 import java.awt.*;
 import java.io.*;

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/TooltipTweaks.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/TooltipTweaks.java
@@ -96,6 +96,14 @@ public class TooltipTweaks {
 
     @Expose
     @ConfigOption(
+            name = "Hide default reforge stats",
+            desc = "Hides the reforge stats only for Legendary items that Hypixel adds to the Reforge stones"
+    )
+    @ConfigEditorBoolean
+    public boolean hideDefaultReforgeStats = true;
+
+    @Expose
+    @ConfigOption(
             name = "Missing Enchant List",
             desc = "Show which enchants are missing on an item when pressing LSHIFT"
     )


### PR DESCRIPTION
This hides the stats for Legendary items that Hypixel adds to the reforge stone lore (if enabled), because you can already see this info with another neu feature.