### PR TITLE
NEU Pack Dev Additions

### DIFF
--- a/Update Notes/2.1.md
+++ b/Update Notes/2.1.md
@@ -69,6 +69,9 @@
 - Added NBT data to Profile Viewer Tab Icons - whalker
 - Added NBT data to Profile Viewer XP Bar Icons - whalker
 - Added Blaze Slayer information - whalker
+- Added subcommand to /neupackdev allowing you to get NBT data from nearby mob(s) - whalker
+- Added subcommand to /neupackdev allowing you to get NBT data from nearby armor stand(s) - whalker
+- Added optional radius argument for neupackdev subcommands. -whalker
 ### **Bug Fixes:**
 - Fix wiki pages freezing the entire game - nea89
 - Made titanium overlay and waypoints work with dwarven overlay off

--- a/src/main/java/io/github/moulberry/notenoughupdates/commands/dev/PackDevCommand.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/commands/dev/PackDevCommand.java
@@ -35,8 +35,6 @@ public class PackDevCommand extends ClientCommandBase {
 						EnumChatFormatting.RED + "Invalid distance! Must be a number, defaulting to a radius of 5."));
 				}
 			}
-			sender.addChatMessage(new ChatComponentText(
-				EnumChatFormatting.RED + "Debug: distSq = " + distSq));
 
 			switch (args[0].toLowerCase()) {
 				case "getnpc":

--- a/src/main/java/io/github/moulberry/notenoughupdates/commands/dev/PackDevCommand.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/commands/dev/PackDevCommand.java
@@ -8,6 +8,9 @@ import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.item.EntityArmorStand;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
@@ -20,40 +23,273 @@ public class PackDevCommand extends ClientCommandBase {
 
 	@Override
 	public void processCommand(ICommandSender sender, String[] args) throws CommandException {
-		if (args.length == 1 && args[0].equalsIgnoreCase("getnpc")) {
+		if (args.length >= 1) {
 			double distSq = 25;
-			EntityPlayer closestNPC = null;
 			EntityPlayerSP p = Minecraft.getMinecraft().thePlayer;
-			for (EntityPlayer player : Minecraft.getMinecraft().theWorld.playerEntities) {
-				if (player instanceof AbstractClientPlayer && p != player && player.getUniqueID().version() != 4) {
-					double dSq = player.getDistanceSq(p.posX, p.posY, p.posZ);
-					if (dSq < distSq) {
-						distSq = dSq;
-						closestNPC = player;
-					}
+
+			if (args.length == 2) {
+				try {
+					distSq = Double.parseDouble(args[1]) * Double.parseDouble(args[1]);
+				} catch (NumberFormatException e) {
+					sender.addChatMessage(new ChatComponentText(
+						EnumChatFormatting.RED + "Invalid distance! Must be a number, defaulting to a radius of 5."));
 				}
 			}
+			sender.addChatMessage(new ChatComponentText(
+				EnumChatFormatting.RED + "Debug: distSq = " + distSq));
 
-			if (closestNPC == null) {
-				Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(
-					EnumChatFormatting.RED + "No NPCs found within 5 blocks :("));
-			} else {
-				Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(
-					EnumChatFormatting.GREEN + "Copied entity texture id to clipboard"));
-				MiscUtils.copyToClipboard(((AbstractClientPlayer) closestNPC)
-					.getLocationSkin()
-					.getResourcePath()
-					.replace("skins/", ""));
+			switch (args[0].toLowerCase()) {
+				case "getnpc":
+					EntityPlayer closestNPC = null;
+					for (EntityPlayer player : Minecraft.getMinecraft().theWorld.playerEntities) {
+						if (player instanceof AbstractClientPlayer && p != player && player.getUniqueID().version() != 4) {
+							double dSq = player.getDistanceSq(p.posX, p.posY, p.posZ);
+							if (dSq < distSq) {
+								distSq = dSq;
+								closestNPC = player;
+							}
+						}
+					}
+
+					if (closestNPC == null) {
+						sender.addChatMessage(new ChatComponentText(
+							EnumChatFormatting.RED + "No NPCs found within " + (Double.parseDouble(args[1])) + " blocks. :("));
+					} else {
+						sender.addChatMessage(new ChatComponentText(
+							EnumChatFormatting.GREEN + "Copied NPC entity texture id to clipboard"));
+						MiscUtils.copyToClipboard(((AbstractClientPlayer) closestNPC)
+							.getLocationSkin()
+							.getResourcePath()
+							.replace("skins/", ""));
+					}
+					break;
+
+				case "getmob":
+					Entity closestMob = null;
+					for (Entity mob : Minecraft.getMinecraft().theWorld.loadedEntityList) {
+						if (mob != null && mob != Minecraft.getMinecraft().thePlayer && mob instanceof EntityLiving) {
+							double dSq = mob.getDistanceSq(p.posX, p.posY, p.posZ);
+							if (dSq < distSq) {
+								distSq = dSq;
+								closestMob = mob;
+							}
+						}
+					}
+
+					if (closestMob == null) {
+						sender.addChatMessage(new ChatComponentText(
+							EnumChatFormatting.RED + "No mobs found within" + (Double.parseDouble(args[1])) + " blocks. :("));
+					} else {
+						sender.addChatMessage(new ChatComponentText(
+							EnumChatFormatting.GREEN + "Copied mob data to clipboard"));
+
+						MiscUtils.copyToClipboard(mobDataBuilder(closestMob).toString());
+
+					}
+					break;
+
+				case "getmobs":
+					String mobData;
+					StringBuilder mobStringBuilder = new StringBuilder();
+					for (Entity mob : Minecraft.getMinecraft().theWorld.loadedEntityList) {
+						if (mob != null && mob != Minecraft.getMinecraft().thePlayer && mob instanceof EntityLiving &&
+							mob.getDistanceSq(p.posX, p.posY, p.posZ) < distSq) {
+							mobStringBuilder.append(mobDataBuilder(mob));
+						}
+					}
+					mobData = mobStringBuilder.toString();
+					if (mobData.equals("")) {
+						sender.addChatMessage(new ChatComponentText(
+							EnumChatFormatting.RED + "No mobs found within" + (Double.parseDouble(args[1])) + " blocks. :("));
+					} else {
+						sender.addChatMessage(new ChatComponentText(
+							EnumChatFormatting.GREEN + "Copied mob data to clipboard"));
+						MiscUtils.copyToClipboard(mobData);
+					}
+					break;
+
+				case "getarmorstand":
+					EntityArmorStand closestArmorStand = null;
+					for (Entity armorStand : Minecraft.getMinecraft().theWorld.loadedEntityList) {
+						if (armorStand instanceof EntityArmorStand) {
+							double dSq = armorStand.getDistanceSq(p.posX, p.posY, p.posZ);
+							if (dSq < distSq) {
+								distSq = dSq;
+								closestArmorStand = (EntityArmorStand) armorStand;
+							}
+						}
+					}
+					
+					if (closestArmorStand == null) {
+						sender.addChatMessage(new ChatComponentText(
+							EnumChatFormatting.RED + "No armor stands found within " + (Double.parseDouble(args[1])) + " blocks. :("));
+					} else {
+						sender.addChatMessage(new ChatComponentText(
+							EnumChatFormatting.GREEN + "Copied armor stand data to clipboard"));
+						
+						MiscUtils.copyToClipboard(armorStandDataBuilder(closestArmorStand).toString());
+							
+					}
+					break;
+
+				case "getarmorstands":
+					String armorStandData;
+					StringBuilder armorStandStringBuilder = new StringBuilder();
+					for (Entity armorStand : Minecraft.getMinecraft().theWorld.loadedEntityList) {
+						if (armorStand instanceof EntityArmorStand &&
+							armorStand.getDistanceSq(p.posX, p.posY, p.posZ) < distSq) {
+							armorStandStringBuilder.append(armorStandDataBuilder((EntityArmorStand) armorStand));
+						}
+					}
+					armorStandData = armorStandStringBuilder.toString();
+					if (armorStandData.equals("")) {
+						sender.addChatMessage(new ChatComponentText(
+							EnumChatFormatting.RED + "No armor stands found within" + (Double.parseDouble(args[1])) + " blocks. :("));
+					} else {
+						sender.addChatMessage(new ChatComponentText(
+							EnumChatFormatting.GREEN + "Copied armor stand data to clipboard"));
+						MiscUtils.copyToClipboard(armorStandData);
+					}
+					break;
+
+				default:
+					break;
 			}
-			return;
-		}
-		NotEnoughUpdates.INSTANCE.packDevEnabled = !NotEnoughUpdates.INSTANCE.packDevEnabled;
-		if (NotEnoughUpdates.INSTANCE.packDevEnabled) {
-			Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(
-				EnumChatFormatting.GREEN + "Enabled pack developer mode."));
+
 		} else {
-			Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(
-				EnumChatFormatting.RED + "Disabled pack developer mode."));
+			NotEnoughUpdates.INSTANCE.packDevEnabled = !NotEnoughUpdates.INSTANCE.packDevEnabled;
+			if (NotEnoughUpdates.INSTANCE.packDevEnabled) {
+				sender.addChatMessage(new ChatComponentText(
+					EnumChatFormatting.GREEN + "Enabled pack developer mode."));
+			} else {
+				sender.addChatMessage(new ChatComponentText(
+					EnumChatFormatting.RED + "Disabled pack developer mode."));
+			}
 		}
+	}
+
+	public StringBuilder mobDataBuilder(Entity mob) {
+		StringBuilder mobData = new StringBuilder();
+
+		mobData
+			.append("Entity Id: ")
+			.append(mob.getEntityId())
+			.append("\nMob: ")
+			.append(mob.getName());
+
+		//Preventing null pointers, checking armor slots and hand to see if item is present.
+		if (((EntityLiving) mob).getHeldItem() != null) {
+			mobData
+				.append("\nItem: ")
+				.append(((EntityLiving) mob).getHeldItem())
+				.append("\nItem Display Name: ")
+				.append(((EntityLiving) mob).getHeldItem().getDisplayName())
+				.append("\nItem Tag Compound: ")
+				.append(((EntityLiving) mob).getHeldItem().getTagCompound().toString())
+				.append("\nItem Tag Compound Extra Attributes: ")
+				.append(((EntityLiving) mob).getHeldItem().getTagCompound().getTag("ExtraAttributes"));
+		} else {
+			mobData.append("\nItem: null");
+		}
+
+		if (((EntityLiving) mob).getCurrentArmor(0) != null) {
+			mobData
+				.append("\nBoots: ")
+				.append(((EntityLiving) mob).getCurrentArmor(0).getTagCompound());
+		} else {
+			mobData.append("\nBoots: null");
+		}
+
+		if (((EntityLiving) mob).getCurrentArmor(1) != null) {
+			mobData
+				.append("\nLeggings: ")
+				.append(((EntityLiving) mob).getCurrentArmor(1).getTagCompound());
+		} else {
+			mobData.append("\nLeggings: null");
+		}
+
+		if (((EntityLiving) mob).getCurrentArmor(2) != null) {
+			mobData
+				.append("\nChestplate: ")
+				.append(((EntityLiving) mob).getCurrentArmor(2).getTagCompound());
+		} else {
+			mobData.append("\nChestplate: null");
+		}
+
+		if (((EntityLiving) mob).getCurrentArmor(3) != null) {
+			mobData
+				.append("\nHelmet: ")
+				.append(((EntityLiving) mob).getCurrentArmor(3).getTagCompound());
+		} else {
+			mobData.append("\nHelmet: null");
+		}
+		mobData.append("\n\n");
+		return mobData;
+	}
+
+	public StringBuilder armorStandDataBuilder(EntityArmorStand armorStand) {
+		StringBuilder armorStandData = new StringBuilder();
+
+		armorStandData
+			.append("Entity Id: ")
+			.append(armorStand.getEntityId())
+			.append("\nMob: ")
+			.append(armorStand.getName())
+			.append("\nCustom Name: ")
+			.append(armorStand.getCustomNameTag());
+
+		//Preventing null pointers, checking armor slots and hand to see if item is present.
+		if (armorStand.getHeldItem() != null) {
+			armorStandData
+				.append("\nItem: ")
+				.append(armorStand.getHeldItem())
+				.append("\nItem Display Name: ")
+				.append(armorStand.getHeldItem().getDisplayName());
+			if (armorStand.getHeldItem().getTagCompound() != null) {
+				armorStandData
+					.append("\nItem Tag Compound: ")
+					.append(armorStand.getHeldItem().getTagCompound().toString())
+					.append("\nItem Tag Compound Extra Attributes: ")
+					.append(armorStand.getHeldItem().getTagCompound().getTag("ExtraAttributes"));
+			} else {
+				armorStandData.append("\nItem Tag Compound: null");
+			}
+		} else {
+			armorStandData.append("\nItem: null");
+		}
+
+		if (armorStand.getCurrentArmor(0) != null) {
+			armorStandData
+				.append("\nBoots: ")
+				.append(armorStand.getCurrentArmor(0).getTagCompound());
+		} else {
+			armorStandData.append("\nBoots: null");
+		}
+
+		if (armorStand.getCurrentArmor(1) != null) {
+			armorStandData
+				.append("\nLeggings: ")
+				.append(armorStand.getCurrentArmor(1).getTagCompound());
+		} else {
+			armorStandData.append("\nLeggings: null");
+		}
+
+		if (armorStand.getCurrentArmor(2) != null) {
+			armorStandData
+				.append("\nChestplate: ")
+				.append(armorStand.getCurrentArmor(2).getTagCompound());
+		} else {
+			armorStandData.append("\nChestplate: null");
+		}
+
+		if (armorStand.getCurrentArmor(3) != null) {
+			armorStandData
+				.append("\nHelmet: ")
+				.append(armorStand.getCurrentArmor(3).getTagCompound());
+		} else {
+			armorStandData.append("\nHelmet: null");
+		}
+		armorStandData.append("\n\n");
+		return armorStandData;
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/commands/dev/PackDevCommand.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/commands/dev/PackDevCommand.java
@@ -21,132 +21,59 @@ public class PackDevCommand extends ClientCommandBase {
 		super("neupackdev");
 	}
 
+	EntityPlayerSP p = Minecraft.getMinecraft().thePlayer;
+	double dist  = 5;
+	double distSq = 25;
 	@Override
 	public void processCommand(ICommandSender sender, String[] args) throws CommandException {
 		if (args.length >= 1) {
-			double distSq = 25;
-			EntityPlayerSP p = Minecraft.getMinecraft().thePlayer;
 
 			if (args.length == 2) {
 				try {
 					distSq = Double.parseDouble(args[1]) * Double.parseDouble(args[1]);
+					dist = Double.parseDouble(args[1]);
 				} catch (NumberFormatException e) {
 					sender.addChatMessage(new ChatComponentText(
 						EnumChatFormatting.RED + "Invalid distance! Must be a number, defaulting to a radius of 5."));
 				}
 			}
-
+			StringBuilder value;
 			switch (args[0].toLowerCase()) {
 				case "getnpc":
-					EntityPlayer closestNPC = null;
-					for (EntityPlayer player : Minecraft.getMinecraft().theWorld.playerEntities) {
-						if (player instanceof AbstractClientPlayer && p != player && player.getUniqueID().version() != 4) {
-							double dSq = player.getDistanceSq(p.posX, p.posY, p.posZ);
-							if (dSq < distSq) {
-								distSq = dSq;
-								closestNPC = player;
-							}
-						}
-					}
-
-					if (closestNPC == null) {
-						sender.addChatMessage(new ChatComponentText(
-							EnumChatFormatting.RED + "No NPCs found within " + (Double.parseDouble(args[1])) + " blocks. :("));
-					} else {
-						sender.addChatMessage(new ChatComponentText(
-							EnumChatFormatting.GREEN + "Copied NPC entity texture id to clipboard"));
-						MiscUtils.copyToClipboard(((AbstractClientPlayer) closestNPC)
-							.getLocationSkin()
-							.getResourcePath()
-							.replace("skins/", ""));
-					}
+					getNPCData();
 					break;
 
 				case "getmob":
-					Entity closestMob = null;
-					for (Entity mob : Minecraft.getMinecraft().theWorld.loadedEntityList) {
-						if (mob != null && mob != Minecraft.getMinecraft().thePlayer && mob instanceof EntityLiving) {
-							double dSq = mob.getDistanceSq(p.posX, p.posY, p.posZ);
-							if (dSq < distSq) {
-								distSq = dSq;
-								closestMob = mob;
-							}
-						}
-					}
-
-					if (closestMob == null) {
-						sender.addChatMessage(new ChatComponentText(
-							EnumChatFormatting.RED + "No mobs found within" + (Double.parseDouble(args[1])) + " blocks. :("));
-					} else {
-						sender.addChatMessage(new ChatComponentText(
-							EnumChatFormatting.GREEN + "Copied mob data to clipboard"));
-
-						MiscUtils.copyToClipboard(mobDataBuilder(closestMob).toString());
-
-					}
+					value	= getMobData();
+					if (value != null) MiscUtils.copyToClipboard(value.toString());
 					break;
 
 				case "getmobs":
-					String mobData;
-					StringBuilder mobStringBuilder = new StringBuilder();
-					for (Entity mob : Minecraft.getMinecraft().theWorld.loadedEntityList) {
-						if (mob != null && mob != Minecraft.getMinecraft().thePlayer && mob instanceof EntityLiving &&
-							mob.getDistanceSq(p.posX, p.posY, p.posZ) < distSq) {
-							mobStringBuilder.append(mobDataBuilder(mob));
-						}
-					}
-					mobData = mobStringBuilder.toString();
-					if (mobData.equals("")) {
-						sender.addChatMessage(new ChatComponentText(
-							EnumChatFormatting.RED + "No mobs found within" + (Double.parseDouble(args[1])) + " blocks. :("));
-					} else {
-						sender.addChatMessage(new ChatComponentText(
-							EnumChatFormatting.GREEN + "Copied mob data to clipboard"));
-						MiscUtils.copyToClipboard(mobData);
-					}
+					value = getMobsData();
+					if (value != null) MiscUtils.copyToClipboard(value.toString());
 					break;
 
 				case "getarmorstand":
-					EntityArmorStand closestArmorStand = null;
-					for (Entity armorStand : Minecraft.getMinecraft().theWorld.loadedEntityList) {
-						if (armorStand instanceof EntityArmorStand) {
-							double dSq = armorStand.getDistanceSq(p.posX, p.posY, p.posZ);
-							if (dSq < distSq) {
-								distSq = dSq;
-								closestArmorStand = (EntityArmorStand) armorStand;
-							}
-						}
-					}
-					
-					if (closestArmorStand == null) {
-						sender.addChatMessage(new ChatComponentText(
-							EnumChatFormatting.RED + "No armor stands found within " + (Double.parseDouble(args[1])) + " blocks. :("));
-					} else {
-						sender.addChatMessage(new ChatComponentText(
-							EnumChatFormatting.GREEN + "Copied armor stand data to clipboard"));
-						
-						MiscUtils.copyToClipboard(armorStandDataBuilder(closestArmorStand).toString());
-							
-					}
+					value = getArmorStandData();
+					if (value != null) MiscUtils.copyToClipboard(value.toString());
 					break;
 
 				case "getarmorstands":
-					String armorStandData;
-					StringBuilder armorStandStringBuilder = new StringBuilder();
-					for (Entity armorStand : Minecraft.getMinecraft().theWorld.loadedEntityList) {
-						if (armorStand instanceof EntityArmorStand &&
-							armorStand.getDistanceSq(p.posX, p.posY, p.posZ) < distSq) {
-							armorStandStringBuilder.append(armorStandDataBuilder((EntityArmorStand) armorStand));
-						}
-					}
-					armorStandData = armorStandStringBuilder.toString();
-					if (armorStandData.equals("")) {
-						sender.addChatMessage(new ChatComponentText(
-							EnumChatFormatting.RED + "No armor stands found within" + (Double.parseDouble(args[1])) + " blocks. :("));
+					value = getArmorStandsData();
+					if (value != null) MiscUtils.copyToClipboard(value.toString());
+					break;
+
+				case "getall":
+					value = getMobsData();
+					StringBuilder value2 = getArmorStandsData();
+					if (value == null && value2 == null) {
+						break;
+					} else if (value != null && value2 != null) {
+						MiscUtils.copyToClipboard(value.append(value2).toString());
+					} else if (value == null) {
+						MiscUtils.copyToClipboard(value2.toString());
 					} else {
-						sender.addChatMessage(new ChatComponentText(
-							EnumChatFormatting.GREEN + "Copied armor stand data to clipboard"));
-						MiscUtils.copyToClipboard(armorStandData);
+						MiscUtils.copyToClipboard(value.toString());
 					}
 					break;
 
@@ -166,127 +93,208 @@ public class PackDevCommand extends ClientCommandBase {
 		}
 	}
 
+	public void getNPCData() {
+		EntityPlayer closestNPC = null;
+		for (EntityPlayer player : Minecraft.getMinecraft().theWorld.playerEntities) {
+			if (player instanceof AbstractClientPlayer && p != player && player.getUniqueID().version() != 4) {
+				double dSq = player.getDistanceSq(p.posX, p.posY, p.posZ);
+				if (dSq < distSq) {
+					distSq = dSq;
+					closestNPC = player;
+				}
+			}
+		}
+
+		if (closestNPC == null) {
+			p.addChatMessage(new ChatComponentText(
+				EnumChatFormatting.RED + "No NPCs found within " + dist + " blocks. :("));
+		} else {
+			p.addChatMessage(new ChatComponentText(
+				EnumChatFormatting.GREEN + "Copied NPC entity texture id to clipboard"));
+			MiscUtils.copyToClipboard(((AbstractClientPlayer) closestNPC)
+				.getLocationSkin()
+				.getResourcePath()
+				.replace("skins/", ""));
+		}
+	}
+
+	public StringBuilder getMobData(){
+		Entity closestMob = null;
+		for (Entity mob : Minecraft.getMinecraft().theWorld.loadedEntityList) {
+			if (mob != null && mob != Minecraft.getMinecraft().thePlayer && mob instanceof EntityLiving) {
+				double dSq = mob.getDistanceSq(p.posX, p.posY, p.posZ);
+				if (dSq < distSq) {
+					distSq = dSq;
+					closestMob = mob;
+				}
+			}
+		}
+
+
+		if (closestMob == null) {
+			p.addChatMessage(new ChatComponentText(
+				EnumChatFormatting.RED + "No mobs found within" + dist + " blocks. :("));
+		} else {
+			p.addChatMessage(new ChatComponentText(
+				EnumChatFormatting.GREEN + "Copied mob data to clipboard"));
+
+				return mobDataBuilder(closestMob);
+
+		}
+		return null;
+	}
+
+	public StringBuilder getMobsData(){
+		StringBuilder mobStringBuilder = new StringBuilder();
+		for (Entity mob : Minecraft.getMinecraft().theWorld.loadedEntityList) {
+			if (mob != null && mob != Minecraft.getMinecraft().thePlayer && mob instanceof EntityLiving &&
+				mob.getDistanceSq(p.posX, p.posY, p.posZ) < distSq) {
+				mobStringBuilder.append(mobDataBuilder(mob));
+			}
+		}
+
+		if (mobStringBuilder.toString().equals("")) {
+			p.addChatMessage(new ChatComponentText(
+				EnumChatFormatting.RED + "No mobs found within" + dist + " blocks. :("));
+		} else {
+			p.addChatMessage(new ChatComponentText(
+				EnumChatFormatting.GREEN + "Copied mob data to clipboard"));
+			return mobStringBuilder;
+		}
+		return null;
+	}
+
+	public StringBuilder getArmorStandData(){
+		EntityArmorStand closestArmorStand = null;
+		for (Entity armorStand : Minecraft.getMinecraft().theWorld.loadedEntityList) {
+			if (armorStand instanceof EntityArmorStand) {
+				double dSq = armorStand.getDistanceSq(p.posX, p.posY, p.posZ);
+				if (dSq < distSq) {
+					distSq = dSq;
+					closestArmorStand = (EntityArmorStand) armorStand;
+				}
+			}
+		}
+
+		if (closestArmorStand == null) {
+			p.addChatMessage(new ChatComponentText(
+				EnumChatFormatting.RED + "No armor stands found within " + dist + " blocks. :("));
+		} else {
+			p.addChatMessage(new ChatComponentText(
+				EnumChatFormatting.GREEN + "Copied armor stand data to clipboard"));
+
+			return(armorStandDataBuilder(closestArmorStand));
+
+		}
+		return null;
+	}
+
+	public StringBuilder getArmorStandsData(){
+
+		StringBuilder armorStandStringBuilder = new StringBuilder();
+		for (Entity armorStand : Minecraft.getMinecraft().theWorld.loadedEntityList) {
+			if (armorStand instanceof EntityArmorStand &&
+				armorStand.getDistanceSq(p.posX, p.posY, p.posZ) < distSq) {
+				armorStandStringBuilder.append(armorStandDataBuilder((EntityArmorStand) armorStand));
+			}
+		}
+
+		if (armorStandStringBuilder.toString().equals("")) {
+			p.addChatMessage(new ChatComponentText(
+				EnumChatFormatting.RED + "No armor stands found within" + dist + " blocks. :("));
+		} else {
+			p.addChatMessage(new ChatComponentText(
+				EnumChatFormatting.GREEN + "Copied armor stand data to clipboard"));
+			return armorStandStringBuilder;
+		}
+		return null;
+	}
+
+
+
+
 	public StringBuilder mobDataBuilder(Entity mob) {
 		StringBuilder mobData = new StringBuilder();
 
+		//Preventing Null Pointer Exception
+		//Entity Information
 		mobData
 			.append("Entity Id: ")
-			.append(mob.getEntityId())
+			.append(mob.getEntityId() != -1 ? mob.getEntityId() : "null")
 			.append("\nMob: ")
-			.append(mob.getName());
+			.append(mob.getName() != null ? mob.getName() : "null")
+			.append("\nCuston Name: ")
+			.append(mob.getCustomNameTag() != null ? mob.getCustomNameTag() : "null");
 
-		//Preventing null pointers, checking armor slots and hand to see if item is present.
+		//Held Item
 		if (((EntityLiving) mob).getHeldItem() != null) {
 			mobData
 				.append("\nItem: ")
 				.append(((EntityLiving) mob).getHeldItem())
 				.append("\nItem Display Name: ")
-				.append(((EntityLiving) mob).getHeldItem().getDisplayName())
+				.append(((EntityLiving) mob).getHeldItem().getDisplayName()!= null ? ((EntityLiving) mob).getHeldItem().getDisplayName() : "null")
 				.append("\nItem Tag Compound: ")
-				.append(((EntityLiving) mob).getHeldItem().getTagCompound().toString())
+				.append(((EntityLiving) mob).getHeldItem().getTagCompound().toString() != null ? ((EntityLiving) mob).getHeldItem().getTagCompound().toString() : "null")
 				.append("\nItem Tag Compound Extra Attributes: ")
-				.append(((EntityLiving) mob).getHeldItem().getTagCompound().getTag("ExtraAttributes"));
+				.append(((EntityLiving) mob).getHeldItem().getTagCompound().getTag("ExtraAttributes") != null ? ((EntityLiving) mob).getHeldItem().getTagCompound().getTag("ExtraAttributes").toString() : "null");
 		} else {
 			mobData.append("\nItem: null");
 		}
 
-		if (((EntityLiving) mob).getCurrentArmor(0) != null) {
+		//Armor
 			mobData
 				.append("\nBoots: ")
-				.append(((EntityLiving) mob).getCurrentArmor(0).getTagCompound());
-		} else {
-			mobData.append("\nBoots: null");
-		}
-
-		if (((EntityLiving) mob).getCurrentArmor(1) != null) {
-			mobData
+				.append(((EntityLiving) mob).getCurrentArmor(0).getTagCompound() != null ? ((EntityLiving) mob).getCurrentArmor(0).getTagCompound().toString() : "null")
 				.append("\nLeggings: ")
-				.append(((EntityLiving) mob).getCurrentArmor(1).getTagCompound());
-		} else {
-			mobData.append("\nLeggings: null");
-		}
-
-		if (((EntityLiving) mob).getCurrentArmor(2) != null) {
-			mobData
+				.append(((EntityLiving) mob).getCurrentArmor(1).getTagCompound() != null ? ((EntityLiving) mob).getCurrentArmor(1).getTagCompound() : "null")
 				.append("\nChestplate: ")
-				.append(((EntityLiving) mob).getCurrentArmor(2).getTagCompound());
-		} else {
-			mobData.append("\nChestplate: null");
-		}
-
-		if (((EntityLiving) mob).getCurrentArmor(3) != null) {
-			mobData
+				.append(((EntityLiving) mob).getCurrentArmor(2).getTagCompound() != null ? ((EntityLiving) mob).getCurrentArmor(2).getTagCompound() : "null")
 				.append("\nHelmet: ")
-				.append(((EntityLiving) mob).getCurrentArmor(3).getTagCompound());
-		} else {
-			mobData.append("\nHelmet: null");
-		}
-		mobData.append("\n\n");
+				.append(((EntityLiving) mob).getCurrentArmor(3).getTagCompound() != null ? ((EntityLiving) mob).getCurrentArmor(3).getTagCompound() : "null")
+				.append("\n\n");
+
 		return mobData;
 	}
 
 	public StringBuilder armorStandDataBuilder(EntityArmorStand armorStand) {
 		StringBuilder armorStandData = new StringBuilder();
 
+		//Preventing Null Pointer Exception
+		//Entity Information
 		armorStandData
 			.append("Entity Id: ")
 			.append(armorStand.getEntityId())
 			.append("\nMob: ")
-			.append(armorStand.getName())
+			.append(armorStand.getName() != null ? armorStand.getName() : "null")
 			.append("\nCustom Name: ")
-			.append(armorStand.getCustomNameTag());
+			.append(armorStand.getCustomNameTag() != null ? armorStand.getCustomNameTag() : "null");
 
-		//Preventing null pointers, checking armor slots and hand to see if item is present.
+		//Held Item
 		if (armorStand.getHeldItem() != null) {
 			armorStandData
 				.append("\nItem: ")
 				.append(armorStand.getHeldItem())
 				.append("\nItem Display Name: ")
-				.append(armorStand.getHeldItem().getDisplayName());
-			if (armorStand.getHeldItem().getTagCompound() != null) {
-				armorStandData
+				.append(armorStand.getHeldItem().getDisplayName() != null ? armorStand.getHeldItem().getDisplayName() : "null")
 					.append("\nItem Tag Compound: ")
-					.append(armorStand.getHeldItem().getTagCompound().toString())
+					.append(armorStand.getHeldItem().getTagCompound().toString() != null ? armorStand.getHeldItem().getTagCompound().toString() : "null")
 					.append("\nItem Tag Compound Extra Attributes: ")
-					.append(armorStand.getHeldItem().getTagCompound().getTag("ExtraAttributes"));
-			} else {
-				armorStandData.append("\nItem Tag Compound: null");
-			}
+					.append(armorStand.getHeldItem().getTagCompound().getTag("ExtraAttributes") != null ? armorStand.getHeldItem().getTagCompound().getTag("ExtraAttributes") : "null");
+
 		} else {
 			armorStandData.append("\nItem: null");
 		}
 
-		if (armorStand.getCurrentArmor(0) != null) {
+		//Armor
 			armorStandData
 				.append("\nBoots: ")
-				.append(armorStand.getCurrentArmor(0).getTagCompound());
-		} else {
-			armorStandData.append("\nBoots: null");
-		}
-
-		if (armorStand.getCurrentArmor(1) != null) {
-			armorStandData
+				.append(armorStand.getCurrentArmor(0).getTagCompound() != null ? armorStand.getCurrentArmor(0).getTagCompound() : "null")
 				.append("\nLeggings: ")
-				.append(armorStand.getCurrentArmor(1).getTagCompound());
-		} else {
-			armorStandData.append("\nLeggings: null");
-		}
-
-		if (armorStand.getCurrentArmor(2) != null) {
-			armorStandData
+				.append(armorStand.getCurrentArmor(1).getTagCompound() != null ? armorStand.getCurrentArmor(1).getTagCompound() : "null")
 				.append("\nChestplate: ")
-				.append(armorStand.getCurrentArmor(2).getTagCompound());
-		} else {
-			armorStandData.append("\nChestplate: null");
-		}
-
-		if (armorStand.getCurrentArmor(3) != null) {
-			armorStandData
+				.append(armorStand.getCurrentArmor(2).getTagCompound() != null ? armorStand.getCurrentArmor(2).getTagCompound() : "null")
 				.append("\nHelmet: ")
-				.append(armorStand.getCurrentArmor(3).getTagCompound());
-		} else {
-			armorStandData.append("\nHelmet: null");
-		}
+				.append(armorStand.getCurrentArmor(3).getTagCompound() != null ? armorStand.getCurrentArmor(3).getTagCompound() : "null");
 		armorStandData.append("\n\n");
 		return armorStandData;
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/commands/help/HelpCommand.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/commands/help/HelpCommand.java
@@ -46,7 +46,7 @@ public class HelpCommand extends ClientCommandBase {
 			"\u00a76/neureloadrepo \u00a7r\u00a77- Debug command with repo.",
 			"",
 			"\u00a76\u00a7lDev commands:",
-			"\u00a76/neupackdev \u00a7r\u00a77- pack creator command - getnpc"
+			"\u00a76/neupackdev \u00a7r\u00a77- pack creator command - getnpc, getmob(s), getarmorstand(s), getall. Optional radius argument for all.  "
 		);
 		for (String neuHelpMessage : neuHelpMessages) {
 			Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(neuHelpMessage));


### PR DESCRIPTION
Add "getmob" subcommand
Add "getmobs" subcommand
Add "getarmorstand" subcommand
Add "getarmorstands" subcommand
Add optional radius argument for neupackdev subcommands. (If not specified, it defaults to the prior static 5 block radius)
Added changes to changelog

These additions will be a good utility for pack developers, as they can get information about NBT data of certain mobs and armor stands that they might not be able to texture otherwise, such as the ID of a held sword or armor pieces.