### PR TITLE
Lowest BIN related fixes & optimizations

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/auction/APIManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/auction/APIManager.java
@@ -41,6 +41,9 @@ public class APIManager {
 	private final HashSet<String> playerBids = new HashSet<>();
 	private final HashSet<String> playerBidsNotified = new HashSet<>();
 	private final HashSet<String> playerBidsFinishedNotified = new HashSet<>();
+	private final int LOWEST_BIN_UPDATE_INTERVAL = 2 * 60 * 1000; // 2 minutes
+	private final int AUCTION_AVG_UPDATE_INTERVAL = 5 * 60 * 1000; // 5 minutes
+	private final int BAZAAR_UPDATE_INTERVAL = 5 * 60 * 1000; // 5 minutes
 
 	private JsonObject lowestBins = null;
 	private JsonObject auctionPricesAvgLowestBinJson = null;
@@ -203,15 +206,16 @@ public class APIManager {
 				}
 			}
 		}
-		if (currentTime - lastAuctionAvgUpdate > 5 * 60 * 1000) { //5 minutes
-			lastAuctionAvgUpdate = currentTime - 4 * 60 * 1000; //Try again in 1 minute if updateAvgPrices doesn't succeed
+		if (currentTime - lastAuctionAvgUpdate > AUCTION_AVG_UPDATE_INTERVAL) {
+			lastAuctionAvgUpdate = currentTime - AUCTION_AVG_UPDATE_INTERVAL + 60 * 1000; // Try again in 1 minute on failure
 			updateAvgPrices();
 		}
-		if (currentTime - lastBazaarUpdate > 5 * 60 * 1000) { //5 minutes
-			lastBazaarUpdate = currentTime;
+		if (currentTime - lastBazaarUpdate > BAZAAR_UPDATE_INTERVAL) {
+			lastBazaarUpdate = currentTime - BAZAAR_UPDATE_INTERVAL + 60 * 1000; // Try again in 1 minute on failure
 			updateBazaar();
 		}
-		if (currentTime - lastLowestBinUpdate > 2 * 60 * 1000) {
+		if (currentTime - lastLowestBinUpdate >  LOWEST_BIN_UPDATE_INTERVAL) {
+			lastLowestBinUpdate = currentTime - LOWEST_BIN_UPDATE_INTERVAL + 30 * 1000;  // Try again in 30 seconds on failure
 			updateLowestBin();
 		}
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/GuiPriceGraph.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/GuiPriceGraph.java
@@ -407,10 +407,7 @@ public class GuiPriceGraph extends GuiScreen {
 			HashMap<String, Data> prices = new HashMap<>();
 			if (file.exists())
 				prices = load(file);
-			if (prices == null) {
-				file.delete();
-				return;
-			}
+			if (prices == null) return;
 			for (Map.Entry<String, JsonElement> item : items.entrySet()) {
 				if (prices.containsKey(item.getKey())) {
 					if (bazaar && item.getValue().getAsJsonObject().has("curr_buy") && item.getValue().getAsJsonObject().has(

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/GuiPriceGraph.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/GuiPriceGraph.java
@@ -407,7 +407,10 @@ public class GuiPriceGraph extends GuiScreen {
 			HashMap<String, Data> prices = new HashMap<>();
 			if (file.exists())
 				prices = load(file);
-			if (prices == null) return;
+			if (prices == null) {
+				file.delete();
+				return;
+			}
 			for (Map.Entry<String, JsonElement> item : items.entrySet()) {
 				if (prices.containsKey(item.getKey())) {
 					if (bazaar && item.getValue().getAsJsonObject().has("curr_buy") && item.getValue().getAsJsonObject().has(
@@ -417,7 +420,7 @@ public class GuiPriceGraph extends GuiScreen {
 							item.getValue().getAsJsonObject().get("curr_sell").getAsFloat()
 						));
 					else if (!bazaar)
-						prices.get(item.getKey()).ah.put(epochSecond, item.getValue().getAsInt());
+						prices.get(item.getKey()).ah.put(epochSecond, item.getValue().getAsBigDecimal().intValue());
 				} else {
 					TreeMap<Long, Object> mapData = new TreeMap<>();
 					if (bazaar && item.getValue().getAsJsonObject().has("curr_buy") && item.getValue().getAsJsonObject().has(


### PR DESCRIPTION
This PR contains fixes for a few issues I found when trying to track down intermittent freezes

- Fix double-call of updateLowestBin due to a race condition where lastLowestBinUpdate is not updated by the async thread until after the following tick.
- Change the parsing of item prices to avoid using getAsInt on a decimal string that throws two exceptions per value parsed. I replaced it with the code that getAsInt ends up falling back to.
- Make the Bazaar update retry after 60 seconds instead of 5 minutes to be consistent with auction average data.
- (Removed since it's addressed by #97) Delete corrupted prices_*.gz file so that it can be re-downloaded.
