### PR TITLE
Pv hide offline location

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/GuiProfileViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/GuiProfileViewer.java
@@ -4653,23 +4653,33 @@ public class GuiProfileViewer extends GuiScreen {
 			JsonElement onlineElement = Utils.getElement(status, "online");
 			boolean online = onlineElement != null && onlineElement.isJsonPrimitive() && onlineElement.getAsBoolean();
 			String statusStr = online ? EnumChatFormatting.GREEN + "ONLINE" : EnumChatFormatting.RED + "OFFLINE";
-			String locationStr = null;
-			if (profile.getUuid().equals("20934ef9488c465180a78f861586b4cf")) {
-				locationStr = "Ignoring DMs";
-			} else if(profile.getUuid().equals("b876ec32e396476ba1158438d83c67d4")) {
-				statusStr = EnumChatFormatting.LIGHT_PURPLE + "Long live Potato King";
-				ItemStack potato_crown = NotEnoughUpdates.INSTANCE.manager.jsonToStack(NotEnoughUpdates.INSTANCE.manager
-					.getItemInformation()
-					.get("POTATO_CROWN"));
-				potato_crown.addEnchantment(Enchantment.unbreaking, 1656638942); // this number may be useful
-				Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(new ItemStack(Items.potato), guiLeft + 35, guiTop + 160);
-				Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(potato_crown, guiLeft + 50, guiTop + 162);
-				Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(new ItemStack(Items.potato), guiLeft + 63, guiTop + 160);
-			} else {
-				locationStr = NotEnoughUpdates.INSTANCE.navigation.getNameForAreaModeOrUnknown(location);
-			}
-			if (locationStr != null) {
-				statusStr += EnumChatFormatting.GRAY + " - " + EnumChatFormatting.GREEN + locationStr;
+			if (online) {
+				String locationStr = null;
+				if (profile.getUuid().equals("20934ef9488c465180a78f861586b4cf")) {
+					locationStr = "Ignoring DMs";
+				} else if (profile.getUuid().equals("b876ec32e396476ba1158438d83c67d4")) {
+					statusStr = EnumChatFormatting.LIGHT_PURPLE + "Long live Potato King";
+					ItemStack potato_crown = NotEnoughUpdates.INSTANCE.manager.jsonToStack(NotEnoughUpdates.INSTANCE.manager
+						.getItemInformation()
+						.get("POTATO_CROWN"));
+					potato_crown.addEnchantment(Enchantment.unbreaking, 1656638942); // this number may be useful
+					Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(
+						new ItemStack(Items.potato),
+						guiLeft + 35,
+						guiTop + 160
+					);
+					Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(potato_crown, guiLeft + 50, guiTop + 162);
+					Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(
+						new ItemStack(Items.potato),
+						guiLeft + 63,
+						guiTop + 160
+					);
+				} else {
+					locationStr = NotEnoughUpdates.INSTANCE.navigation.getNameForAreaModeOrUnknown(location);
+				}
+				if (locationStr != null) {
+					statusStr += EnumChatFormatting.GRAY + " - " + EnumChatFormatting.GREEN + locationStr;
+				}
 			}
 
 			Utils.drawStringCentered(statusStr, fr, guiLeft + 63, guiTop + 160, true, 0);

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/GuiProfileViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/GuiProfileViewer.java
@@ -4653,33 +4653,31 @@ public class GuiProfileViewer extends GuiScreen {
 			JsonElement onlineElement = Utils.getElement(status, "online");
 			boolean online = onlineElement != null && onlineElement.isJsonPrimitive() && onlineElement.getAsBoolean();
 			String statusStr = online ? EnumChatFormatting.GREEN + "ONLINE" : EnumChatFormatting.RED + "OFFLINE";
-			if (online) {
-				String locationStr = null;
-				if (profile.getUuid().equals("20934ef9488c465180a78f861586b4cf")) {
-					locationStr = "Ignoring DMs";
-				} else if (profile.getUuid().equals("b876ec32e396476ba1158438d83c67d4")) {
-					statusStr = EnumChatFormatting.LIGHT_PURPLE + "Long live Potato King";
-					ItemStack potato_crown = NotEnoughUpdates.INSTANCE.manager.jsonToStack(NotEnoughUpdates.INSTANCE.manager
-						.getItemInformation()
-						.get("POTATO_CROWN"));
-					potato_crown.addEnchantment(Enchantment.unbreaking, 1656638942); // this number may be useful
-					Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(
-						new ItemStack(Items.potato),
-						guiLeft + 35,
-						guiTop + 160
-					);
-					Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(potato_crown, guiLeft + 50, guiTop + 162);
-					Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(
-						new ItemStack(Items.potato),
-						guiLeft + 63,
-						guiTop + 160
-					);
-				} else {
-					locationStr = NotEnoughUpdates.INSTANCE.navigation.getNameForAreaModeOrUnknown(location);
-				}
-				if (locationStr != null) {
-					statusStr += EnumChatFormatting.GRAY + " - " + EnumChatFormatting.GREEN + locationStr;
-				}
+			String locationStr = null;
+			if (profile.getUuid().equals("20934ef9488c465180a78f861586b4cf")) {
+				locationStr = "Ignoring DMs";
+			} else if (profile.getUuid().equals("b876ec32e396476ba1158438d83c67d4")) {
+				statusStr = EnumChatFormatting.LIGHT_PURPLE + "Long live Potato King";
+				ItemStack potato_crown = NotEnoughUpdates.INSTANCE.manager.jsonToStack(NotEnoughUpdates.INSTANCE.manager
+					.getItemInformation()
+					.get("POTATO_CROWN"));
+				potato_crown.addEnchantment(Enchantment.unbreaking, 1656638942); // this number may be useful
+				Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(
+					new ItemStack(Items.potato),
+					guiLeft + 35,
+					guiTop + 160
+				);
+				Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(potato_crown, guiLeft + 50, guiTop + 162);
+				Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(
+					new ItemStack(Items.potato),
+					guiLeft + 63,
+					guiTop + 160
+				);
+			} else if (online) {
+				locationStr = NotEnoughUpdates.INSTANCE.navigation.getNameForAreaModeOrUnknown(location);
+			}
+			if (locationStr != null) {
+				statusStr += EnumChatFormatting.GRAY + " - " + EnumChatFormatting.GREEN + locationStr;
 			}
 
 			Utils.drawStringCentered(statusStr, fr, guiLeft + 63, guiTop + 160, true, 0);


### PR DESCRIPTION
Fixing a bug that when a player is offline, the profile viewer is showing the location anyways.
![image](https://user-images.githubusercontent.com/24389977/182164378-bb505f4c-4388-41bb-a459-9d2acbb1ac2f.png)
