### PR TITLE
Fixes social controls in party and guild chats

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
@@ -2009,12 +2009,12 @@ public class Utils {
 		// If the first character is a square bracket the user has a rank
 		// So we get the username from the space after the closing square bracket (end of their rank)
 		if (username.charAt(0) == '[') {
-			username = username.substring(unformattedText.indexOf(" ") + 2);
+			username = username.substring(username.indexOf(" ") + 1);
 		}
 		// If we still get any square brackets it means the user was talking in guild chat with a guild rank
 		// So we get the username up to the space before the guild rank
 		if (username.contains("[") || username.contains("]")) {
-			username = username.substring(0, unformattedText.indexOf(" "));
+			username = username.substring(0, username.indexOf(" "));
 		}
 		return username;
 	}


### PR DESCRIPTION
See the line changes to see the stupid mistake, didn't catch it at first since it happened to work with my name and rank even though the code was wrong, probably just due to the number of letters in my name and indexes just happening to line up how it needed to. Anyways this should fix it, does need some testing with guild chat since my guild is dead af and no one is typing in it and I cba to change guild rn