### PR TITLE
Api Collection Int Limit Fun

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
@@ -1315,7 +1315,7 @@ public class ProfileViewer {
 			}
 
 			for (Map.Entry<String, JsonElement> entry : personalAmounts.entrySet()) {
-				totalAmounts.addProperty(entry.getKey(), entry.getValue().getAsInt());
+				totalAmounts.addProperty(entry.getKey(), entry.getValue().getAsLong());
 			}
 
 			List<JsonObject> coopProfiles = getCoopProfileInformation(profileId);
@@ -1325,7 +1325,7 @@ public class ProfileViewer {
 					if (coopCollectionInfoElement != null && coopCollectionInfoElement.isJsonObject()) {
 						for (Map.Entry<String, JsonElement> entry : coopCollectionInfoElement.getAsJsonObject().entrySet()) {
 							float existing = Utils.getElementAsFloat(totalAmounts.get(entry.getKey()), 0);
-							totalAmounts.addProperty(entry.getKey(), existing + entry.getValue().getAsInt());
+							totalAmounts.addProperty(entry.getKey(), existing + entry.getValue().getAsLong());
 						}
 					}
 				}


### PR DESCRIPTION
Fixed some collection display problems because of the int limit in the collection page in profile viewer.
Worked for example for the carrot collection from 'dawjaw'.
But the gemstone collection from 'deathstreeks' is still negative. API moment?

![image](https://user-images.githubusercontent.com/24389977/183298515-75ef70d9-b393-4a79-b10c-14502ccd7129.png)
