### PR TITLE
Prevents wrong coopadd commands

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
@@ -318,7 +318,7 @@ public class NotEnoughUpdates {
 		MinecraftForge.EVENT_BUS.register(new SignCalculator());
 		MinecraftForge.EVENT_BUS.register(TrophyRewardOverlay.getInstance());
 		MinecraftForge.EVENT_BUS.register(PowerStoneStatsDisplay.getInstance());
-		MinecraftForge.EVENT_BUS.register(new AntiCoopAdd());
+		MinecraftForge.EVENT_BUS.register(AntiCoopAdd.getInstance());
 		MinecraftForge.EVENT_BUS.register(AbiphoneWarning.getInstance());
 		MinecraftForge.EVENT_BUS.register(new BetterContainers());
 		MinecraftForge.EVENT_BUS.register(AuctionBINWarning.getInstance());

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/AntiCoopAdd.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/AntiCoopAdd.java
@@ -27,11 +27,18 @@ import net.minecraft.event.ClickEvent;
 import net.minecraft.event.HoverEvent;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraft.network.play.client.C01PacketChatMessage;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class AntiCoopAdd {
+
+	private static final AntiCoopAdd INSTANCE = new AntiCoopAdd();
+
+	public static AntiCoopAdd getInstance() {
+		return INSTANCE;
+	}
 
 	@SubscribeEvent
 	public void onMouseClick(SlotClickEvent event) {
@@ -58,5 +65,16 @@ public class AntiCoopAdd {
 			Minecraft.getMinecraft().thePlayer.addChatMessage(storageChatMessage);
 			event.setCanceled(true);
 		}
+	}
+
+	public Boolean onPacketChatMessage(C01PacketChatMessage packet) {
+		if (!NotEnoughUpdates.INSTANCE.config.misc.coopWarning) return false;
+
+		String message = packet.getMessage().toLowerCase();
+		if (message.startsWith("/hypixelcommand:coopadd")) {
+			Utils.addChatMessage("§e[NEU] You just entered a malicious looking Co-op add command! If you truly want to add someone to your coop, type §e/coopadd <name>");
+			return true;
+		}
+		return false;
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinNetHandlerPlayClient.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinNetHandlerPlayClient.java
@@ -19,6 +19,7 @@
 
 package io.github.moulberry.notenoughupdates.mixins;
 
+import io.github.moulberry.notenoughupdates.miscfeatures.AntiCoopAdd;
 import io.github.moulberry.notenoughupdates.miscfeatures.CrystalWishingCompassSolver;
 import io.github.moulberry.notenoughupdates.miscfeatures.CustomItemEffects;
 import io.github.moulberry.notenoughupdates.miscfeatures.EnchantingSolvers;
@@ -133,6 +134,9 @@ public class MixinNetHandlerPlayClient {
 		}
 		if (packet instanceof C01PacketChatMessage) {
 			NewApiKeyHelper.getInstance().hookPacketChatMessage((C01PacketChatMessage) packet);
+			if (AntiCoopAdd.getInstance().onPacketChatMessage((C01PacketChatMessage) packet)) {
+				ci.cancel();
+			}
 		}
 	}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Misc.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Misc.java
@@ -262,7 +262,7 @@ public class Misc {
 	@Expose
 	@ConfigOption(
 		name = "Enable Coop Warning",
-		desc = "Asks for confirmation when clicking the coop diamond in profile menu"
+		desc = "Asks for confirmation when clicking the coop diamond in profile menu and prevents 'wrong' /coopadd commands"
 	)
 	@ConfigEditorBoolean
 	public boolean coopWarning = true;


### PR DESCRIPTION
Prevents the player from typing /hypixelcommand:coopadd name

![grafik](https://user-images.githubusercontent.com/24389977/198971091-95a76160-02d6-41c6-9a8c-6fa365847bf0.png)
