### PR TITLE
Disable wither cloak overlay when creepers are gone

### DIFF
--- a/Update Notes/2.1.1.md
+++ b/Update Notes/2.1.1.md
@@ -58,6 +58,5 @@
 - Fixed todo overlay with cookie - nopo
 - Fixed todo overlay with god pot - heyngra
 - Fixed Slayer Overlay to now take Aatrox's +25% Slayer XP buff into account - Taoshi
-- Fixed wither essence not showing in /pv - Lulonaut
 - Fixed inventory backpack keybind not working without unrelated option - Lulonaut
 - Fixed wither cloak overlay staying on when picking up the item in the inventory - Lulonaut

--- a/Update Notes/2.1.1.md
+++ b/Update Notes/2.1.1.md
@@ -58,3 +58,6 @@
 - Fixed todo overlay with cookie - nopo
 - Fixed todo overlay with god pot - heyngra
 - Fixed Slayer Overlay to now take Aatrox's +25% Slayer XP buff into account - Taoshi
+- Fixed wither essence not showing in /pv - Lulonaut
+- Fixed inventory backpack keybind not working without unrelated option - Lulonaut
+- Fixed wither cloak overlay staying on when picking up the item in the inventory - Lulonaut

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/WitherCloakChanger.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/WitherCloakChanger.java
@@ -33,7 +33,6 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL14;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 public class WitherCloakChanger {
 	public static boolean isCloakActive = false;
@@ -41,7 +40,7 @@ public class WitherCloakChanger {
 	 * When was the last charged Creeper that is a member of the group rendered?
 	 * Used to determine if the cloak was deactivated by Hypixel without sending a message
 	 *
-	 * @see io.github.moulberry.notenoughupdates.mixins.MixinEntityChargedCreeper#cancelChargedCreeperLayer(EntityCreeper, float, float, float, float, float, float, float, CallbackInfo)
+	 * @see io.github.moulberry.notenoughupdates.mixins.MixinEntityChargedCreeper#cancelChargedCreeperLayer(EntityCreeper, float, float, float, float, float, float, float, org.spongepowered.asm.mixin.injection.callback.CallbackInfo)
 	 */
 	public static long lastCreeperRender = 0;
 	public static long lastDeactivate = System.currentTimeMillis();

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/WitherCloakChanger.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/WitherCloakChanger.java
@@ -23,7 +23,6 @@ import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.core.util.render.RenderUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.entity.monster.EntityCreeper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Vec3;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
@@ -40,7 +39,7 @@ public class WitherCloakChanger {
 	 * When was the last charged Creeper that is a member of the group rendered?
 	 * Used to determine if the cloak was deactivated by Hypixel without sending a message
 	 *
-	 * @see io.github.moulberry.notenoughupdates.mixins.MixinEntityChargedCreeper#cancelChargedCreeperLayer(EntityCreeper, float, float, float, float, float, float, float, org.spongepowered.asm.mixin.injection.callback.CallbackInfo)
+	 * @see io.github.moulberry.notenoughupdates.mixins.MixinEntityChargedCreeper#cancelChargedCreeperLayer(net.minecraft.entity.monster.EntityCreeper , float, float, float, float, float, float, float, org.spongepowered.asm.mixin.injection.callback.CallbackInfo)
 	 */
 	public static long lastCreeperRender = 0;
 	public static long lastDeactivate = System.currentTimeMillis();

--- a/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinEntityChargedCreeper.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinEntityChargedCreeper.java
@@ -31,7 +31,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LayerCreeperCharge.class)
 public abstract class MixinEntityChargedCreeper {
-
 	@Inject(method = "doRenderLayer(Lnet/minecraft/entity/monster/EntityCreeper;FFFFFFF)V", at = @At("HEAD"), cancellable = true)
 	public void cancelChargedCreeperLayer(EntityCreeper creeper, float f, float g, float partialTicks, float h, float i, float j, float scale, CallbackInfo ci) {
 		//Wither Cloak Creepers: Is toggled on, Are invisible, 20 max health, usually less than 7.5M from the player, only existent when active, and only in sb obviously
@@ -41,6 +40,7 @@ public abstract class MixinEntityChargedCreeper {
 				(WitherCloakChanger.isCloakActive || System.currentTimeMillis() - WitherCloakChanger.lastDeactivate < 300) &&
 				NotEnoughUpdates.INSTANCE.isOnSkyblock();
 		if (isWitherCloak) {
+			WitherCloakChanger.lastCreeperRender = System.currentTimeMillis();
 			if (ci.isCancellable()) {
 				ci.cancel();
 			}

--- a/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinEntityChargedCreeper.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinEntityChargedCreeper.java
@@ -31,6 +31,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LayerCreeperCharge.class)
 public abstract class MixinEntityChargedCreeper {
+
 	@Inject(method = "doRenderLayer(Lnet/minecraft/entity/monster/EntityCreeper;FFFFFFF)V", at = @At("HEAD"), cancellable = true)
 	public void cancelChargedCreeperLayer(EntityCreeper creeper, float f, float g, float partialTicks, float h, float i, float j, float scale, CallbackInfo ci) {
 		//Wither Cloak Creepers: Is toggled on, Are invisible, 20 max health, usually less than 7.5M from the player, only existent when active, and only in sb obviously


### PR DESCRIPTION
closes #458

Thanks to Hypixel for disabling the wither cloak when clicking on the item in your inventory (but not when shift clicking) without sending the message.

Considers the wither cloak disabled if no valid charged creepers where rendered for 2+ seconds

MAY cause problems with really high ping (false positives)? I had no issues