### PR TITLE
Update SlayerOverlay.java

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
@@ -222,7 +222,7 @@ public class SlayerOverlay extends TextOverlay {
 
 		untilNextSlayerLevel = xpToLevelUp - slayerIntXP;
 		if (xpPerBoss != 0 && untilNextSlayerLevel != 0 && xpToLevelUp != 0) {
-			bossesUntilNextLevel = (int) Math.ceil((xpToLevelUp - untilNextSlayerLevel) / xpPerBoss);
+			bossesUntilNextLevel = (int) Math.ceil((float) (xpToLevelUp - untilNextSlayerLevel) / (float)(xpPerBoss));
 		} else {
 			bossesUntilNextLevel = 0;
 		}


### PR DESCRIPTION
Fixed bossesUntilNextLevel so that it no longer uses integer division. This makes it so Math.ceil works and the overlay says 1 instead of 0 when there are 0.5 bosses remaining.