### PR TITLE
Update typo in Security.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,7 +6,7 @@ The following versions of the mod support security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| > 2.0   | :x:                |
+| < 2.0   | :x:                |
 | 2.0.x   | :white_check_mark: |
 | 2.1.x   | :white_check_mark: |
 


### PR DESCRIPTION
Hello!

My understanding is that this table should say that that less than 2.0 is not supported but 2.1.x and 2.0.x is supported. Otherwise there should be a new line in the table for pre 2.0 versions. Let me know if this is incorrect. 

Thanks!