### PR TITLE
Entity Scale and Party and Guild chat social options

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/ChatListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/ChatListener.java
@@ -33,6 +33,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.event.ClickEvent;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.ChatStyle;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
 import net.minecraftforge.client.ClientCommandHandler;
@@ -108,29 +109,62 @@ public class ChatListener {
 
 	private IChatComponent replaceSocialControlsWithPV(IChatComponent chatComponent) {
 
-		if (NotEnoughUpdates.INSTANCE.config.misc.replaceSocialOptions1 > 0 && chatComponent.getChatStyle() != null &&
+		if (NotEnoughUpdates.INSTANCE.config.misc.replaceSocialOptions1 > 0 &&
+			((chatComponent.getChatStyle() != null &&
 			chatComponent.getChatStyle().getChatClickEvent() != null &&
-			chatComponent.getChatStyle().getChatClickEvent().getAction() == ClickEvent.Action.RUN_COMMAND &&
+			chatComponent.getChatStyle().getChatClickEvent().getAction() == ClickEvent.Action.RUN_COMMAND) ||
+				// Party and guild chat components are different from global chats, so need to check for them here
+			(!chatComponent.getSiblings().isEmpty() && chatComponent.getSiblings().get(0).getChatStyle() != null &&
+				chatComponent.getSiblings().get(0).getChatStyle().getChatClickEvent() != null &&
+				chatComponent.getSiblings().get(0).getChatStyle().getChatClickEvent().getAction() == ClickEvent.Action.RUN_COMMAND)) &&
 			NotEnoughUpdates.INSTANCE.hasSkyblockScoreboard()) {
-			if (chatComponent.getChatStyle().getChatClickEvent().getValue().startsWith("/socialoptions")) {
-				String username = chatComponent.getChatStyle().getChatClickEvent().getValue().substring(15);
+
+			String startsWith = null;
+			boolean partyOrGuildChat = false;
+
+			if (chatComponent.getSiblings().get(0).getChatStyle().getChatClickEvent().getValue().startsWith("/viewprofile")) {
+				startsWith = "/viewprofile";
+				partyOrGuildChat = true;
+			} else if (chatComponent.getChatStyle().getChatClickEvent().getValue().startsWith("/socialoptions")) {
+				startsWith = "/socialoptions";
+			}
+
+			if (startsWith != null) {
+				String username = partyOrGuildChat ?
+					Utils.getNameFromChatComponent(chatComponent) :
+					chatComponent.getChatStyle().getChatClickEvent().getValue().substring(15);
+
 				if (NotEnoughUpdates.INSTANCE.config.misc.replaceSocialOptions1 == 1) {
-					chatComponent.setChatStyle(Utils.createClickStyle(
+
+					ChatStyle pvClickStyle = Utils.createClickStyle(
 						ClickEvent.Action.RUN_COMMAND,
 						"/pv " + username,
 						"" + EnumChatFormatting.YELLOW + "Click to open " + EnumChatFormatting.AQUA + EnumChatFormatting.BOLD +
 							username + EnumChatFormatting.RESET + EnumChatFormatting.YELLOW + "'s profile in " +
 							EnumChatFormatting.DARK_PURPLE + EnumChatFormatting.BOLD + "NEU's" + EnumChatFormatting.RESET +
 							EnumChatFormatting.YELLOW + " profile viewer."
-					));
+					);
+
+					if (partyOrGuildChat) {
+						chatComponent.getSiblings().get(0).setChatStyle(pvClickStyle);
+					} else {
+						chatComponent.setChatStyle(pvClickStyle);
+					}
 					return chatComponent;
 				} else if (NotEnoughUpdates.INSTANCE.config.misc.replaceSocialOptions1 == 2) {
-					chatComponent.setChatStyle(Utils.createClickStyle(
+
+					ChatStyle ahClickStyle = Utils.createClickStyle(
 						ClickEvent.Action.RUN_COMMAND,
 						"/ah " + username,
 						"" + EnumChatFormatting.YELLOW + "Click to open " + EnumChatFormatting.AQUA + EnumChatFormatting.BOLD +
 							username + EnumChatFormatting.RESET + EnumChatFormatting.YELLOW + "'s /ah page"
-					));
+					);
+
+					if (partyOrGuildChat) {
+						chatComponent.getSiblings().get(0).setChatStyle(ahClickStyle);
+					} else {
+						chatComponent.setChatStyle(ahClickStyle);
+					}
 					return chatComponent;
 				}
 			} // wanted to add this for guild but guild uses uuid :sad:

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/entityviewer/EntityViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/entityviewer/EntityViewer.java
@@ -65,6 +65,7 @@ import net.minecraft.entity.passive.EntitySquid;
 import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.entity.passive.EntityWolf;
 import net.minecraft.util.ResourceLocation;
+import org.lwjgl.input.Keyboard;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -227,10 +228,16 @@ public class EntityViewer extends GuiScreen {
 		EntityLivingBase stack = entity;
 		while (true) {
 			if (stack instanceof EntityDragon) {
-				scale = 5;
-				bottomOffset = 6F;
+				if (Keyboard.isKeyDown(Keyboard.KEY_SPACE)) {
+					scale = 35;
+					bottomOffset = 0F;
+				}
+				else {
+					scale = 10;
+					bottomOffset = 2F;
+				}
 			} else if (stack instanceof EntityWither) {
-				scale = 15;
+				scale = 20;
 			} else if (stack instanceof EntityGhast) {
 				scale = 8;
 				bottomOffset = 4F;

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/entityviewer/EntityViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/entityviewer/EntityViewer.java
@@ -27,8 +27,10 @@ import io.github.moulberry.notenoughupdates.util.Utils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.boss.EntityDragon;
 import net.minecraft.entity.boss.EntityWither;
@@ -224,9 +226,17 @@ public class EntityViewer extends GuiScreen {
 		float bottomOffset = 0F;
 		EntityLivingBase stack = entity;
 		while (true) {
-
+			if (stack instanceof EntityDragon) {
+				scale = 5;
+				bottomOffset = 6F;
+			} else if (stack instanceof EntityWither) {
+				scale = 15;
+			} else if (stack instanceof EntityGhast) {
+				scale = 8;
+				bottomOffset = 4F;
+			}
 			stack.ticksExisted = Minecraft.getMinecraft().thePlayer.ticksExisted;
-			GuiInventory.drawEntityOnScreen(
+			drawEntityOnScreen(
 				posX,
 				(int) (posY - bottomOffset * scale),
 				scale,
@@ -241,5 +251,45 @@ public class EntityViewer extends GuiScreen {
 			stack = (EntityLivingBase) stack.riddenByEntity;
 		}
 
+	}
+
+	// Need this to flip the ender dragon and make it follow mouse correctly
+	public static void drawEntityOnScreen(int posX, int posY, int scale, float mouseX, float mouseY, EntityLivingBase ent) {
+		GlStateManager.enableColorMaterial();
+		GlStateManager.pushMatrix();
+		GlStateManager.translate((float)posX, (float)posY, 50.0F);
+		GlStateManager.scale((float)(-scale), (float)scale, (float)scale);
+		GlStateManager.rotate(180.0F, 0.0F, 0.0F, 1.0F);
+		float f = ent.renderYawOffset;
+		float g = ent.rotationYaw;
+		float h = ent.rotationPitch;
+		float i = ent.prevRotationYawHead;
+		float j = ent.rotationYawHead;
+		GlStateManager.rotate(135.0F, 0.0F, 1.0F, 0.0F);
+		RenderHelper.enableStandardItemLighting();
+		GlStateManager.rotate((ent instanceof EntityDragon) ? 45.0F : -135.0F, 0.0F, 1.0F, 0.0F);
+		GlStateManager.rotate((ent instanceof EntityDragon) ? ((float)Math.atan(mouseY / 40.0F)) * 20.0F : -((float)Math.atan(mouseY / 40.0F)) * 20.0F, 1.0F, 0.0F, 0.0F);
+		ent.renderYawOffset = (float)Math.atan(mouseX / 40.0F) * 20.0F;
+		ent.rotationYaw = (float)Math.atan(mouseX / 40.0F) * 40.0F;
+		ent.rotationPitch = -((float)Math.atan(mouseY / 40.0F)) * 20.0F;
+		ent.rotationYawHead = ent.rotationYaw;
+		ent.prevRotationYawHead = ent.rotationYaw;
+		GlStateManager.translate(0.0F, 0.0F, 0.0F);
+		RenderManager renderManager = Minecraft.getMinecraft().getRenderManager();
+		renderManager.setPlayerViewY(180.0F);
+		renderManager.setRenderShadow(false);
+		renderManager.renderEntityWithPosYaw(ent, 0.0D, 0.0D, 0.0D, 0.0F, 1.0F);
+		renderManager.setRenderShadow(true);
+		ent.renderYawOffset = f;
+		ent.rotationYaw = g;
+		ent.rotationPitch = h;
+		ent.prevRotationYawHead = i;
+		ent.rotationYawHead = j;
+		GlStateManager.popMatrix();
+		RenderHelper.disableStandardItemLighting();
+		GlStateManager.disableRescaleNormal();
+		GlStateManager.setActiveTexture(OpenGlHelper.lightmapTexUnit);
+		GlStateManager.disableTexture2D();
+		GlStateManager.setActiveTexture(OpenGlHelper.defaultTexUnit);
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
@@ -57,6 +57,7 @@ import net.minecraft.network.play.client.C0DPacketCloseWindow;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatStyle;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.IChatComponent;
 import net.minecraft.util.Matrix4f;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
@@ -1998,5 +1999,21 @@ public class Utils {
 
 	public static String getLastOpenChestName() {
 		return SBInfo.getInstance().lastOpenChestName;
+	}
+
+	public static String getNameFromChatComponent(IChatComponent chatComponent) {
+		String unformattedText = cleanColour(chatComponent.getSiblings().get(0).getUnformattedText());
+		String username = unformattedText.substring(unformattedText.indexOf(">") + 2, unformattedText.indexOf(":"));
+		// If the first character is a square bracket the user has a rank
+		// So we get the username from the space after the closing square bracket (end of their rank)
+		if (username.charAt(0) == '[') {
+			username = username.substring(unformattedText.indexOf(" ") + 2);
+		}
+		// If we still get any square brackets it means the user was talking in guild chat with a guild rank
+		// So we get the username up to the space before the guild rank
+		if (username.contains("[") || username.contains("]")) {
+			username = username.substring(0, unformattedText.indexOf(" "));
+		}
+		return username;
 	}
 }


### PR DESCRIPTION
Fixed some entity scales for mob loot in the entity viewer for the Ender Dragon, Ghast, and Wither. Dragon is also facing the correct way. (if anyone feels the scales should be bigger or smaller, you can change them if you wish)

Added replace chat social options for party and guild chat. Works for both /pv and /ah

![image](https://user-images.githubusercontent.com/52578495/195446837-c6c890a7-9a3a-4cfa-a544-7e2d16744af6.png)
![image](https://user-images.githubusercontent.com/52578495/195446907-0398ca15-e972-4022-af7b-df9c1c6764f8.png)
![image](https://user-images.githubusercontent.com/52578495/195446956-566236b5-018b-4992-a592-7b5d9f5bf251.png)

![image](https://user-images.githubusercontent.com/52578495/195447088-a256fafc-1025-4214-a5e3-856e6f245f91.png)
![image](https://user-images.githubusercontent.com/52578495/195447201-bd7dd7d0-56c8-437e-89ee-ba500393f726.png)


