### PR TITLE
Fix Crash

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/Navigation.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/Navigation.java
@@ -390,10 +390,8 @@ public class Navigation {
 			&& NotEnoughUpdates.INSTANCE.config.misc.untrackCloseWaypoints
 			&& island.equals(SBInfo.getInstance().mode)) {
 			EntityPlayerSP thePlayer = Minecraft.getMinecraft().thePlayer;
-			if (thePlayer != null) {
-				if (thePlayer.getDistanceSq(position) < 16)
-					untrackWaypoint();
-			}
+			if (thePlayer != null && thePlayer.getDistanceSq(position) < 16)
+				untrackWaypoint();
 		}
 	}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/Navigation.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/Navigation.java
@@ -390,8 +390,10 @@ public class Navigation {
 			&& NotEnoughUpdates.INSTANCE.config.misc.untrackCloseWaypoints
 			&& island.equals(SBInfo.getInstance().mode)) {
 			EntityPlayerSP thePlayer = Minecraft.getMinecraft().thePlayer;
-			if (thePlayer.getDistanceSq(position) < 16)
-				untrackWaypoint();
+			if (thePlayer != null) {
+				if (thePlayer.getDistanceSq(position) < 16)
+					untrackWaypoint();
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix a legit game crash


```
java.lang.NullPointerException: Unexpected error
	at io.github.moulberry.notenoughupdates.miscfeatures.Navigation.onEvent(Navigation.java:393)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_110_Navigation_onEvent_ClientTickEvent.invoke(.dynamic)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:49)
	at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:140)
	at net.minecraftforge.fml.common.FMLCommonHandler.onPostClientTick(FMLCommonHandler.java:336)
	at net.minecraft.client.Minecraft.runTick(Minecraft.java:2151)
	at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1024)
	at net.minecraft.client.Minecraft.run(Minecraft.java:349)
	at net.minecraft.client.main.Main.main(SourceFile:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at gg.essential.loader.stage2.relaunch.Relaunch.relaunch(Relaunch.java:124)
	at gg.essential.loader.stage2.EssentialLoader.preloadEssential(EssentialLoader.java:164)
	at gg.essential.loader.stage2.EssentialLoader.loadPlatform(EssentialLoader.java:110)
	at gg.essential.loader.stage2.EssentialLoaderBase.load(EssentialLoaderBase.java:192)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at gg.essential.loader.stage1.EssentialLoaderBase.load(EssentialLoaderBase.java:110)
	at gg.essential.loader.stage1.EssentialSetupTweaker.<init>(EssentialSetupTweaker.java:44)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:422)
	at gg.essential.loader.stage0.EssentialSetupTweaker.loadStage1(EssentialSetupTweaker.java:53)
	at gg.essential.loader.stage0.EssentialSetupTweaker.<init>(EssentialSetupTweaker.java:26)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:422)
	at java.lang.Class.newInstance(Class.java:442)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:98)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
```