### PR TITLE
Fixed /join not always going to Master Mode

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/commands/dungeon/JoinDungeonCommand.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/commands/dungeon/JoinDungeonCommand.java
@@ -44,7 +44,7 @@ public class JoinDungeonCommand extends ClientCommandBase {
 					EnumChatFormatting.RED + "Example Usage: /join f7, /join m6 or /join 7"));
 			} else {
 				String cataPrefix = "catacombs";
-				if (args[0].startsWith("m")) {
+				if (args[0].toLowerCase().startsWith("m")) {
 					cataPrefix = "master_catacombs";
 				}
 				String cmd = "/joindungeon " + cataPrefix + " " + args[0].charAt(args[0].length() - 1);


### PR DESCRIPTION
Changed master mode check to not be case sensitivity for /join command. 
(M5 and m5 both now properly direct to join master_catacombs 5, for example)

See card [here](https://github.com/NotEnoughUpdates/NotEnoughUpdates/projects/1#card-86110175)