### PR TITLE
refactor: change ProfileViewer 'Your Skills' tab to 'Skills'

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/GuiProfileViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/GuiProfileViewer.java
@@ -1262,7 +1262,7 @@ public class GuiProfileViewer extends GuiScreen {
 		LOADING(),
 		INVALID_NAME(),
 		NO_SKYBLOCK(),
-		BASIC(0, Items.paper, "§9Your Skills"),
+		BASIC(0, Items.paper, "§9Skills"),
 		DUNGEON(1, Item.getItemFromBlock(Blocks.deadbush), "§eDungeoneering"),
 		EXTRA(2, Items.book, "§7Profile Stats"),
 		INVENTORIES(3, Item.getItemFromBlock(Blocks.ender_chest), "§bStorage"),


### PR DESCRIPTION
Just a minor error I noticed while using the mod, given you're not always viewing your own profile.