### PR TITLE
Removed prerelease option, set prerelease branch as default

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUManager.java
@@ -1585,7 +1585,7 @@ public class NEUManager {
 					"§cRepository not fully reloaded.",
 					"§cThere was an error reloading your repository.",
 					"§cThis might be caused by an outdated version of neu",
-					"§c(or by not using the dangerous repository if you are using a prerelease of neu).",
+					"§c(or by not using the prerelease repository if you are using a prerelease of neu).",
 					"§aYour repository will still work, but is in a suboptimal state.",
 					"§eJoin §bdiscord.gg/moulberry §efor help."
 				);

--- a/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
@@ -273,7 +273,7 @@ public class NotEnoughUpdates {
 
 			// Remove after 2.1 ig
 			if ("dangerous".equals(config.apiData.repoBranch)) {
-				config.apiData.repoBranch = "master";
+				config.apiData.repoBranch = "prerelease";
 			}
 
 			// Remove before 2.1.1 release

--- a/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
@@ -276,6 +276,11 @@ public class NotEnoughUpdates {
 				config.apiData.repoBranch = "master";
 			}
 
+			// Remove before 2.1.1 release
+			if ("master".equals(config.apiData.repoBranch)) {
+				config.apiData.repoBranch = "prerelease";
+			}
+
 			saveConfig();
 		}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
@@ -161,13 +161,6 @@ public class NEUConfig extends Config {
 				NotEnoughUpdates.INSTANCE.openGui =
 					new GuiScreenElementWrapper(new NEUConfigEditor(NotEnoughUpdates.INSTANCE.config, "apis"));
 				return;
-			case 24:
-				NotEnoughUpdates.INSTANCE.config.apiData.repoUser = "NotEnoughUpdates";
-				NotEnoughUpdates.INSTANCE.config.apiData.repoName = "NotEnoughUpdates-REPO";
-				NotEnoughUpdates.INSTANCE.config.apiData.repoBranch = "dangerous";
-				NotEnoughUpdates.INSTANCE.openGui =
-					new GuiScreenElementWrapper(new NEUConfigEditor(NotEnoughUpdates.INSTANCE.config, "apis"));
-				return;
 			case 26:
 				OverlayManager.powderGrindingOverlay.reset();
 				return;

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/ApiData.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/ApiData.java
@@ -74,14 +74,6 @@ public class ApiData {
 	@ConfigEditorButton(runnableId = 23, buttonText = "Reset")
 	public int setRepositoryToDefaultButton = 0;
 
-	@ConfigAccordionId(id = 1)
-	@ConfigOption(
-		name = "Use pre-release repository",
-		desc = "The latest, most up to date item list for the NEU pre-releases.\n§4Use §lonly§r§4 with the pre-releases."
-	)
-	@ConfigEditorButton(runnableId = 24, buttonText = "Use")
-	public int setRepositoryToDangerousButton = 0;
-
 	@Expose
 	@ConfigAccordionId(id = 1)
 	@ConfigOption(


### PR DESCRIPTION
I think doing it this way is better than having the user to choose which one they should use, especially because of some features, like the essencegui doesn't work correctly without using the needed branch.