### PR TITLE
Fix for 1006832334638678057/1011342800840839298

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/recipes/MobLootRecipe.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/recipes/MobLootRecipe.java
@@ -72,6 +72,10 @@ public class MobLootRecipe implements NeuRecipe {
 		}
 
 		private String formatDropChance() {
+			if (chance == null) {
+				return "";
+			}
+			
 			if (!chance.endsWith("%")) {
 				return chance;
 			}


### PR DESCRIPTION
returns an empty string to avoid the mod crashing when the drop chance doesn't exist