### PR TITLE
Show slayer overlay in "None" location

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
@@ -66,11 +66,15 @@ public class SlayerOverlay extends TextOverlay {
 	}
 
 	private boolean shouldUpdate() {
-		if (!NotEnoughUpdates.INSTANCE.config.slayerOverlay.onlyShowWhenRelevant || SBInfo.getInstance().stranded)
+		if (!NotEnoughUpdates.INSTANCE.config.slayerOverlay.onlyShowWhenRelevant || SBInfo.getInstance().stranded) {
 			return true;
-		//Ignore if on stranded
+		}
+
 		String scoreboardLocation = SBInfo.getInstance().location;
 		String locrawLocation = SBInfo.getInstance().getLocation();
+		if ("None".equals(scoreboardLocation)) {
+			scoreboardLocation = SBInfo.getInstance().getLastScoreboardLocation();
+		}
 		//In case something is broken still show the overlay
 		if (locrawLocation == null || scoreboardLocation == null) return true;
 		switch (SBInfo.getInstance().slayer) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
@@ -78,6 +78,7 @@ public class SBInfo {
 	public IChatComponent header;
 
 	public String location = "";
+	public String lastLocation = "";
 	public String date = "";
 	public String time = "";
 	public String objective = "";
@@ -279,11 +280,26 @@ public class SBInfo {
 	}
 
 	public void setLocation(String location) {
-		location = location == null ? location :location.intern();
-		if (!Objects.equals(this.mode, location)) {
-			MinecraftForge.EVENT_BUS.post(new LocationChangeEvent(location, this.mode));
+		location = location == null ? location : location.intern();
+		if (!Objects.equals(mode, location)) {
+			MinecraftForge.EVENT_BUS.post(new LocationChangeEvent(location, mode));
 		}
-		this.mode = location;
+		mode = location;
+	}
+
+	/**
+	 * @return the current location as displayed on the scoreboard
+	 */
+	public String getScoreboardLocation() {
+		return location;
+	}
+
+	/**
+	 * @return the previous location as displayed on the scoreboard
+	 * @see #getScoreboardLocation()
+	 */
+	public String getLastScoreboardLocation() {
+		return lastLocation;
 	}
 
 	private static final String profilePrefix = "\u00a7r\u00a7e\u00a7lProfile: \u00a7r\u00a7a";
@@ -426,8 +442,9 @@ public class SBInfo {
 						String l = Utils.cleanColour(line).replaceAll("[^A-Za-z0-9() ]", "").trim();
 						if (!l.equals(location)) {
 							new ScoreboardLocationChangeListener(location, l);
+							lastLocation = location;
+							location = l;
 						}
-						location = l;
 						break;
 					}
 				}


### PR DESCRIPTION
Will still show the overlay when the previos location was a relevant location. 
This prevents the overlay not showing when the player is in a location Hypixel considers as "None" that is actually part of the last (relevant) location.