### PR TITLE
Fix ItemEditor keeping unnecessary ExtraAttributes tags

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/itemeditor/NEUItemEditor.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/itemeditor/NEUItemEditor.java
@@ -93,6 +93,7 @@ public class NEUItemEditor extends GuiScreen {
 		NBTTagCompound extraAttributes = nbtTag.getCompoundTag("ExtraAttributes");
 		extraAttributes.removeTag("uuid");
 		extraAttributes.removeTag("timestamp");
+		extraAttributes.removeTag("attributes");
 
 		if (extraAttributes.hasKey("petInfo")) {
 			String petInfo = extraAttributes.getString("petInfo");

--- a/src/main/java/io/github/moulberry/notenoughupdates/itemeditor/NEUItemEditor.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/itemeditor/NEUItemEditor.java
@@ -95,6 +95,7 @@ public class NEUItemEditor extends GuiScreen {
 		extraAttributes.removeTag("timestamp");
 		extraAttributes.removeTag("attributes");
 		extraAttributes.removeTag("originTag");
+		extraAttributes.removeTag("modifier");
 
 		if (extraAttributes.hasKey("petInfo")) {
 			String petInfo = extraAttributes.getString("petInfo");

--- a/src/main/java/io/github/moulberry/notenoughupdates/itemeditor/NEUItemEditor.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/itemeditor/NEUItemEditor.java
@@ -94,6 +94,7 @@ public class NEUItemEditor extends GuiScreen {
 		extraAttributes.removeTag("uuid");
 		extraAttributes.removeTag("timestamp");
 		extraAttributes.removeTag("attributes");
+		extraAttributes.removeTag("originTag");
 
 		if (extraAttributes.hasKey("petInfo")) {
 			String petInfo = extraAttributes.getString("petInfo");


### PR DESCRIPTION
Made it remove the tags "attributes", "originTag", and "modifier.