### PR TITLE
If above 100% of price will show actual added percentage

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/AuctionBINWarning.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/AuctionBINWarning.java
@@ -234,7 +234,7 @@ public class AuctionBINWarning extends GuiElement {
 		);
 		TextRenderUtils.drawStringCenteredScaledMaxWidth(
 			"\u00a76" + sellingPriceStr + "\u00a7r coins?" +
-				(lowestPrice > 0 ? "(\u00a7" + (isALoss ? "c-" : "a+") + buyPercentage + "%\u00a7r)" : ""),
+				(lowestPrice > 0 ? "(\u00a7" + (isALoss ? "c-" : "a+") + (buyPercentage > 100 ? buyPercentage - 100 : buyPercentage) + "%\u00a7r)" : ""),
 			Minecraft.getMinecraft().fontRendererObj,
 			width / 2,
 			height / 2 - 45 + 59,

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/AuctionBINWarning.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/AuctionBINWarning.java
@@ -234,7 +234,7 @@ public class AuctionBINWarning extends GuiElement {
 		);
 		TextRenderUtils.drawStringCenteredScaledMaxWidth(
 			"\u00a76" + sellingPriceStr + "\u00a7r coins?" +
-				(lowestPrice > 0 ? "(\u00a7" + (isALoss ? "c-" : "a+") + (buyPercentage > 100 ? buyPercentage - 100 : buyPercentage) + "%\u00a7r)" : ""),
+				(lowestPrice > 0 ? "(\u00a7" + (isALoss ? "c-" : "a+") + (buyPercentage >= 100 ? buyPercentage - 100 : buyPercentage) + "%\u00a7r)" : ""),
 			Minecraft.getMinecraft().fontRendererObj,
 			width / 2,
 			height / 2 - 45 + 59,

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/AHTweaks.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/AHTweaks.java
@@ -112,7 +112,7 @@ public class AHTweaks {
 	@Expose
 	@ConfigOption(
 		name = "Overcut Warning Threshold",
-		desc = "Threshold for BIN warning\nExample: 50% means warn if sell price is 50% higher than lowest bin"
+		desc = "Threshold for BIN warning\nExample: 50% means warn if sell price is 50% higher than lowest bin\n\u00A7c\u00a7lWARNING: \u00A7r\u00A7c100% will if above lbin always trigger, 0% instead will never trigger"
 	)
 	@ConfigEditorSlider(
 		minValue = 0.0f,


### PR DESCRIPTION
Instead of showing for example +110% which could be confusing, will show +10% as it's the actual added price.

<details>
<summary>Example image</summary>

![Magma rod overbin 10%](https://user-images.githubusercontent.com/78341107/195916873-690a1ded-1241-41f3-bdad-c237eda5c549.png)

</details>