### PR TITLE
Improve item editor

### DIFF
--- a/Update Notes/2.1.md
+++ b/Update Notes/2.1.md
@@ -85,7 +85,6 @@
 - Added support for attributes in neuec
 - Added Heavy Pearls to todo overlay - cobble8
 - Added Booster Cookie Warning - 2stinkysocks
-- Added command 
 ### **Bug Fixes:**
 - Fix wiki pages freezing the entire game - nea89
 - Made titanium overlay and waypoints work with dwarven overlay off

--- a/Update Notes/2.1.md
+++ b/Update Notes/2.1.md
@@ -113,6 +113,7 @@
 - Fixed minion tiers crafted by coop members not showing up in /pv - Lulonaut
 - Fixed crash in /pv when the player had a pet that is not saved in the repo - Lulonaut
 - Fixed some vanilla Minecraft keybinds not working in NEU GUIs
+- Fixed crash with spamming remove enchant in /neuec
 ### **Other:**
 - New icons was added in storage_icons.png
 - Moved the help icon in /neucustomize over a little

--- a/Update Notes/2.1.md
+++ b/Update Notes/2.1.md
@@ -38,7 +38,7 @@
 - Added a help menu to /neuec
 - Made it so treecap shows foraging xp instead of farming xp on the farming overlay
 - Made it so a jungle axe with cult will show the "farming" overlay
-- Added /neurepomode to toggle item editing and dev mode, and changing the item repo url 
+- Added /neurepomode to toggle item editing and dev mode, changing the item repo url and toggling autoupdating of the repo
 - Changed "NEUAH is DISABLED! Enable in /neusettings." to /neu
 - Changed misc overlays tab to todo overlays
 - Added a config option for npc retexturing 
@@ -85,6 +85,7 @@
 - Added support for attributes in neuec
 - Added Heavy Pearls to todo overlay - cobble8
 - Added Booster Cookie Warning - 2stinkysocks
+- Added command 
 ### **Bug Fixes:**
 - Fix wiki pages freezing the entire game - nea89
 - Made titanium overlay and waypoints work with dwarven overlay off

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -80,6 +80,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -1881,7 +1882,7 @@ public class NEUOverlay extends Gui {
 	private String lastProfile;
 
 	private ItemStack getWardrobeSlot(int armourSlot) {
-		if (!SBInfo.getInstance().currentProfile.equals(lastProfile)) {
+		if (Objects.equals(SBInfo.getInstance().currentProfile, lastProfile)) {
 			lastProfile = SBInfo.getInstance().currentProfile;
 			slot1 = null;
 			slot2 = null;

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -1137,8 +1137,9 @@ public class NEUOverlay extends Gui {
 				if (internalname.get() != null) {
 					if (itemstack.get() != null) {
 						if (NotEnoughUpdates.INSTANCE.config.hidden.enableItemEditing && Keyboard.getEventCharacter() == 'k') {
-							Minecraft.getMinecraft().displayGuiScreen(new NEUItemEditor(manager,
-								internalname.get(), manager.getJsonForItem(itemstack.get())
+							Minecraft.getMinecraft().displayGuiScreen(new NEUItemEditor(
+								internalname.get(),
+								manager.getJsonForItem(itemstack.get())
 							));
 							return true;
 						}
@@ -1161,9 +1162,7 @@ public class NEUOverlay extends Gui {
 							}
 						} else if (NotEnoughUpdates.INSTANCE.config.hidden.enableItemEditing &&
 							Keyboard.getEventCharacter() == 'k') {
-							Minecraft.getMinecraft().displayGuiScreen(new NEUItemEditor(manager,
-								internalname.get(), item
-							));
+							Minecraft.getMinecraft().displayGuiScreen(new NEUItemEditor(internalname.get(), item));
 							return true;
 						} else if (keyPressed == manager.keybindItemSelect.getKeyCode() &&
 							NotEnoughUpdates.INSTANCE.config.toolbar.searchBar) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -1881,7 +1881,7 @@ public class NEUOverlay extends Gui {
 	private String lastProfile;
 
 	private ItemStack getWardrobeSlot(int armourSlot) {
-		if (Objects.equals(SBInfo.getInstance().currentProfile, lastProfile)) {
+		if (!Objects.equals(SBInfo.getInstance().currentProfile, lastProfile)) {
 			lastProfile = SBInfo.getInstance().currentProfile;
 			slot1 = null;
 			slot2 = null;

--- a/src/main/java/io/github/moulberry/notenoughupdates/commands/repo/RepoModeCommand.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/commands/repo/RepoModeCommand.java
@@ -47,10 +47,14 @@ public class RepoModeCommand extends ClientCommandBase {
 					ClickEvent.Action.SUGGEST_COMMAND, "/neureloadrepo fetch"))))
 				.appendSibling(new ChatComponentText("\u00a75> to redownload your repo.")));
 
+		} else if (args.length == 1 && args[0].equalsIgnoreCase("autoupdate")) {
+			NotEnoughUpdates.INSTANCE.config.hidden.autoupdate = !NotEnoughUpdates.INSTANCE.config.hidden.autoupdate;
+			Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText("\u00a75Toggled repo auto-updating"));
 		} else {
 			Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText("\u00a7cUsage:" +
 				"\n\u00a75/neurepomode <toggle> Toggles on/off dev mode and item editing." +
-				"\n\u00a75/neurepomode <setRepoURL> <githubuser> [reponame] [branch] Sets the repo URL for downloading from."));
+				"\n\u00a75/neurepomode <setRepoURL> <githubuser> [reponame] [branch] Sets the repo URL for downloading from." +
+				"\n\u00a75/neurepomode <autoupdate> Toggles on/off auto-updating the repo"));
 		}
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/commands/repo/RepoModeCommand.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/commands/repo/RepoModeCommand.java
@@ -49,7 +49,7 @@ public class RepoModeCommand extends ClientCommandBase {
 
 		} else if (args.length == 1 && args[0].equalsIgnoreCase("autoupdate")) {
 			NotEnoughUpdates.INSTANCE.config.hidden.autoupdate = !NotEnoughUpdates.INSTANCE.config.hidden.autoupdate;
-			Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText("\u00a75Toggled repo auto-updating"));
+			Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText("\u00a75Toggled repo auto-updating" + (NotEnoughUpdates.INSTANCE.config.hidden.autoupdate ? "on" : "off"));
 		} else {
 			Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText("\u00a7cUsage:" +
 				"\n\u00a75/neurepomode <toggle> Toggles on/off dev mode and item editing." +

--- a/src/main/java/io/github/moulberry/notenoughupdates/commands/repo/RepoModeCommand.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/commands/repo/RepoModeCommand.java
@@ -49,7 +49,7 @@ public class RepoModeCommand extends ClientCommandBase {
 
 		} else if (args.length == 1 && args[0].equalsIgnoreCase("autoupdate")) {
 			NotEnoughUpdates.INSTANCE.config.hidden.autoupdate = !NotEnoughUpdates.INSTANCE.config.hidden.autoupdate;
-			Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText("\u00a75Toggled repo auto-updating" + (NotEnoughUpdates.INSTANCE.config.hidden.autoupdate ? "on" : "off"));
+			Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText("\u00a75Toggled repo auto-updating" + (NotEnoughUpdates.INSTANCE.config.hidden.autoupdate ? "on" : "off")));
 		} else {
 			Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText("\u00a7cUsage:" +
 				"\n\u00a75/neurepomode <toggle> Toggles on/off dev mode and item editing." +

--- a/src/main/java/io/github/moulberry/notenoughupdates/itemeditor/NEUItemEditor.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/itemeditor/NEUItemEditor.java
@@ -1,6 +1,7 @@
 package io.github.moulberry.notenoughupdates.itemeditor;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.github.moulberry.notenoughupdates.NEUManager;
 import io.github.moulberry.notenoughupdates.core.util.lerp.LerpingInteger;
@@ -44,108 +45,135 @@ public class NEUItemEditor extends GuiScreen {
 	private final List<GuiElement> rightOptions = new ArrayList<>();
 
 	private final JsonObject item;
+	private final JsonObject savedRepoItem;
 
 	private static final int PADDING = 10;
 	private static final int SCROLL_AMOUNT = 20;
 
 	private final LerpingInteger scrollHeight = new LerpingInteger(0);
 
-	private final Supplier<String> internalname;
-	private final Supplier<String> itemid;
-	private final Supplier<String> displayname;
+	private final Supplier<String> internalName;
+	private final Supplier<String> itemId;
+	private final Supplier<String> displayName;
 	private final Supplier<String> lore;
-	private final Supplier<String> crafttext;
+	private final Supplier<String> craftText;
 	private final Supplier<String> infoType;
 	private final Supplier<String> info;
-	private final Supplier<String> clickcommand;
+	private final Supplier<String> clickCommand;
 	private final Supplier<String> damage;
-	private NBTTagCompound nbttag;
-	private boolean hasChanges = false;
+	private NBTTagCompound nbtTag;
+	private int saved = 0;
 
-	public NEUItemEditor(NEUManager manager, String internalname, JsonObject item) {
+	public NEUItemEditor(NEUManager manager, String internalName, JsonObject item) {
 		this.manager = manager;
-		this.item = item;
-
 		if (item.has("nbttag")) {
 			try {
-				nbttag = JsonToNBT.getTagFromJson(item.get("nbttag").getAsString());
+				nbtTag = JsonToNBT.getTagFromJson(item.get("nbttag").getAsString());
 			} catch (NBTException ignored) {
 			}
 		}
+		nbtTag.getCompoundTag("ExtraAttributes").removeTag("uuid");
+		nbtTag.getCompoundTag("ExtraAttributes").removeTag("timestamp");
 
-		internalname = internalname == null ? "" : internalname;
+		savedRepoItem = manager.getItemInformation().getOrDefault(internalName, null);
+		if (savedRepoItem != null) {
+			this.item = savedRepoItem;
+		} else {
+			this.item = item;
+		}
+
+		internalName = internalName == null ? "" : internalName;
 		options.add(new GuiElementText("Internal Name: ", Color.WHITE.getRGB()));
-		this.internalname = addTextFieldWithSupplier(internalname, NO_SPACE | FORCE_CAPS);
+		this.internalName = addTextFieldWithSupplier(internalName, NO_SPACE | FORCE_CAPS);
 
 		options.add(new GuiElementText("Item ID: ", Color.WHITE.getRGB()));
 		String itemid = item.has("itemid") ? item.get("itemid").getAsString() : "";
-		this.itemid = addTextFieldWithSupplier(itemid, NO_SPACE);
+		this.itemId = addTextFieldWithSupplier(itemid, NO_SPACE);
 
 		options.add(new GuiElementText("Display name: ", Color.WHITE.getRGB()));
 		String displayname = item.has("displayname") ? item.get("displayname").getAsString() : "";
-		this.displayname = addTextFieldWithSupplier(displayname, COLOUR);
+		this.displayName = addTextFieldWithSupplier(displayname, COLOUR);
 
 		options.add(new GuiElementText("Lore: ", Color.WHITE.getRGB()));
-		JsonArray lore = item.has("lore") ? item.get("lore").getAsJsonArray() : new JsonArray();
+		JsonElement loreElement = getItemInfo("lore");
+		JsonArray lore = loreElement != null ? loreElement.getAsJsonArray() : new JsonArray();
 		String[] loreA = new String[lore.size()];
 		for (int i = 0; i < lore.size(); i++) loreA[i] = lore.get(i).getAsString();
 		this.lore = addTextFieldWithSupplier(String.join("\n", loreA), COLOUR | MULTILINE);
 
 		options.add(new GuiElementText("Craft text: ", Color.WHITE.getRGB()));
-		String crafttext = item.has("crafttext") ? item.get("crafttext").getAsString() : "";
-		this.crafttext = addTextFieldWithSupplier(crafttext, COLOUR);
+		JsonElement craftTextElement = getItemInfo("crafttext");
+		String craftText = craftTextElement != null ? craftTextElement.getAsString() : "";
+		this.craftText = addTextFieldWithSupplier(craftText, COLOUR);
 
 		options.add(new GuiElementText("Info type: ", Color.WHITE.getRGB()));
-		String infoType = item.has("infoType") ? item.get("infoType").getAsString() : "";
+		JsonElement infoTypeElement = getItemInfo("infoType");
+		String infoType = infoTypeElement != null ? infoTypeElement.getAsString() : "";
 		this.infoType = addTextFieldWithSupplier(infoType, NO_SPACE | FORCE_CAPS);
 
 		options.add(new GuiElementText("Additional information: ", Color.WHITE.getRGB()));
-		JsonArray info = item.has("info") ? item.get("info").getAsJsonArray() : new JsonArray();
+		JsonElement infoElement = getItemInfo("info");
+		JsonArray info = infoElement != null ? infoElement.getAsJsonArray() : new JsonArray();
 		String[] infoA = new String[info.size()];
 		for (int i = 0; i < info.size(); i++) infoA[i] = info.get(i).getAsString();
 		this.info = addTextFieldWithSupplier(String.join("\n", infoA), COLOUR | MULTILINE);
 
 		options.add(new GuiElementText("Click-command (viewrecipe or viewpotion): ", Color.WHITE.getRGB()));
-		String clickcommand = item.has("clickcommand") ? item.get("clickcommand").getAsString() : "";
-		this.clickcommand = addTextFieldWithSupplier(clickcommand, NO_SPACE);
+		JsonElement clickCommandElement = getItemInfo("clickcommand");
+		String clickCommand = clickCommandElement != null ? clickCommandElement.getAsString() : "";
+		this.clickCommand = addTextFieldWithSupplier(clickCommand, NO_SPACE);
 
 		options.add(new GuiElementText("Damage: ", Color.WHITE.getRGB()));
-		String damage = item.has("damage") ? item.get("damage").getAsString() : "";
+		JsonElement damageElement = getItemInfo("damage");
+		String damage = damageElement != null ? damageElement.getAsString() : "";
 		this.damage = addTextFieldWithSupplier(damage, NO_SPACE | NUM_ONLY);
 
 		rightOptions.add(new GuiElementButton("Close (discards changes)", Color.LIGHT_GRAY.getRGB(), () ->
 			Minecraft.getMinecraft().displayGuiScreen(null)));
+
+		rightOptions.add(new GuiElementText("", Color.WHITE.getRGB()));
+
 		GuiElementButton button = new Object() { //Used to make the compiler shut the fuck up
 			final GuiElementButton b = new GuiElementButton("Save to local disk", Color.GREEN.getRGB(), new Runnable() {
 				public void run() {
 					if (save()) {
-						b.setText("Save to local disk (SUCCESS)");
+						b.setText(saved == 0 ? "Saved" : "Saved (" + saved + ")");
+						saved++;
 					} else {
-						b.setText("Save to local disk (FAILED)");
+						b.setText("Saving FAILED!");
 					}
 				}
 			});
 		}.b;
 		rightOptions.add(button);
 
-		rightOptions.add(new GuiElementText("", Color.WHITE.getRGB()));
-
 		rightOptions.add(new GuiElementButton("Remove enchants", Color.RED.getRGB(), () -> {
-			nbttag.removeTag("ench");
-			nbttag.getCompoundTag("ExtraAttributes").removeTag("enchantments");
+			nbtTag.removeTag("ench");
+			nbtTag.getCompoundTag("ExtraAttributes").removeTag("enchantments");
 		}));
 		rightOptions.add(new GuiElementButton(
 			"Add enchant glint",
 			Color.ORANGE.getRGB(),
-			() -> nbttag.setTag("ench", new NBTTagList())
+			() -> nbtTag.setTag("ench", new NBTTagList())
 		));
 
-		rightOptions.add(new GuiElementButton("Remove timestamp/uuid", Color.RED.getRGB(), () -> {
-			nbttag.getCompoundTag("ExtraAttributes").removeTag("uuid");
-			nbttag.getCompoundTag("ExtraAttributes").removeTag("timestamp");
-		}));
-
 		resetScrollToTop();
+	}
+
+	/**
+	 * Returns the Element from the item being edited or the already existing item, prioritizing the item currently being edited
+	 *
+	 * @param key The JSON key
+	 * @return the element found, or null
+	 */
+	private JsonElement getItemInfo(String key) {
+		if (item.has(key)) {
+			return item.get(key);
+		} else if (savedRepoItem != null && savedRepoItem.has(key)) {
+			return savedRepoItem.get(key);
+		} else {
+			return null;
+		}
 	}
 
 	public boolean save() {
@@ -159,8 +187,8 @@ public class NEUItemEditor extends GuiScreen {
 		if (infoA.length == 0 || infoA[0].isEmpty()) {
 			infoA = new String[0];
 		}
-		return manager.writeItemJson(item, internalname.get(), itemid.get(), displayname.get(), lore.get().split("\n"),
-			crafttext.get(), infoType.get(), infoA, clickcommand.get(), damageI, nbttag
+		return manager.writeItemJson(item, internalName.get(), itemId.get(), displayName.get(), lore.get().split("\n"),
+			craftText.get(), infoType.get(), infoA, clickCommand.get(), damageI, nbtTag
 		);
 	}
 
@@ -175,7 +203,7 @@ public class NEUItemEditor extends GuiScreen {
 	}
 
 	public void resyncNbttag() {
-		if (nbttag == null) nbttag = new NBTTagCompound();
+		if (nbtTag == null) nbtTag = new NBTTagCompound();
 
 		//Item lore
 		NBTTagList list = new NBTTagList();
@@ -183,17 +211,17 @@ public class NEUItemEditor extends GuiScreen {
 			list.appendTag(new NBTTagString(lore));
 		}
 
-		NBTTagCompound display = nbttag.getCompoundTag("display");
+		NBTTagCompound display = nbtTag.getCompoundTag("display");
 		display.setTag("Lore", list);
 
 		//Name
-		display.setString("Name", displayname.get());
-		nbttag.setTag("display", display);
+		display.setString("Name", displayName.get());
+		nbtTag.setTag("display", display);
 
 		//Internal ID
-		NBTTagCompound ea = nbttag.getCompoundTag("ExtraAttributes");
-		ea.setString("id", internalname.get());
-		nbttag.setTag("ExtraAttributes", ea);
+		NBTTagCompound ea = nbtTag.getCompoundTag("ExtraAttributes");
+		ea.setString("id", internalName.get());
+		nbtTag.setTag("ExtraAttributes", ea);
 	}
 
 	public void resetScrollToTop() {
@@ -247,9 +275,6 @@ public class NEUItemEditor extends GuiScreen {
 		drawRect(0, 0, width, height, backgroundColour.getRGB());
 
 		int yScroll = calculateYScroll();
-		if (yScroll > 0) {
-			//Render scroll bar
-		}
 
 		int currentY = PADDING - yScroll;
 		for (GuiElement gui : options) {
@@ -272,7 +297,7 @@ public class NEUItemEditor extends GuiScreen {
 		drawRect(itemX - 9, itemY - 9, itemX + itemSize + 9, itemY + itemSize + 9, itemBorder.getRGB());
 		drawRect(itemX - 6, itemY - 6, itemX + itemSize + 6, itemY + itemSize + 6, Color.DARK_GRAY.getRGB());
 		drawRect(itemX - 5, itemY - 5, itemX + itemSize + 5, itemY + itemSize + 5, itemBackground.getRGB());
-		ItemStack stack = new ItemStack(Item.itemRegistry.getObject(new ResourceLocation(itemid.get())));
+		ItemStack stack = new ItemStack(Item.itemRegistry.getObject(new ResourceLocation(itemId.get())));
 
 		if (stack.getItem() != null) {
 			try {
@@ -281,18 +306,18 @@ public class NEUItemEditor extends GuiScreen {
 			}
 
 			resyncNbttag();
-			stack.setTagCompound(nbttag);
+			stack.setTagCompound(nbtTag);
 
 			int scaleFactor = itemSize / 16;
 			GL11.glPushMatrix();
 			GlStateManager.scale(scaleFactor, scaleFactor, 1);
-			drawItemStack(stack, itemX / scaleFactor, itemY / scaleFactor, null);
+			drawItemStack(stack, itemX / scaleFactor, itemY / scaleFactor);
 			GL11.glPopMatrix();
 		}
 
 		//Tooltip
 		List<String> text = new ArrayList<>();
-		text.add(displayname.get());
+		text.add(displayName.get());
 		text.addAll(Arrays.asList(lore.get().split("\n")));
 
 		Utils.drawHoveringText(text, itemX - 20, itemY + itemSize + 28, width, height, -1,
@@ -304,6 +329,7 @@ public class NEUItemEditor extends GuiScreen {
 
 	@Override
 	protected void keyTyped(char typedChar, int keyCode) {
+		boolean hasChanges = false;
 		if (keyCode == Keyboard.KEY_ESCAPE && !hasChanges) {
 			Minecraft.getMinecraft().displayGuiScreen(null);
 			return;
@@ -412,7 +438,7 @@ public class NEUItemEditor extends GuiScreen {
 		}
 	}
 
-	private void drawItemStack(ItemStack stack, int x, int y, String altText) {
+	private void drawItemStack(ItemStack stack, int x, int y) {
 		RenderItem itemRender = Minecraft.getMinecraft().getRenderItem();
 		FontRenderer font = Minecraft.getMinecraft().fontRendererObj;
 
@@ -420,7 +446,7 @@ public class NEUItemEditor extends GuiScreen {
 		itemRender.renderItemAndEffectIntoGUI(stack, x, y);
 		RenderHelper.disableStandardItemLighting();
 
-		itemRender.renderItemOverlayIntoGUI(font, stack, x, y, altText);
+		itemRender.renderItemOverlayIntoGUI(font, stack, x, y, null);
 	}
 
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
@@ -1026,11 +1026,20 @@ public class RenderListener {
 		}
 		if (NotEnoughUpdates.INSTANCE.config.hidden.dev && Keyboard.isKeyDown(Keyboard.KEY_B) &&
 			Minecraft.getMinecraft().currentScreen instanceof GuiChest &&
-			((((ContainerChest) ((GuiChest) Minecraft.getMinecraft().currentScreen).inventorySlots)
+			(((ContainerChest) ((GuiChest) Minecraft.getMinecraft().currentScreen).inventorySlots)
 				.getLowerChestInventory()
-				.getDisplayName()
-				.getUnformattedText()
-				.endsWith("Upgrades")))) {
+				.getStackInSlot(48)
+				!= null &&
+				((ContainerChest) ((GuiChest) Minecraft.getMinecraft().currentScreen).inventorySlots)
+					.getLowerChestInventory()
+					.getStackInSlot(48)
+					.getTooltip(Minecraft.getMinecraft().thePlayer, false).size() == 2 &&
+					(((ContainerChest) ((GuiChest) Minecraft.getMinecraft().currentScreen).inventorySlots)
+						.getLowerChestInventory()
+						.getStackInSlot(48)
+						.getTooltip(Minecraft.getMinecraft().thePlayer, false)
+						.get(1)
+						.endsWith("Essence")))) {
 			GuiChest eventGui = (GuiChest) Minecraft.getMinecraft().currentScreen;
 			ContainerChest cc = (ContainerChest) eventGui.inventorySlots;
 			IInventory lower = cc.getLowerChestInventory();

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
@@ -1022,12 +1022,13 @@ public class RenderListener {
 			event.setCanceled(true);
 		}
 		if (NotEnoughUpdates.INSTANCE.config.hidden.dev && Keyboard.isKeyDown(Keyboard.KEY_B) &&
-			(Minecraft.getMinecraft().currentScreen instanceof GuiChest &&
-				(((ContainerChest) ((GuiChest) Minecraft.getMinecraft().currentScreen).inventorySlots)
-					.getLowerChestInventory()
-					.getDisplayName()
-					.toString()
-					.endsWith("Upgrades")))) {
+			Minecraft.getMinecraft().currentScreen instanceof GuiChest &&
+			((((ContainerChest) ((GuiChest) Minecraft.getMinecraft().currentScreen).inventorySlots)
+				.getLowerChestInventory()
+				.getDisplayName()
+				.getUnformattedText()
+				.endsWith("Upgrades")))) {
+			System.out.println("afsfd");
 			GuiChest eventGui = (GuiChest) Minecraft.getMinecraft().currentScreen;
 			ContainerChest cc = (ContainerChest) eventGui.inventorySlots;
 			IInventory lower = cc.getLowerChestInventory();

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
@@ -76,7 +76,6 @@ import javax.swing.*;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
@@ -1025,51 +1024,42 @@ public class RenderListener {
 			event.setCanceled(true);
 		}
 		if (NotEnoughUpdates.INSTANCE.config.hidden.dev && Keyboard.isKeyDown(Keyboard.KEY_B) &&
-			Minecraft.getMinecraft().currentScreen instanceof GuiChest &&
-			(((ContainerChest) ((GuiChest) Minecraft.getMinecraft().currentScreen).inventorySlots)
-				.getLowerChestInventory()
-				.getStackInSlot(48)
-				!= null &&
-				((ContainerChest) ((GuiChest) Minecraft.getMinecraft().currentScreen).inventorySlots)
-					.getLowerChestInventory()
-					.getStackInSlot(48)
-					.getTooltip(Minecraft.getMinecraft().thePlayer, false).size() == 2 &&
-					(((ContainerChest) ((GuiChest) Minecraft.getMinecraft().currentScreen).inventorySlots)
-						.getLowerChestInventory()
-						.getStackInSlot(48)
-						.getTooltip(Minecraft.getMinecraft().thePlayer, false)
-						.get(1)
-						.endsWith("Essence")))) {
+			Minecraft.getMinecraft().currentScreen instanceof GuiChest
+		) {
 			GuiChest eventGui = (GuiChest) Minecraft.getMinecraft().currentScreen;
 			ContainerChest cc = (ContainerChest) eventGui.inventorySlots;
 			IInventory lower = cc.getLowerChestInventory();
 
-			try {
-				File file = new File(
-					Minecraft.getMinecraft().mcDataDir.getAbsolutePath(),
-					"config/notenoughupdates/repo/constants/essencecosts.json"
-				);
-				String fileContent;
-				fileContent = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))
-					.lines()
-					.collect(Collectors.joining(System.lineSeparator()));
-				String id = null;
-				JsonObject jsonObject = new JsonParser().parse(fileContent).getAsJsonObject();
-				JsonObject newEntry = new JsonObject();
-				for (int i = 0; i < 54; i++) {
-					ItemStack stack = lower.getStackInSlot(i);
-					if (!stack.getDisplayName().isEmpty() && stack.getItem() != Item.getItemFromBlock(Blocks.barrier) &&
-						stack.getItem() != Items.arrow) {
-						if (stack.getTagCompound().getCompoundTag("display").hasKey("Lore", 9)) {
-							int stars = Utils.getNumberOfStars(stack);
-							if (stars == 0) continue;
+			ItemStack backArrow = lower.getStackInSlot(48);
+			List<String> tooltip = backArrow != null ? backArrow.getTooltip(Minecraft.getMinecraft().thePlayer, false) : null;
+			if (tooltip != null && tooltip.size() >= 2 && tooltip.get(1).endsWith("Essence")) {
 
-							NBTTagList lore = stack.getTagCompound().getCompoundTag("display").getTagList("Lore", 8);
-							int costIndex = 10000;
-							id = NotEnoughUpdates.INSTANCE.manager.getInternalnameFromNBT(stack.getTagCompound());
-							if (jsonObject.has(id)) {
-								jsonObject.remove(id);
-							}
+				try {
+					File file = new File(
+						Minecraft.getMinecraft().mcDataDir.getAbsolutePath(),
+						"config/notenoughupdates/repo/constants/essencecosts.json"
+					);
+					String fileContent;
+					fileContent = new BufferedReader(new InputStreamReader(Files.newInputStream(file.toPath()), StandardCharsets.UTF_8))
+						.lines()
+						.collect(Collectors.joining(System.lineSeparator()));
+					String id = null;
+					JsonObject jsonObject = new JsonParser().parse(fileContent).getAsJsonObject();
+					JsonObject newEntry = new JsonObject();
+					for (int i = 0; i < 54; i++) {
+						ItemStack stack = lower.getStackInSlot(i);
+						if (!stack.getDisplayName().isEmpty() && stack.getItem() != Item.getItemFromBlock(Blocks.barrier) &&
+							stack.getItem() != Items.arrow) {
+							if (stack.getTagCompound().getCompoundTag("display").hasKey("Lore", 9)) {
+								int stars = Utils.getNumberOfStars(stack);
+								if (stars == 0) continue;
+
+								NBTTagList lore = stack.getTagCompound().getCompoundTag("display").getTagList("Lore", 8);
+								int costIndex = 10000;
+								id = NotEnoughUpdates.INSTANCE.manager.getInternalnameFromNBT(stack.getTagCompound());
+								if (jsonObject.has(id)) {
+									jsonObject.remove(id);
+								}
 								for (int j = 0; j < lore.tagCount(); j++) {
 									String entry = lore.getStringTagAt(j);
 									if (entry.equals("§7Cost")) {
@@ -1137,6 +1127,7 @@ public class RenderListener {
 					e.printStackTrace();
 					Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(
 						EnumChatFormatting.RED + "Error while parsing inventory. Try again or check logs for details."));
+				}
 			}
 		} else if (Keyboard.isKeyDown(Keyboard.KEY_RETURN) && NotEnoughUpdates.INSTANCE.config.hidden.dev) {
 			Minecraft mc = Minecraft.getMinecraft();

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
@@ -1021,38 +1021,43 @@ public class RenderListener {
 		if (typing) {
 			event.setCanceled(true);
 		}
-		if (Keyboard.isKeyDown(Keyboard.KEY_B) && NotEnoughUpdates.INSTANCE.config.hidden.dev) {
-			if (Minecraft.getMinecraft().currentScreen instanceof GuiChest) {
-				GuiChest eventGui = (GuiChest) Minecraft.getMinecraft().currentScreen;
-				ContainerChest cc = (ContainerChest) eventGui.inventorySlots;
-				IInventory lower = cc.getLowerChestInventory();
+		if (NotEnoughUpdates.INSTANCE.config.hidden.dev && Keyboard.isKeyDown(Keyboard.KEY_B) &&
+			(Minecraft.getMinecraft().currentScreen instanceof GuiChest &&
+				(((ContainerChest) ((GuiChest) Minecraft.getMinecraft().currentScreen).inventorySlots)
+					.getLowerChestInventory()
+					.getDisplayName()
+					.toString()
+					.endsWith("Upgrades")))) {
+			GuiChest eventGui = (GuiChest) Minecraft.getMinecraft().currentScreen;
+			ContainerChest cc = (ContainerChest) eventGui.inventorySlots;
+			IInventory lower = cc.getLowerChestInventory();
 
-				try {
-					File file = new File(
-						Minecraft.getMinecraft().mcDataDir.getAbsolutePath(),
-						"config/notenoughupdates/repo/constants/essencecosts.json"
-					);
-					String fileContent;
-					fileContent = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))
-						.lines()
-						.collect(Collectors.joining(System.lineSeparator()));
-					String id = null;
-					JsonObject jsonObject = new JsonParser().parse(fileContent).getAsJsonObject();
-					JsonObject newEntry = new JsonObject();
-					for (int i = 0; i < 54; i++) {
-						ItemStack stack = lower.getStackInSlot(i);
-						if (!stack.getDisplayName().isEmpty() && stack.getItem() != Item.getItemFromBlock(Blocks.barrier) &&
-							stack.getItem() != Items.arrow) {
-							if (stack.getTagCompound().getCompoundTag("display").hasKey("Lore", 9)) {
-								int stars = Utils.getNumberOfStars(stack);
-								if (stars == 0) continue;
+			try {
+				File file = new File(
+					Minecraft.getMinecraft().mcDataDir.getAbsolutePath(),
+					"config/notenoughupdates/repo/constants/essencecosts.json"
+				);
+				String fileContent;
+				fileContent = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))
+					.lines()
+					.collect(Collectors.joining(System.lineSeparator()));
+				String id = null;
+				JsonObject jsonObject = new JsonParser().parse(fileContent).getAsJsonObject();
+				JsonObject newEntry = new JsonObject();
+				for (int i = 0; i < 54; i++) {
+					ItemStack stack = lower.getStackInSlot(i);
+					if (!stack.getDisplayName().isEmpty() && stack.getItem() != Item.getItemFromBlock(Blocks.barrier) &&
+						stack.getItem() != Items.arrow) {
+						if (stack.getTagCompound().getCompoundTag("display").hasKey("Lore", 9)) {
+							int stars = Utils.getNumberOfStars(stack);
+							if (stars == 0) continue;
 
-								NBTTagList lore = stack.getTagCompound().getCompoundTag("display").getTagList("Lore", 8);
-								int costIndex = 10000;
-								id = NotEnoughUpdates.INSTANCE.manager.getInternalnameFromNBT(stack.getTagCompound());
-								if (jsonObject.has(id)) {
-									jsonObject.remove(id);
-								}
+							NBTTagList lore = stack.getTagCompound().getCompoundTag("display").getTagList("Lore", 8);
+							int costIndex = 10000;
+							id = NotEnoughUpdates.INSTANCE.manager.getInternalnameFromNBT(stack.getTagCompound());
+							if (jsonObject.has(id)) {
+								jsonObject.remove(id);
+							}
 								for (int j = 0; j < lore.tagCount(); j++) {
 									String entry = lore.getStringTagAt(j);
 									if (entry.equals("§7Cost")) {
@@ -1120,7 +1125,6 @@ public class RenderListener {
 					e.printStackTrace();
 					Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(
 						EnumChatFormatting.RED + "Error while parsing inventory. Try again or check logs for details."));
-				}
 			}
 		} else if (Keyboard.isKeyDown(Keyboard.KEY_RETURN) && NotEnoughUpdates.INSTANCE.config.hidden.dev) {
 			Minecraft mc = Minecraft.getMinecraft();

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
@@ -14,6 +14,7 @@ import io.github.moulberry.notenoughupdates.auction.CustomAHGui;
 import io.github.moulberry.notenoughupdates.commands.profile.ViewProfileCommand;
 import io.github.moulberry.notenoughupdates.core.GuiScreenElementWrapper;
 import io.github.moulberry.notenoughupdates.dungeons.DungeonWin;
+import io.github.moulberry.notenoughupdates.itemeditor.NEUItemEditor;
 import io.github.moulberry.notenoughupdates.miscfeatures.AuctionBINWarning;
 import io.github.moulberry.notenoughupdates.miscfeatures.BetterContainers;
 import io.github.moulberry.notenoughupdates.miscfeatures.CrystalMetalDetectorSolver;
@@ -82,8 +83,10 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.text.NumberFormat;
+import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
@@ -1028,7 +1031,6 @@ public class RenderListener {
 				.getDisplayName()
 				.getUnformattedText()
 				.endsWith("Upgrades")))) {
-			System.out.println("afsfd");
 			GuiChest eventGui = (GuiChest) Minecraft.getMinecraft().currentScreen;
 			ContainerChest cc = (ContainerChest) eventGui.inventorySlots;
 			IInventory lower = cc.getLowerChestInventory();
@@ -1262,6 +1264,54 @@ public class RenderListener {
 						EnumChatFormatting.RED + "Error while parsing inventory. Try again or check logs for details"));
 				}
 			}
+		} else if (NotEnoughUpdates.INSTANCE.config.hidden.dev && Keyboard.isKeyDown(Keyboard.KEY_B) &&
+			Minecraft.getMinecraft().currentScreen instanceof GuiChest &&
+			((((ContainerChest) ((GuiChest) Minecraft.getMinecraft().currentScreen).inventorySlots)
+				.getLowerChestInventory()
+				.getDisplayName()
+				.getUnformattedText()
+				.endsWith("Essence")))) {
+			GuiChest eventGui = (GuiChest) Minecraft.getMinecraft().currentScreen;
+			ContainerChest cc = (ContainerChest) eventGui.inventorySlots;
+			IInventory lower = cc.getLowerChestInventory();
+
+			for (int i = 9; i < 45; i++) {
+				ItemStack stack = lower.getStackInSlot(i);
+				if (stack == null) continue;
+				if (stack.getDisplayName().isEmpty() || stack.getDisplayName().equals(" ")) continue;
+				String internalName = NotEnoughUpdates.INSTANCE.manager.getInternalNameForItem(stack);
+				if (internalName == null) {
+					Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(
+						EnumChatFormatting.RED + "ERROR: Could not get internal name for: " + EnumChatFormatting.AQUA +
+							stack.getDisplayName()));
+					continue;
+				}
+				JsonObject itemObject = NotEnoughUpdates.INSTANCE.manager.getJsonForItem(stack);
+				JsonArray lore = itemObject.get("lore").getAsJsonArray();
+				List<String> loreList = new ArrayList<>();
+				for (int j = 0; j < lore.size(); j++) loreList.add(lore.get(j).getAsString());
+				if (loreList.get(loreList.size() - 1).equals("§7§eClick to view upgrades!")) {
+					loreList.remove(loreList.size() - 1);
+					loreList.remove(loreList.size() - 1);
+				}
+
+				JsonArray newLore = new JsonArray();
+				for (String s : loreList) {
+					newLore.add(new JsonPrimitive(s));
+				}
+				itemObject.remove("lore");
+				itemObject.add("lore", newLore);
+
+				if (!NEUItemEditor.saveOnly(internalName, itemObject)) {
+					Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(
+						EnumChatFormatting.RED + "ERROR: Failed to save item: " + EnumChatFormatting.AQUA +
+							stack.getDisplayName()));
+				}
+			}
+			Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(
+				EnumChatFormatting.AQUA + "Parsed page: " + lower.getDisplayName().getUnformattedText()));
+			event.setCanceled(true);
+			return;
 		}
 
 		if (AuctionBINWarning.getInstance().shouldShow()) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/GuiEnchantColour.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/GuiEnchantColour.java
@@ -599,10 +599,12 @@ public class GuiEnchantColour extends GuiScreen {
 						getEnchantOpString(guiElementTextFields.get(yIndex), comparators.get(yIndex), modifiers.get(yIndex))
 					);
 				} else if (mouseX > guiLeft + 160 && mouseX < guiLeft + 160 + 20) {
-					NotEnoughUpdates.INSTANCE.config.hidden.enchantColours.remove(yIndex);
-					guiElementTextFields.remove(yIndex);
-					comparators.remove(yIndex);
-					modifiers.remove(yIndex);
+					if (NotEnoughUpdates.INSTANCE.config.hidden.enchantColours.size() > 0) {
+						NotEnoughUpdates.INSTANCE.config.hidden.enchantColours.remove(yIndex);
+						guiElementTextFields.remove(yIndex);
+						comparators.remove(yIndex);
+						modifiers.remove(yIndex);
+					}
 				}
 			}
 		}

--- a/src/main/java/io/github/moulberry/notenoughupdates/recipes/RecipeGenerator.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/recipes/RecipeGenerator.java
@@ -21,7 +21,12 @@ import net.minecraftforge.fml.common.gameevent.TickEvent;
 import org.lwjgl.input.Keyboard;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -231,6 +236,7 @@ public class RecipeGenerator {
 	Damage: 3s
 }*/
 	public boolean saveRecipes(String relevantItem, List<NeuRecipe> recipes) throws IOException {
+		relevantItem = relevantItem.replace(" ", "_");
 		JsonObject outputJson = neu.manager.readJsonDefaultDir(relevantItem + ".json");
 		if (outputJson == null) return false;
 		outputJson.addProperty("clickcommand", "viewrecipe");


### PR DESCRIPTION
Now gets info such as wiki links, recipe etc. when editing for example an item from bazaar so they don't have to be added back manually

Also restricts the parsing for essence to the essence guide menu