### PR TITLE
Fix TextTabOverlay crash

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/TextTabOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/TextTabOverlay.java
@@ -49,8 +49,13 @@ public abstract class TextTabOverlay extends TextOverlay {
 	public void realTick() {
 		shouldUpdateOverlay = shouldUpdate();
 		if (shouldUpdateOverlay) {
-			boolean currentTabState =
-				Keyboard.isKeyDown(Minecraft.getMinecraft().gameSettings.keyBindPlayerList.getKeyCode());
+			int keycode = Minecraft.getMinecraft().gameSettings.keyBindPlayerList.getKeyCode();
+			boolean currentTabState;
+			if (keycode > 0) {
+				currentTabState = Keyboard.isKeyDown(keycode);
+			} else {
+				currentTabState = false;
+			}
 			if (lastTabState != currentTabState) {
 				lastTabState = currentTabState;
 				update();


### PR DESCRIPTION
appears to be crashing when the keybind is a negative number (for some reason)