### PR TITLE
Aatrox buff calculation in Slayer Overlay

### DIFF
--- a/Update Notes/2.1.1.md
+++ b/Update Notes/2.1.1.md
@@ -50,4 +50,4 @@
  - Added searchbar to Kills/Deaths section in pv - Cobble8
  - Added Ender Node Highlighter, Endermite Nest Alert - GodOfPro
  - Added CTRL + F support to searchbar and config menu - Lulonaut
- - Fixed Slayer Overlay to now takes Aatrox +25% Slayer XP buff into account -Taoshi
+ - Fixed Slayer Overlay to now take Aatrox's +25% Slayer XP buff into account - Taoshi

--- a/Update Notes/2.1.1.md
+++ b/Update Notes/2.1.1.md
@@ -50,4 +50,4 @@
  - Added searchbar to Kills/Deaths section in pv - Cobble8
  - Added Ender Node Highlighter, Endermite Nest Alert - GodOfPro
  - Added CTRL + F support to searchbar and config menu - Lulonaut
- - Fixed Slayer Overlay now takes Aatrox +25% Slayer XP buff into account
+ - Fixed Slayer Overlay to now takes Aatrox +25% Slayer XP buff into account -Taoshi

--- a/Update Notes/2.1.1.md
+++ b/Update Notes/2.1.1.md
@@ -50,3 +50,4 @@
  - Added searchbar to Kills/Deaths section in pv - Cobble8
  - Added Ender Node Highlighter, Endermite Nest Alert - GodOfPro
  - Added CTRL + F support to searchbar and config menu - Lulonaut
+ - Fixed Slayer Overlay now takes Aatrox +25% Slayer XP buff into account

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
@@ -47,6 +47,7 @@ public class SlayerOverlay extends TextOverlay {
 
 	private static String slayerEXP = "0";
 	private static int slayerIntXP;
+	private static int differenceFromLastXP = 0;
 	private static int untilNextSlayerLevel;
 	private static int xpToLevelUp;
 	private static boolean useSmallXpNext = true;
@@ -118,9 +119,10 @@ public class SlayerOverlay extends TextOverlay {
 			isSlayerNine = true;
 		} else if (!slayerXp.equals("0")) {
 			slayerEXP = slayerXp.replace(",", "");
-			int difference = slayerIntXP-Integer.parseInt(slayerEXP);
-			if(difference != 0){
-				switch(difference){
+
+			differenceFromLastXP = slayerIntXP-Integer.parseInt(slayerEXP);
+			if(differenceFromLastXP != 0){
+				switch(differenceFromLastXP){
 					case 1875:
 					case 625:
 					case 125:
@@ -132,6 +134,7 @@ public class SlayerOverlay extends TextOverlay {
 						slayerXPBuffActive = false;
 				}
 			}
+
 			slayerIntXP = Integer.parseInt(slayerEXP);
 			isSlayerNine = false;
 		} else {
@@ -208,9 +211,11 @@ public class SlayerOverlay extends TextOverlay {
 		} else {
 			xpPerBoss = 0;
 		}
+
 		if(slayerXPBuffActive){
 			xpPerBoss *= 1.25;
 		}
+		
 		untilNextSlayerLevel = xpToLevelUp - slayerIntXP;
 		if (xpPerBoss != 0 && untilNextSlayerLevel != 0 && xpToLevelUp != 0) {
 			bossesUntilNextLevel = (xpToLevelUp - untilNextSlayerLevel) / xpPerBoss;

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
@@ -218,7 +218,7 @@ public class SlayerOverlay extends TextOverlay {
 
 		untilNextSlayerLevel = xpToLevelUp - slayerIntXP;
 		if (xpPerBoss != 0 && untilNextSlayerLevel != 0 && xpToLevelUp != 0) {
-			bossesUntilNextLevel = (xpToLevelUp - untilNextSlayerLevel) / xpPerBoss;
+			bossesUntilNextLevel = (int) Math.ceil((xpToLevelUp - untilNextSlayerLevel) / xpPerBoss);
 		} else {
 			bossesUntilNextLevel = 0;
 		}

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
@@ -120,9 +120,9 @@ public class SlayerOverlay extends TextOverlay {
 		} else if (!slayerXp.equals("0")) {
 			slayerEXP = slayerXp.replace(",", "");
 
-			differenceFromLastXP = slayerIntXP-Integer.parseInt(slayerEXP);
-			if(differenceFromLastXP != 0){
-				switch(differenceFromLastXP){
+			differenceFromLastXP = slayerIntXP - Integer.parseInt(slayerEXP);
+			if (differenceFromLastXP != 0) {
+				switch (differenceFromLastXP) {
 					case 1875:
 					case 625:
 					case 125:
@@ -212,10 +212,10 @@ public class SlayerOverlay extends TextOverlay {
 			xpPerBoss = 0;
 		}
 
-		if(slayerXPBuffActive){
+		if (slayerXPBuffActive) {
 			xpPerBoss *= 1.25;
 		}
-		
+
 		untilNextSlayerLevel = xpToLevelUp - slayerIntXP;
 		if (xpPerBoss != 0 && untilNextSlayerLevel != 0 && xpToLevelUp != 0) {
 			bossesUntilNextLevel = (xpToLevelUp - untilNextSlayerLevel) / xpPerBoss;

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
@@ -52,6 +52,7 @@ public class SlayerOverlay extends TextOverlay {
 	private static boolean useSmallXpNext = true;
 	private static long agvSlayerTime = 0;
 	private static boolean isSlayerNine = false;
+	private static boolean slayerXPBuffActive = false;
 	private static int xpPerBoss = 0;
 	private static int bossesUntilNextLevel = 0;
 	private final HashSet<String> revenantLocations = new HashSet<>(Arrays.asList("Graveyard", "Coal Mine"));
@@ -117,6 +118,20 @@ public class SlayerOverlay extends TextOverlay {
 			isSlayerNine = true;
 		} else if (!slayerXp.equals("0")) {
 			slayerEXP = slayerXp.replace(",", "");
+			int difference = slayerIntXP-Integer.parseInt(slayerEXP);
+			if(difference != 0){
+				switch(difference){
+					case 1875:
+					case 625:
+					case 125:
+					case 31:
+					case 6:
+						slayerXPBuffActive = true;
+						break;
+					default:
+						slayerXPBuffActive = false;
+				}
+			}
 			slayerIntXP = Integer.parseInt(slayerEXP);
 			isSlayerNine = false;
 		} else {
@@ -192,6 +207,9 @@ public class SlayerOverlay extends TextOverlay {
 			xpPerBoss = 5;
 		} else {
 			xpPerBoss = 0;
+		}
+		if(slayerXPBuffActive){
+			xpPerBoss *= 1.25;
 		}
 		untilNextSlayerLevel = xpToLevelUp - slayerIntXP;
 		if (xpPerBoss != 0 && untilNextSlayerLevel != 0 && xpToLevelUp != 0) {


### PR DESCRIPTION
If Aatrox has his +25% xp buff active, update bosses to next level calculation to use the increased gains