### PR TITLE
Add Custom Resource Pack Support to Mining in Profile Viewer

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/GuiProfileViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/GuiProfileViewer.java
@@ -2942,7 +2942,6 @@ public class GuiProfileViewer extends GuiScreen {
 
         //hotm render
         //Pain
-        //if (miningSpeed == 0) {
 
         renderHotmPerk(
                 miningSpeed,
@@ -3077,7 +3076,7 @@ public class GuiProfileViewer extends GuiScreen {
                 (int) (guiLeft + xStart + 255), (int) (guiTop + yStartTop + 42),
                 mouseX, mouseY,
                 () -> {
-                    switch(potm) {
+                    switch (potm) {
                         case 0:
                             return Lists.newArrayList(
                                     EnumChatFormatting.RED + "Peak of the Mountain",
@@ -3462,18 +3461,29 @@ public class GuiProfileViewer extends GuiScreen {
         boolean unlocked = perkLevel > 0;
         GlStateManager.color(1, 1, 1, 1);
         GlStateManager.disableLighting();
-        if(isPickaxeAbility) RenderHelper.enableGUIStandardItemLighting(); // GUI standard item lighting must be enabled for items that are rendered as blocks, like emerald blocks.
-        Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(
-                isPickaxeAbility ?
-                        new ItemStack(unlocked ? Blocks.emerald_block : Blocks.coal_block) : // Pickaxe abilities are rendered as blocks
-                        new ItemStack(unlocked ? (perkLevel >= maxLevel ? Items.diamond : Items.emerald) : Items.coal), // Non-pickaxe abilities are rendered as items
-                xPosition, yPosition);
+
+        ItemStack itemStack;
+        if(isPickaxeAbility){
+            RenderHelper.enableGUIStandardItemLighting(); // GUI standard item lighting must be enabled for items that are rendered as blocks, like emerald blocks.
+            itemStack = new ItemStack(unlocked ? Blocks.emerald_block : Blocks.coal_block); // Pickaxe abilities are rendered as blocks
+        } else {  // Non-pickaxe abilities are rendered as items
+            itemStack = new ItemStack(unlocked ? (perkLevel >= maxLevel ? Items.diamond : Items.emerald) : Items.coal);
+        }
+
+        ArrayList<String> tooltip = tooltipSupplier.get();
+        // Prepend the green, yellow, or red color on the first line of each tooltip depending on if the perk is unlocked
+        tooltip.set(0, (unlocked ? (perkLevel >= maxLevel ? EnumChatFormatting.GREEN : EnumChatFormatting.YELLOW) : EnumChatFormatting.RED) + tooltip.get(0));
+
+        NBTTagCompound nbt = new NBTTagCompound(); //Adding NBT Data for Custom Resource Packs
+        NBTTagCompound display = new NBTTagCompound();
+        display.setString("Name", tooltip.get(0));
+        nbt.setTag("display", display);
+        itemStack.setTagCompound(nbt);
+
+        Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(itemStack, xPosition, yPosition);
         GlStateManager.enableLighting();
         if (mouseX >= xPosition && mouseX < xPosition + 16) {
             if (mouseY >= yPosition && mouseY <= yPosition + 16) {
-                ArrayList<String> tooltip = tooltipSupplier.get();
-                // Prepend the green or red color on the first line of each tooltip depending on if the perk is unlocked
-                tooltip.set(0, (unlocked ? EnumChatFormatting.GREEN : EnumChatFormatting.RED) + tooltip.get(0));
                 Utils.drawHoveringText(tooltip, mouseX, mouseY, width, height, -1, Minecraft.getMinecraft().fontRendererObj);
             }
         }
@@ -3496,13 +3506,22 @@ public class GuiProfileViewer extends GuiScreen {
         GlStateManager.color(1, 1, 1, 1);
         GlStateManager.disableLighting();
         if(isRenderingBlock) RenderHelper.enableGUIStandardItemLighting();
+
+        ArrayList<String> tooltip = tooltipSupplier.get();
+        // Prepend the green or red color on the first line of each tooltip depending on if the perk is unlocked
+        if(!tooltip.get(0).contains("Peak of the Mountain")) tooltip.set(0, (unlocked ? EnumChatFormatting.GREEN : EnumChatFormatting.RED) + tooltip.get(0)); //Peak of the Moutain has three color options, and is set already
+
+        NBTTagCompound nbt = new NBTTagCompound(); //Adding NBT Data for Resource Packs
+        NBTTagCompound display = new NBTTagCompound();
+        display.setString("Name", tooltip.get(0));
+        if(tooltip.get(0).contains("Peak of the Mountain")) display.setString("Lore", tooltip.get(1)); //Set Lore to Level
+        nbt.setTag("display", display);
+        itemStack.setTagCompound(nbt);
+
         Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(itemStack, xPosition, yPosition);
         GlStateManager.enableLighting();
         if (mouseX >= xPosition && mouseX < xPosition + 16) {
             if (mouseY >= yPosition && mouseY <= yPosition + 16) {
-                ArrayList<String> tooltip = tooltipSupplier.get();
-                // Prepend the green or red color on the first line of each tooltip depending on if the perk is unlocked
-                tooltip.set(0, (unlocked ? EnumChatFormatting.GREEN : EnumChatFormatting.RED) + tooltip.get(0));
                 Utils.drawHoveringText(tooltip, mouseX, mouseY, width, height, -1, Minecraft.getMinecraft().fontRendererObj);
             }
         }

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
@@ -133,7 +133,7 @@ public class ProfileViewer {
         put("ENDER_STONE", Utils.createItemStack(Item.getItemFromBlock(Blocks.end_stone), EnumChatFormatting.GRAY + "End Stone"));
         put("MITHRIL_ORE", Utils.createItemStack(Items.prismarine_crystals, EnumChatFormatting.GRAY + "Mithril"));
         put("HARD_STONE", Utils.createItemStack(Item.getItemFromBlock(Blocks.stone), EnumChatFormatting.GRAY + "Hard Stone"));
-        put("GEMSTONE_COLLECTION", Utils.createItemStack(Item.getItemFromBlock(Blocks.stained_glass), EnumChatFormatting.GRAY + "Gem Stones", 14));
+        put("GEMSTONE_COLLECTION", Utils.createSkull(EnumChatFormatting.GRAY + "Gemstone", "e942eb66-a350-38e5-aafa-0dfc3e17b4ac","ewogICJ0aW1lc3RhbXAiIDogMTYxODA4Mzg4ODc3MSwKICAicHJvZmlsZUlkIiA6ICJjNTBhZmE4YWJlYjk0ZTQ1OTRiZjFiNDI1YTk4MGYwMiIsCiAgInByb2ZpbGVOYW1lIiA6ICJUd29FQmFlIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2FhYzE1ZjZmY2YyY2U5NjNlZjRjYTcxZjFhODY4NWFkYjk3ZWI3NjllMWQxMTE5NGNiYmQyZTk2NGE4ODk3OGMiCiAgICB9CiAgfQp9"));
 
         /* COMBAT COLLECTIONS */
         put("ROTTEN_FLESH", Utils.createItemStack(Items.rotten_flesh, EnumChatFormatting.RED + "Rotten Flesh"));

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
@@ -710,6 +710,31 @@ public class Utils {
         return itemStack;
     }
 
+    public static ItemStack createSkull(String displayName, String uuid, String value){
+        ItemStack render = new ItemStack(Items.skull, 1, 3);
+        NBTTagCompound tag = new NBTTagCompound();
+        NBTTagCompound skullOwner = new NBTTagCompound();
+        NBTTagCompound properties = new NBTTagCompound();
+        NBTTagList textures = new NBTTagList();
+        NBTTagCompound textures_0 = new NBTTagCompound();
+        NBTTagCompound display = new NBTTagCompound();
+
+        skullOwner.setString("Id", uuid);
+        skullOwner.setString("Name", uuid);
+
+        textures_0.setString("Value", value);
+        textures.appendTag(textures_0);
+
+        display.setString("Name", displayName);
+        tag.setTag("display",display);
+
+        properties.setTag("textures", textures);
+        skullOwner.setTag("Properties", properties);
+        tag.setTag("SkullOwner", skullOwner);
+        render.setTagCompound(tag);
+        return render;
+    }
+
     public static void drawStringF(String str, FontRenderer fr, float x, float y, boolean shadow, int colour) {
         fr.drawString(str, x, y, colour, shadow);
     }


### PR DESCRIPTION
### Note
Hello! I noticed that my resource pack that I use for Skyblock was not properly texturing items inside the profile viewer, specifically for the heart of the mountain tree. After talking to the creator of my pack, I learned that the HOTM tree inside NEU's profile viewer did not have the NBT data that resource packs use for propagating Skyblock textures. As such, I have added that, along with a few changes. 

### Changes
Utils.java
- Add createSkull Util, makes it easier to make a custom skull when needed.

ProfileViewer.java
- Change displayName from "Gem stones" to "Gemstone"
- Change displayItem from Red Stained Glass to Gemstone Item Head (specifically fine jasper, to match Hypixel's collection symbol).

GuiProfileViewer.java
- Remove code remnant in comment
- Add space to switch (potm) for consistent style
- Add NBT data so that Custom Resource Packs work properly with the HOTM GUI.
- Change tooltip logic to add third yellow color when in progress, matching Hypixel's HOTM display.