### PR TITLE
Migrate away from set-output

### DIFF
--- a/.github/workflows/send_webhook_update.sh
+++ b/.github/workflows/send_webhook_update.sh
@@ -104,4 +104,4 @@ fi
 echo "Message sent to discord."
 echo "$discord_output" | jq .
 id_string=$(echo "$discord_output" | jq .id)
-echo "::set-output name=MESSAGE_ID::${id_string//\"/}"
+echo "MESSAGE_ID=${id_string//\"/}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Yet again, GitHub is deprecating something in their workflows.
See [this action](https://github.com/NotEnoughUpdates/NotEnoughUpdates/actions/runs/3306905669) as an example.
This PR migrates to [the new way](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) for setting step outputs.