### PR TITLE
Update workflow actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Send discord notification
         id: sendmsg
         if: ${{ env.WEBHOOK_URL }}
@@ -39,14 +39,14 @@ jobs:
         env:
           STATUS: WORKING
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: temurin
           cache: gradle
       - name: Build with Gradle
         run: chmod +x ./gradlew && ./gradlew clean test remapJar --no-daemon
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: build/libs/*-dep.jar
       - name: Update discord notification

--- a/.github/workflows/infer.yml
+++ b/.github/workflows/infer.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout feature
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: temurin
@@ -27,7 +27,7 @@ jobs:
           infer capture -- ./gradlew clean test --no-daemon
           infer analyze
           cp infer-out/report.json ciwork/report-feature.json
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout base
         with:
           ref: ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
GitHub has deprecated NodeJS 12 actions within workflows which results in warnings like these:
https://github.com/NotEnoughUpdates/NotEnoughUpdates/actions/runs/3255746292
This PR updates all of them.