### PR TITLE
fix star selection

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/AuctionSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/AuctionSearchOverlay.java
@@ -326,7 +326,7 @@ public class AuctionSearchOverlay {
 
 		StringBuilder stringBuilder = new StringBuilder(searchString.trim());
 		if (!searchStringExtra.isEmpty()) {
-			stringBuilder.append(searchStringExtra.trim());
+			stringBuilder.append(searchStringExtra);
 		}
 		if (onlyLevel100) {
 			stringBuilder.insert(0, "[Lvl 100] ");
@@ -631,7 +631,7 @@ public class AuctionSearchOverlay {
 								}
 
 								JsonObject essenceCosts = Constants.ESSENCECOSTS;
-								searchStringExtra = "";
+								searchStringExtra = " ";
 								if (essenceCosts != null && essenceCosts.has(str) && selectedStars > 0) {
 									for (int i = 0; i < selectedStars; i++) {
 										if (i > 4) break;


### PR DESCRIPTION
The star search feature in the ah overlay broke in the latest unofficial prerelease, so I quickly fixed it (mostly so I can keep flipping lol).