### PR TITLE
Bugfixes (see description)

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUManager.java
@@ -397,17 +397,19 @@ public class NEUManager {
 	 * function. This method is used for the chest-item-search feature.
 	 */
 	public boolean searchString(String toSearch, String query) {
-		int lastMatch = -1;
+		int lastQueryMatched = -1;
 
 		toSearch = clean(toSearch).toLowerCase();
 		query = clean(query).toLowerCase();
-		String[] splitToSeach = toSearch.split(" ");
+		String[] splitToSearch = toSearch.split(" ");
+		String[] queryArray = query.split(" ");
+
 		out:
-		for (String s : query.split(" ")) {
-			for (int i = 0; i < splitToSeach.length; i++) {
-				if (!(lastMatch == -1 || lastMatch == i - 1)) continue;
-				if (splitToSeach[i].startsWith(s)) {
-					lastMatch = i;
+		for (int j = 0; j < queryArray.length; j++) {
+			for (int i = 0; i < splitToSearch.length; i++) {
+				if ((queryArray.length - (lastQueryMatched != -1 ? lastQueryMatched : 0)) > (splitToSearch.length - i)) continue;
+				if (splitToSearch[i].startsWith(queryArray[j])) {
+					lastQueryMatched = j;
 					continue out;
 				}
 			}

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/ItemTooltipListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/ItemTooltipListener.java
@@ -690,7 +690,7 @@ public class ItemTooltipListener {
 					if (i - 2 < 0) {
 						break;
 					}
-					newTooltip.addAll(i - 1, petToolTipXPExtend(event));
+					if (!Utils.getOpenChestName().startsWith("Auctions:")) newTooltip.addAll(i - 1, petToolTipXPExtend(event));
 					break;
 				}
 			}
@@ -723,7 +723,6 @@ public class ItemTooltipListener {
 			//7 is just a random number i chose, prob no pets with less lines than 7
 			if (event.toolTip.size() > 7) {
 				if (Utils.cleanColour(event.toolTip.get(1)).matches(petToolTipRegex)) {
-
 					GuiProfileViewer.PetLevel petlevel = null;
 
 					//this is the item itself

--- a/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinRenderItem.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinRenderItem.java
@@ -25,6 +25,7 @@ import io.github.moulberry.notenoughupdates.core.ChromaColour;
 import io.github.moulberry.notenoughupdates.listener.RenderListener;
 import io.github.moulberry.notenoughupdates.miscfeatures.ItemCooldowns;
 import io.github.moulberry.notenoughupdates.miscfeatures.ItemCustomizeManager;
+import io.github.moulberry.notenoughupdates.profileviewer.GuiProfileViewer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.Gui;
@@ -195,7 +196,7 @@ public abstract class MixinRenderItem {
 
 	@Inject(method = "renderItemIntoGUI", at = @At("HEAD"))
 	public void renderItemHead(ItemStack stack, int x, int y, CallbackInfo ci) {
-		if (NotEnoughUpdates.INSTANCE.overlay.searchMode && RenderListener.drawingGuiScreen) {
+		if (NotEnoughUpdates.INSTANCE.overlay.searchMode && RenderListener.drawingGuiScreen && !(Minecraft.getMinecraft().currentScreen instanceof GuiProfileViewer)) {
 			boolean matches = false;
 
 			GuiTextField textField = NotEnoughUpdates.INSTANCE.overlay.getTextField();
@@ -221,7 +222,7 @@ public abstract class MixinRenderItem {
 	@Inject(method = "renderItemIntoGUI", at = @At("RETURN"))
 	public void renderItemReturn(ItemStack stack, int x, int y, CallbackInfo ci) {
 		if (stack != null && stack.stackSize != 1) return;
-		if (NotEnoughUpdates.INSTANCE.overlay.searchMode && RenderListener.drawingGuiScreen) {
+		if (NotEnoughUpdates.INSTANCE.overlay.searchMode && RenderListener.drawingGuiScreen && !(Minecraft.getMinecraft().currentScreen instanceof GuiProfileViewer)) {
 			boolean matches = false;
 
 			GuiTextField textField = NotEnoughUpdates.INSTANCE.overlay.getTextField();
@@ -252,9 +253,8 @@ public abstract class MixinRenderItem {
 		CallbackInfo ci
 	) {
 		if (stack != null && stack.stackSize != 1) {
-			if (NotEnoughUpdates.INSTANCE.overlay.searchMode && RenderListener.drawingGuiScreen) {
+			if (NotEnoughUpdates.INSTANCE.overlay.searchMode && RenderListener.drawingGuiScreen && !(Minecraft.getMinecraft().currentScreen instanceof GuiProfileViewer)) {
 				boolean matches = false;
-
 				GuiTextField textField = NotEnoughUpdates.INSTANCE.overlay.getTextField();
 
 				if (textField.getText().trim().isEmpty()) {


### PR DESCRIPTION
Fix for 1006832334638678057/1012877141051969617
-> Fixes the pet exp bar appearing twice in ah while having ExtendPetExp option on.
Fix for 1006832334638678057/1013133115570524190
-> Fixes the searchString method stopping if it finds a partial match (even if a total match is contained within the string) (example: searches for "mana pool", stops at "mana cost")
Fix for 1006832334638678057/1013121688579358820
-> Fixes the main item search bar affecting Player viewer.