### PR TITLE
Change fairy soul beacon colors based on distance, always track found souls

### DIFF
--- a/Update Notes/2.1.md
+++ b/Update Notes/2.1.md
@@ -28,6 +28,8 @@
 - Added pitch and coins/m as options in farming skill overlay
 - Make it so tab completion in ah search GUI goes down the items - Lulonaut
 - Added a toggle for enchant glint in storage gui (ty ery for texture)
+- Fairy soul beacons now change color based on their distance
+- Separated settings for fairy soul tracking from showing beacons. Tracking is turned on by default.
 - Added fairy souls option to /neu misc
 - Make it so fairy souls are tracked independently for each profile - Lulonaut
 - Added a button in the storage gui to open the settings

--- a/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
@@ -186,7 +186,7 @@ public class NotEnoughUpdates {
 
 		ItemCustomizeManager.loadCustomization(new File(neuDir, "itemCustomization.json"));
 		StorageManager.getInstance().loadConfig(new File(neuDir, "storageItems.json"));
-		FairySouls.load(new File(neuDir, "collected_fairy_souls.json"), gson);
+		FairySouls.getInstance().loadFoundSoulsForAllProfiles(new File(neuDir, "collected_fairy_souls.json"), gson);
 		PetInfoOverlay.loadConfig(new File(neuDir, "petCache.json"));
 		SlotLocking.getInstance().loadConfig(new File(neuDir, "slotLocking.json"));
 		ItemPriceInformation.init(new File(neuDir, "auctionable_items.json"), gson);
@@ -208,7 +208,7 @@ public class NotEnoughUpdates {
 		MinecraftForge.EVENT_BUS.register(new DungeonMap());
 		MinecraftForge.EVENT_BUS.register(new SunTzu());
 		MinecraftForge.EVENT_BUS.register(new MiningStuff());
-		MinecraftForge.EVENT_BUS.register(new FairySouls());
+		MinecraftForge.EVENT_BUS.register(FairySouls.getInstance());
 		MinecraftForge.EVENT_BUS.register(new CrystalOverlay());
 		MinecraftForge.EVENT_BUS.register(new ItemCooldowns());
 		MinecraftForge.EVENT_BUS.register(new DwarvenMinesWaypoints());
@@ -223,25 +223,10 @@ public class NotEnoughUpdates {
 		MinecraftForge.EVENT_BUS.register(CrystalWishingCompassSolver.getInstance());
 		MinecraftForge.EVENT_BUS.register(new DwarvenMinesTextures());
 		MinecraftForge.EVENT_BUS.register(CustomBiomes.INSTANCE);
-
-		MinecraftForge.EVENT_BUS.register(this);
-		MinecraftForge.EVENT_BUS.register(new NEUEventListener(this));
 		MinecraftForge.EVENT_BUS.register(new ChatListener(this));
 		MinecraftForge.EVENT_BUS.register(new ItemTooltipListener(this));
 		MinecraftForge.EVENT_BUS.register(new RenderListener(this));
 		MinecraftForge.EVENT_BUS.register(new OldAnimationChecker());
-		MinecraftForge.EVENT_BUS.register(new RecipeGenerator(this));
-		MinecraftForge.EVENT_BUS.register(CapeManager.getInstance());
-		MinecraftForge.EVENT_BUS.register(new EnchantingSolvers());
-		MinecraftForge.EVENT_BUS.register(new CalendarOverlay());
-		MinecraftForge.EVENT_BUS.register(SBInfo.getInstance());
-		MinecraftForge.EVENT_BUS.register(CustomItemEffects.INSTANCE);
-		MinecraftForge.EVENT_BUS.register(new DungeonMap());
-		MinecraftForge.EVENT_BUS.register(new SunTzu());
-		MinecraftForge.EVENT_BUS.register(new MiningStuff());
-		MinecraftForge.EVENT_BUS.register(new FairySouls());
-		MinecraftForge.EVENT_BUS.register(new CrystalOverlay());
-		MinecraftForge.EVENT_BUS.register(new ItemCooldowns());
 
 		if (Minecraft.getMinecraft().getResourceManager() instanceof IReloadableResourceManager) {
 			IReloadableResourceManager manager = (IReloadableResourceManager) Minecraft.getMinecraft().getResourceManager();
@@ -300,7 +285,7 @@ public class NotEnoughUpdates {
 		} catch (Exception ignored) {
 		}
 		try {
-			FairySouls.save(new File(neuDir, "collected_fairy_souls.json"), gson);
+			FairySouls.getInstance().saveFoundSoulsForAllProfiles(new File(neuDir, "collected_fairy_souls.json"), gson);
 		} catch (Exception ignored) {
 		}
 		try {

--- a/src/main/java/io/github/moulberry/notenoughupdates/core/config/annotations/ConfigEditorBoolean.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/core/config/annotations/ConfigEditorBoolean.java
@@ -7,4 +7,6 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
-public @interface ConfigEditorBoolean {}
+public @interface ConfigEditorBoolean {
+	int runnableId() default -1;
+}

--- a/src/main/java/io/github/moulberry/notenoughupdates/core/config/gui/GuiOptionEditorBoolean.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/core/config/gui/GuiOptionEditorBoolean.java
@@ -1,15 +1,24 @@
 package io.github.moulberry.notenoughupdates.core.config.gui;
 
 import io.github.moulberry.notenoughupdates.core.GuiElementBoolean;
+import io.github.moulberry.notenoughupdates.core.config.Config;
 import io.github.moulberry.notenoughupdates.core.config.struct.ConfigProcessor;
 
 public class GuiOptionEditorBoolean extends GuiOptionEditor {
+
 	private final GuiElementBoolean bool;
+	private final Config config;
+	private final int runnableId;
 
-	public GuiOptionEditorBoolean(ConfigProcessor.ProcessedOption option) {
+	public GuiOptionEditorBoolean(
+		ConfigProcessor.ProcessedOption option,
+		int runnableId,
+		Config config
+	) {
 		super(option);
-
-		bool = new GuiElementBoolean(0, 0, (boolean) option.get(), 10, option::set);
+		this.config = config;
+		this.runnableId = runnableId;
+		bool = new GuiElementBoolean(0, 0, (boolean) option.get(),10,	(value) -> onUpdate(option, value));
 	}
 
 	@Override
@@ -33,5 +42,11 @@ public class GuiOptionEditorBoolean extends GuiOptionEditor {
 	@Override
 	public boolean keyboardInput() {
 		return false;
+	}
+
+	private void onUpdate(ConfigProcessor.ProcessedOption option, boolean value) {
+		if (option.set(value)) {
+			config.executeRunnable(runnableId);
+		}
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/core/config/struct/ConfigProcessor.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/core/config/struct/ConfigProcessor.java
@@ -130,7 +130,8 @@ public class ConfigProcessor {
 						}
 						if (optionType.isAssignableFrom(boolean.class) &&
 							optionField.isAnnotationPresent(ConfigEditorBoolean.class)) {
-							editor = new GuiOptionEditorBoolean(option);
+							ConfigEditorBoolean configEditorAnnotation = optionField.getAnnotation(ConfigEditorBoolean.class);
+							editor = new GuiOptionEditorBoolean(option, configEditorAnnotation.runnableId(), config);
 						}
 						if (optionType.isAssignableFrom(boolean.class) &&
 							optionField.isAnnotationPresent(ConfigEditorAccordion.class)) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/core/util/render/RenderUtils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/core/util/render/RenderUtils.java
@@ -228,7 +228,7 @@ public class RenderUtils {
 		double d11 = 0.5D + Math.sin(d2 + 5.497787143782138D) * 0.2D;
 		double d14 = -1.0D + d1;
 		double d15 = (double) (height) * 2.5D + d14;
-		worldrenderer.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+		worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR);
 		worldrenderer.pos(x + d4, y + topOffset, z + d5).tex(1.0D, d15).color(r, g, b, 1.0F * alphaMult).endVertex();
 		worldrenderer.pos(x + d4, y + bottomOffset, z + d5).tex(1.0D, d14).color(r, g, b, 1.0F).endVertex();
 		worldrenderer.pos(x + d6, y + bottomOffset, z + d7).tex(0.0D, d14).color(r, g, b, 1.0F).endVertex();
@@ -251,7 +251,7 @@ public class RenderUtils {
 		double d12 = -1.0D + d1;
 		double d13 = height + d12;
 
-		worldrenderer.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+		worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR);
 		worldrenderer.pos(x + 0.2D, y + topOffset, z + 0.2D).tex(1.0D, d13).color(r, g, b, 0.25F * alphaMult).endVertex();
 		worldrenderer.pos(x + 0.2D, y + bottomOffset, z + 0.2D).tex(1.0D, d12).color(r, g, b, 0.25F).endVertex();
 		worldrenderer.pos(x + 0.8D, y + bottomOffset, z + 0.2D).tex(0.0D, d12).color(r, g, b, 0.25F).endVertex();

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/NEUEventListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/NEUEventListener.java
@@ -212,7 +212,7 @@ public class NEUEventListener {
 
 		if (longUpdate) {
 			CrystalOverlay.tick();
-			FairySouls.tick();
+			FairySouls.getInstance().tick();
 			XPInformation.getInstance().tick();
 			ProfileApiSyncer.getInstance().tick();
 			ItemCustomizeManager.tick();

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/FairySouls.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/FairySouls.java
@@ -165,6 +165,11 @@ public class FairySouls {
 		showSouls = enabled;
 	}
 
+	public void setTrackFairySouls(boolean enabled) {
+		NotEnoughUpdates.INSTANCE.config.misc.trackFairySouls = enabled;
+		trackSouls = enabled;
+	}
+
 	public void markClosestSoulFound() {
 		if (!trackSouls) return;
 		int closestIndex = -1;
@@ -396,6 +401,10 @@ public class FairySouls {
 					break;
 				case "on":
 				case "enable":
+					if (!FairySouls.instance.trackSouls) {
+						print(EnumChatFormatting.RED + "Fairy soul tracking is off, enable it using /neu before using this command");
+						return;
+					}
 					print(EnumChatFormatting.DARK_PURPLE + "Enabled fairy soul waypoints");
 					FairySouls.getInstance().setShowFairySouls(true);
 					break;

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/FairySouls.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/FairySouls.java
@@ -274,7 +274,8 @@ public class FairySouls {
 
 					locationSouls.add(new BlockPos(x, y, z));
 				}
-			} catch (Exception ignored) {
+			} catch (Exception e) {
+				e.printStackTrace();
 				return null;
 			}
 		}
@@ -294,6 +295,7 @@ public class FairySouls {
 				.lines()
 				.collect(Collectors.joining(System.lineSeparator()));
 		} catch (FileNotFoundException e) {
+			// it is possible that the collected_fairy_souls.json won't exist
 			return;
 		}
 
@@ -326,7 +328,8 @@ public class FairySouls {
 			) {
 				writer.write(gson.toJson(allProfilesFoundSouls));
 			}
-		} catch (IOException ignored) {
+		} catch (IOException e) {
+			e.printStackTrace();
 		}
 	}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/FairySouls.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/FairySouls.java
@@ -21,44 +21,268 @@ import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 public class FairySouls {
+	private static FairySouls instance = null;
 	private static final String unknownProfile = "unknown";
-	private static List<BlockPos> currentSoulList = null;
-	private static List<BlockPos> currentSoulListClose = null;
-	private static HashMap<String, HashMap<String, Set<Integer>>> loadedFoundSouls = new HashMap<>();
 
-	private static HashMap<String, Set<Integer>> getFoundSoulsForProfile() {
+	private boolean trackSouls;
+	private boolean showSouls;
+	private HashMap<String, HashMap<String, Set<Integer>>> allProfilesFoundSouls = new HashMap<>();
+	private List<BlockPos> allSoulsInCurrentLocation;
+	private Set<Integer> foundSoulsInLocation;
+	private TreeMap<Double, BlockPos> missingSoulsDistanceSqMap;
+	private List<BlockPos> closestMissingSouls;
+	private String currentLocation;
+	private BlockPos lastPlayerPos;
+
+	public static FairySouls getInstance() {
+		if (instance == null) {
+			instance = new FairySouls();
+		}
+		return instance;
+	}
+
+	@SubscribeEvent
+	public void onWorldLoad(WorldEvent.Load event) {
+		currentLocation = null;
+		trackSouls = NotEnoughUpdates.INSTANCE.config.misc.trackFairySouls;
+		showSouls = NotEnoughUpdates.INSTANCE.config.misc.fariySoul;
+	}
+
+	public void initializeLocation() {
+		if (!trackSouls || currentLocation == null) {
+			return;
+		}
+
+		foundSoulsInLocation = null;
+		closestMissingSouls = new ArrayList<>();
+		missingSoulsDistanceSqMap = new TreeMap<>();
+		lastPlayerPos = BlockPos.ORIGIN;
+
+		allSoulsInCurrentLocation = loadLocationFairySoulsFromConfig(currentLocation);
+		if (allSoulsInCurrentLocation == null) {
+			return;
+		}
+
+		foundSoulsInLocation = getFoundSoulsForProfile()
+			.computeIfAbsent(currentLocation, k -> new HashSet<>());
+		refreshMissingSoulInfo(true);
+	}
+
+	private void refreshMissingSoulInfo(boolean force) {
+		if (allSoulsInCurrentLocation == null) return;
+
+		BlockPos currentPlayerPos = Minecraft.getMinecraft().thePlayer.getPosition();
+		if (lastPlayerPos.equals(currentPlayerPos) && !force) {
+			return;
+		}
+		lastPlayerPos = currentPlayerPos;
+
+		missingSoulsDistanceSqMap.clear();
+		for (int i = 0; i < allSoulsInCurrentLocation.size(); i++) {
+			if (foundSoulsInLocation.contains(i)) {
+				continue;
+			}
+			BlockPos pos = allSoulsInCurrentLocation.get(i);
+			double distSq = pos.distanceSq(lastPlayerPos);
+			missingSoulsDistanceSqMap.put(distSq, pos);
+		}
+		closestMissingSouls.clear();
+		if (missingSoulsDistanceSqMap.isEmpty()) {
+			return;
+		}
+
+		// rebuild the list of the closest ones
+		int maxSouls = 15;
+		int souls = 0;
+		for (BlockPos pos : missingSoulsDistanceSqMap.values()) {
+			closestMissingSouls.add(pos);
+			if (++souls >= maxSouls) break;
+		}
+	}
+
+	private int interpolateColors(int color1, int color2, double factor) {
+		int r1 = ((color1 >> 16) & 0xff);
+		int g1 = ((color1 >> 8) & 0xff);
+		int b1 = (color1 & 0xff);
+
+		int r2 = (color2 >> 16) & 0xff;
+		int g2 = (color2 >> 8) & 0xff;
+		int b2 = color2 & 0xff;
+
+		int r3 = r1 + (int)Math.round(factor * (r2-r1));
+		int g3 = g1 + (int)Math.round(factor * (g2-g1));
+		int b3 = b1 + (int)Math.round(factor * (b2-b1));
+
+		return (r3 & 0xff) << 16 |
+			(g3 & 0xff) << 8 |
+			(b3 & 0xff);	}
+
+	private double normalize(double value, double min, double max) {
+		return ((value - min) / (max - min));
+	}
+
+	@SubscribeEvent
+	public void onRenderLast(RenderWorldLastEvent event) {
+		if (!showSouls || !trackSouls || currentLocation == null || closestMissingSouls.isEmpty()) {
+			return;
+		}
+
+		int closeColor = 0x772991; // 0xa839ce
+		int farColor = 0xCEB4D1;
+		double farSoulDistSq = lastPlayerPos.distanceSq(closestMissingSouls.get(closestMissingSouls.size()-1));
+		for (BlockPos currentSoul : closestMissingSouls) {
+			double currentDistSq = lastPlayerPos.distanceSq(currentSoul);
+			double factor = normalize(currentDistSq, 0.0, farSoulDistSq);
+			int rgb = interpolateColors(closeColor, farColor, Math.min(0.40, factor));
+			RenderUtils.renderBeaconBeamOrBoundingBox(currentSoul, rgb, 1.0f, event.partialTicks);
+		}
+	}
+
+	public void setShowFairySouls(boolean enabled) {
+		NotEnoughUpdates.INSTANCE.config.misc.fariySoul = enabled;
+		showSouls = enabled;
+	}
+
+	public void markClosestSoulFound() {
+		if (!trackSouls) return;
+		int closestIndex = -1;
+		double closestDistSq = 10 * 10;
+		for (int i = 0; i < allSoulsInCurrentLocation.size(); i++) {
+			BlockPos pos = allSoulsInCurrentLocation.get(i);
+
+			double distSq = pos.distanceSq(Minecraft.getMinecraft().thePlayer.getPosition());
+
+			if (distSq < closestDistSq) {
+				closestDistSq = distSq;
+				closestIndex = i;
+			}
+		}
+		if (closestIndex != -1) {
+			foundSoulsInLocation.add(closestIndex);
+			refreshMissingSoulInfo(true);
+		}
+	}
+
+	public void markAllAsFound() {
+		if (!trackSouls) {
+			print(EnumChatFormatting.RED + "Fairy soul tracking is turned off, turn it on using /neu");
+			return;
+		}
+		if (allSoulsInCurrentLocation == null) {
+			print(EnumChatFormatting.RED + "No fairy souls found in your current world");
+			return;
+		}
+		for (int i = 0; i < allSoulsInCurrentLocation.size(); i++) {
+			foundSoulsInLocation.add(i);
+		}
+		refreshMissingSoulInfo(true);
+
+		print(EnumChatFormatting.DARK_PURPLE + "Marked all fairy souls as found");
+	}
+
+	public void markAllAsMissing() {
+		if (!trackSouls) {
+			print(EnumChatFormatting.RED + "Fairy soul tracking is turned off, turn it on using /neu");
+			return;
+		}
+		if (allSoulsInCurrentLocation == null) {
+			print(EnumChatFormatting.RED + "No fairy souls found in your current world");
+			return;
+		}
+		foundSoulsInLocation.clear();
+		refreshMissingSoulInfo(true);
+
+		print(EnumChatFormatting.DARK_PURPLE + "Marked all fairy souls as not found");
+	}
+
+	private HashMap<String, Set<Integer>> getFoundSoulsForProfile() {
 		String profile = SBInfo.getInstance().currentProfile;
 		if (profile == null) {
-			if (loadedFoundSouls.containsKey(unknownProfile))
-				return loadedFoundSouls.get(unknownProfile);
+			if (allProfilesFoundSouls.containsKey(unknownProfile))
+				return allProfilesFoundSouls.get(unknownProfile);
 		} else {
 			profile = profile.toLowerCase(Locale.getDefault());
-			if (loadedFoundSouls.containsKey(unknownProfile)) {
-				HashMap<String, Set<Integer>> unknownProfileData = loadedFoundSouls.remove(unknownProfile);
-				loadedFoundSouls.put(profile, unknownProfileData);
+			if (allProfilesFoundSouls.containsKey(unknownProfile)) {
+				HashMap<String, Set<Integer>> unknownProfileData = allProfilesFoundSouls.remove(unknownProfile);
+				allProfilesFoundSouls.put(profile, unknownProfileData);
 				return unknownProfileData;
 			}
-			if (loadedFoundSouls.containsKey(profile)) {
-				return loadedFoundSouls.get(profile);
+			if (allProfilesFoundSouls.containsKey(profile)) {
+				return allProfilesFoundSouls.get(profile);
 			} else {
-				//create a new entry for this profile
+				// Create a new entry for this profile
 				HashMap<String, Set<Integer>> profileData = new HashMap<>();
-				loadedFoundSouls.put(profile, profileData);
+				allProfilesFoundSouls.put(profile, profileData);
 				return profileData;
 			}
 		}
 		return new HashMap<>();
 	}
 
-	public static void load(File file, Gson gson) {
-		loadedFoundSouls = new HashMap<>();
+	private static List<BlockPos> loadLocationFairySoulsFromConfig(String currentLocation) {
+		JsonObject fairySoulList = Constants.FAIRYSOULS;
+		if (fairySoulList == null) {
+			return null;
+		}
+
+		if (!fairySoulList.has(currentLocation) || !fairySoulList.get(currentLocation).isJsonArray()) {
+			return null;
+		}
+
+		JsonArray locations = fairySoulList.get(currentLocation).getAsJsonArray();
+		List<BlockPos> locationSouls = new ArrayList<>();
+		for (int i = 0; i < locations.size(); i++) {
+			try {
+				String coord = locations.get(i).getAsString();
+
+				String[] split = coord.split(",");
+				if (split.length == 3) {
+					String xS = split[0];
+					String yS = split[1];
+					String zS = split[2];
+
+					int x = Integer.parseInt(xS);
+					int y = Integer.parseInt(yS);
+					int z = Integer.parseInt(zS);
+
+					locationSouls.add(new BlockPos(x, y, z));
+				}
+			} catch (Exception ignored) {
+				return null;
+			}
+		}
+
+		if (locationSouls.size() == 0) {
+			return null;
+		}
+
+		return locationSouls;
+	}
+
+	public void loadFoundSoulsForAllProfiles(File file, Gson gson) {
+		allProfilesFoundSouls = new HashMap<>();
 		String fileContent;
 		try {
 			fileContent = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))
@@ -71,20 +295,20 @@ public class FairySouls {
 		try {
 			//noinspection UnstableApiUsage
 			Type multiProfileSoulsType = new TypeToken<HashMap<String, HashMap<String, Set<Integer>>>>() {}.getType();
-			loadedFoundSouls = gson.fromJson(fileContent, multiProfileSoulsType);
+			allProfilesFoundSouls = gson.fromJson(fileContent, multiProfileSoulsType);
 		} catch (JsonSyntaxException e) {
 			//The file is in the old format, convert it to the new one and set the profile to unknown
 			try {
 				//noinspection UnstableApiUsage
 				Type singleProfileSoulsType = new TypeToken<HashMap<String, Set<Integer>>>() {}.getType();
-				loadedFoundSouls.put(unknownProfile, gson.fromJson(fileContent, singleProfileSoulsType));
+				allProfilesFoundSouls.put(unknownProfile, gson.fromJson(fileContent, singleProfileSoulsType));
 			} catch (JsonSyntaxException e2) {
 				System.err.println("Can't read file containing collected fairy souls, resetting.");
 			}
 		}
 	}
 
-	public static void save(File file, Gson gson) {
+	public void saveFoundSoulsForAllProfiles(File file, Gson gson) {
 		try {
 			//noinspection ResultOfMethodCallIgnored
 			file.createNewFile();
@@ -95,78 +319,23 @@ public class FairySouls {
 					StandardCharsets.UTF_8
 				))
 			) {
-				writer.write(gson.toJson(loadedFoundSouls));
+				writer.write(gson.toJson(allProfilesFoundSouls));
 			}
 		} catch (IOException ignored) {
 		}
 	}
 
-	public static void tick() {
-		if (!NotEnoughUpdates.INSTANCE.config.misc.fariySoul) return;
-
-		if (Minecraft.getMinecraft().theWorld == null) {
-			currentSoulList = null;
-			return;
-		}
-
-		JsonObject fairySouls = Constants.FAIRYSOULS;
-		if (fairySouls == null) return;
-
+	public void tick() {
+		if (!trackSouls) return;
 		String location = SBInfo.getInstance().getLocation();
-		if (location == null) {
-			currentSoulList = null;
-			return;
+		if (location == null || location.isEmpty()) return;
+
+		if (!location.equals(currentLocation)) {
+			currentLocation = location;
+			initializeLocation();
 		}
 
-		if (currentSoulList == null) {
-			if (fairySouls.has(location) && fairySouls.get(location).isJsonArray()) {
-				JsonArray locations = fairySouls.get(location).getAsJsonArray();
-				currentSoulList = new ArrayList<>();
-				for (int i = 0; i < locations.size(); i++) {
-					try {
-						String coord = locations.get(i).getAsString();
-
-						String[] split = coord.split(",");
-						if (split.length == 3) {
-							String xS = split[0];
-							String yS = split[1];
-							String zS = split[2];
-
-							int x = Integer.parseInt(xS);
-							int y = Integer.parseInt(yS);
-							int z = Integer.parseInt(zS);
-
-							currentSoulList.add(new BlockPos(x, y, z));
-						}
-					} catch (Exception ignored) {
-					}
-				}
-			}
-		}
-
-		if (currentSoulList != null && !currentSoulList.isEmpty()) {
-			TreeMap<Double, BlockPos> distanceSqMap = new TreeMap<>();
-
-			HashMap<String, Set<Integer>> foundSouls = getFoundSoulsForProfile();
-
-			Set<Integer> found = foundSouls.computeIfAbsent(location, k -> new HashSet<>());
-
-			for (int i = 0; i < currentSoulList.size(); i++) {
-				if (found.contains(i)) continue;
-
-				BlockPos pos = currentSoulList.get(i);
-				double distSq = pos.distanceSq(Minecraft.getMinecraft().thePlayer.getPosition());
-				distanceSqMap.put(distSq, pos);
-			}
-
-			int maxSouls = 15;
-			int souls = 0;
-			currentSoulListClose = new ArrayList<>();
-			for (BlockPos pos : distanceSqMap.values()) {
-				currentSoulListClose.add(pos);
-				if (++souls >= maxSouls) break;
-			}
-		}
+		refreshMissingSoulInfo(false);
 	}
 
 	private static void print(String s) {
@@ -186,63 +355,24 @@ public class FairySouls {
 		}
 		print(EnumChatFormatting.GOLD.toString() + EnumChatFormatting.BOLD + "     Commands:");
 		print(EnumChatFormatting.YELLOW + "/neusouls help          - Display this message");
-		print(EnumChatFormatting.YELLOW + "/neusouls on/off        - Enable/disable the waypoint markers");
+		print(EnumChatFormatting.YELLOW + "/neusouls on/off        - Enable/disable showing waypoint markers");
 		print(EnumChatFormatting.YELLOW +
 			"/neusouls clear/unclear - Marks every waypoint in your current world as completed/uncompleted");
 		print("");
 	}
 
 	@SubscribeEvent
-	public void onWorldUnload(WorldEvent.Unload event) {
-		currentSoulList = null;
-	}
-
-	@SubscribeEvent
 	public void onChatReceived(ClientChatReceivedEvent event) {
-		if (currentSoulList == null) return;
+		if (!trackSouls || event.type == 2) return;
 
-		if (event.message.getFormattedText().equals("\u00A7r\u00A7dYou have already found that Fairy Soul!\u00A7r") ||
-			event.message.getFormattedText().equals(
-				"\u00A7d\u00A7lSOUL! \u00A7fYou found a \u00A7r\u00A7dFairy Soul\u00A7r\u00A7f!\u00A7r")) {
-			String location = SBInfo.getInstance().getLocation();
-			if (location == null) return;
-
-			int closestIndex = -1;
-			double closestDistSq = 10 * 10;
-			for (int i = 0; i < currentSoulList.size(); i++) {
-				BlockPos pos = currentSoulList.get(i);
-
-				double distSq = pos.distanceSq(Minecraft.getMinecraft().thePlayer.getPosition());
-
-				if (distSq < closestDistSq) {
-					closestDistSq = distSq;
-					closestIndex = i;
-				}
-			}
-			if (closestIndex != -1) {
-				HashMap<String, Set<Integer>> foundSouls = getFoundSoulsForProfile();
-				Set<Integer> found = foundSouls.computeIfAbsent(location, k -> new HashSet<>());
-				found.add(closestIndex);
-			}
-		}
-	}
-
-	@SubscribeEvent
-	public void onRenderLast(RenderWorldLastEvent event) {
-		if (!NotEnoughUpdates.INSTANCE.config.misc.fariySoul) return;
-
-		String location = SBInfo.getInstance().getLocation();
-		if (location == null) return;
-		if (currentSoulList == null || currentSoulList.isEmpty()) return;
-
-		int rgb = 0xa839ce;
-		for (BlockPos currentSoul : currentSoulListClose) {
-			RenderUtils.renderBeaconBeamOrBoundingBox(currentSoul, rgb, 1.0f, event.partialTicks);
+		if (event.message.getUnformattedText().equals("You have already found that Fairy Soul!") ||
+			event.message.getUnformattedText().equals(
+				"SOUL! You found a Fairy Soul!")) {
+			markClosestSoulFound();
 		}
 	}
 
 	public static class FairySoulsCommand extends ClientCommandBase {
-
 		public FairySoulsCommand() {
 			super("neusouls");
 		}
@@ -258,73 +388,31 @@ public class FairySouls {
 				printHelp();
 				return;
 			}
-			String subcommand = args[0].toLowerCase();
 
+			String subcommand = args[0].toLowerCase();
 			switch (subcommand) {
 				case "help":
 					printHelp();
-					return;
+					break;
 				case "on":
 				case "enable":
 					print(EnumChatFormatting.DARK_PURPLE + "Enabled fairy soul waypoints");
-					NotEnoughUpdates.INSTANCE.config.misc.fariySoul = true;
-					return;
+					FairySouls.getInstance().setShowFairySouls(true);
+					break;
 				case "off":
 				case "disable":
+					FairySouls.getInstance().setShowFairySouls(false);
 					print(EnumChatFormatting.DARK_PURPLE + "Disabled fairy soul waypoints");
-					NotEnoughUpdates.INSTANCE.config.misc.fariySoul = false;
-					return;
-				case "clear": {
-					String location = SBInfo.getInstance().getLocation();
-					if (currentSoulList == null || location == null) {
-						print(EnumChatFormatting.RED + "No fairy souls found in your current world");
-					} else {
-						HashMap<String, Set<Integer>> foundSouls = getFoundSoulsForProfile();
-						Set<Integer> found = foundSouls.computeIfAbsent(location, k -> new HashSet<>());
-						for (int i = 0; i < currentSoulList.size(); i++) {
-							found.add(i);
-						}
-						String profileName = SBInfo.getInstance().currentProfile;
-						if (profileName == null) {
-							if (loadedFoundSouls.containsKey(unknownProfile)) {
-								loadedFoundSouls.get(unknownProfile).put(location, found);
-							}
-						} else {
-							profileName = profileName.toLowerCase();
-							if (!loadedFoundSouls.containsKey(profileName)) {
-								HashMap<String, Set<Integer>> profileData = new HashMap<>();
-								loadedFoundSouls.put(profileName, profileData);
-							}
-							loadedFoundSouls.get(profileName).put(location, found);
-						}
-						print(EnumChatFormatting.DARK_PURPLE + "Marked all fairy souls as found");
-					}
-				}
-				return;
+					break;
+				case "clear":
+					FairySouls.getInstance().markAllAsFound();
+					break;
 				case "unclear":
-					String location = SBInfo.getInstance().getLocation();
-					if (location == null) {
-						print(EnumChatFormatting.RED + "No fairy souls found in your current world");
-					} else {
-						String profileName = SBInfo.getInstance().currentProfile;
-						if (profileName == null) {
-							if (loadedFoundSouls.containsKey(unknownProfile)) {
-								loadedFoundSouls.get(unknownProfile).remove(location);
-							}
-						} else {
-							profileName = profileName.toLowerCase();
-							if (!loadedFoundSouls.containsKey(profileName)) {
-								HashMap<String, Set<Integer>> profileData = new HashMap<>();
-								loadedFoundSouls.put(profileName, profileData);
-							}
-							loadedFoundSouls.get(profileName).remove(location);
-						}
-						print(EnumChatFormatting.DARK_PURPLE + "Marked all fairy souls as not found");
-					}
-					return;
+					FairySouls.getInstance().markAllAsMissing();
+					break;
+				default:
+					print(EnumChatFormatting.RED + "Unknown subcommand: " + subcommand);
 			}
-
-			print(EnumChatFormatting.RED + "Unknown subcommand: " + subcommand);
 		}
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
@@ -8,6 +8,7 @@ import io.github.moulberry.notenoughupdates.core.config.Config;
 import io.github.moulberry.notenoughupdates.core.config.Position;
 import io.github.moulberry.notenoughupdates.core.config.annotations.Category;
 import io.github.moulberry.notenoughupdates.core.config.gui.GuiPositionEditor;
+import io.github.moulberry.notenoughupdates.miscfeatures.FairySouls;
 import io.github.moulberry.notenoughupdates.miscgui.GuiEnchantColour;
 import io.github.moulberry.notenoughupdates.miscgui.GuiInvButtonEditor;
 import io.github.moulberry.notenoughupdates.miscgui.NEUOverlayPlacements;
@@ -78,6 +79,8 @@ public class NEUConfig extends Config {
 		}
 
 		switch (runnableId) {
+			case -1:
+				return;
 			case 0:
 				ClientCommandHandler.instance.executeCommand(Minecraft.getMinecraft().thePlayer, "/neumap");
 				return;
@@ -129,6 +132,10 @@ public class NEUConfig extends Config {
 			case 14:
 				editOverlay(activeConfigCategory, OverlayManager.fishingSkillOverlay, skillOverlays.fishingPosition);
 				return;
+			case 15:
+				String command = NotEnoughUpdates.INSTANCE.config.misc.fariySoul ? "/neusouls on" : "/neusouls off";
+				ClientCommandHandler.instance.executeCommand(Minecraft.getMinecraft().thePlayer, command);
+				return;
 			case 16:
 				ClientCommandHandler.instance.executeCommand(Minecraft.getMinecraft().thePlayer, "/neusouls clear");
 				return;
@@ -140,7 +147,9 @@ public class NEUConfig extends Config {
 				return;
 			case 19:
 				editOverlay(activeConfigCategory, OverlayManager.combatSkillOverlay, skillOverlays.combatPosition);
-
+				return;
+			case 20:
+				FairySouls.getInstance().setTrackFairySouls(NotEnoughUpdates.INSTANCE.config.misc.trackFairySouls);
 		}
 	}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Misc.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Misc.java
@@ -36,8 +36,17 @@ public class Misc {
 	public boolean fariySoulAccordion = false;
 	@Expose
 	@ConfigOption(
-		name = "Fairy Souls Finder",
-		desc = "Shows waypoints to fairy souls (/neusouls)"
+		name = "Track Fairy Souls",
+		desc = "Track found fairy souls (Lobby change required to take effect)"
+	)
+	@ConfigEditorBoolean
+	@ConfigAccordionId(id = 0)
+	public boolean trackFairySouls = true;
+
+	@Expose
+	@ConfigOption(
+		name = "Show Waypoints",
+		desc = "Shows waypoints to fairy souls (Requires fairy soul tracking)"
 	)
 	@ConfigEditorBoolean
 	@ConfigAccordionId(id = 0)
@@ -45,8 +54,8 @@ public class Misc {
 
 	@Expose
 	@ConfigOption(
-		name = "Clear Fairy Souls",
-		desc = "Clears waypoints to fairy souls (/neusouls clear)"
+		name = "Mark All As Found",
+		desc = "Mark all fairy souls in current location as found"
 	)
 	@ConfigEditorButton(
 		runnableId = 16,
@@ -57,8 +66,8 @@ public class Misc {
 
 	@Expose
 	@ConfigOption(
-		name = "Unclear Fairy Souls",
-		desc = "Shows all waypoints to fairy souls (/neusouls unclear)"
+		name = "Mark All As Missing",
+		desc = "Mark all fairy souls in current location as missing"
 	)
 	@ConfigEditorButton(
 		runnableId = 17,

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Misc.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Misc.java
@@ -37,18 +37,20 @@ public class Misc {
 	@Expose
 	@ConfigOption(
 		name = "Track Fairy Souls",
-		desc = "Track found fairy souls (Lobby change required to take effect)"
+		desc = "Track Found Fairy Souls"
 	)
-	@ConfigEditorBoolean
+	@ConfigEditorBoolean(runnableId = 20)
 	@ConfigAccordionId(id = 0)
 	public boolean trackFairySouls = true;
 
 	@Expose
 	@ConfigOption(
 		name = "Show Waypoints",
-		desc = "Shows waypoints to fairy souls (Requires fairy soul tracking)"
+		desc = "Show Fairy Soul Waypoints (Requires fairy soul tracking)"
 	)
-	@ConfigEditorBoolean
+	@ConfigEditorBoolean(
+		runnableId = 15
+	)
 	@ConfigAccordionId(id = 0)
 	public boolean fariySoul = false;
 


### PR DESCRIPTION
Play testing (and code review) feedback on this change is appreciated.

- Fairy soul beacons now change color based on their distance
- Separated logic for tracking found souls from showing beacons. Tracking is turned on by default.
- Stop recalculating foundSouls each time tick() is called
- Refactored most of the FairySouls class to eliminate duplicate code and improve readability. Profile loading saving logic was retained.
- Change the FairySouls class to use a static instance instead of being a static class
- Remove redundant Forge EVENT_BUS register calls