### PR TITLE
Fix mining overlay not update while chat is opened (and more)

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
@@ -31,6 +31,7 @@ import io.github.moulberry.notenoughupdates.util.StarCultCalculator;
 import io.github.moulberry.notenoughupdates.util.TabListUtils;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiChat;
 import net.minecraft.client.gui.inventory.GuiChest;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.init.Items;
@@ -73,6 +74,21 @@ public class MiningOverlay extends TextTabOverlay {
 
 	private static final Pattern NUMBER_PATTERN = Pattern.compile("(?<number>\\d*,?\\d+)(?: |$)");
 	public static Map<String, Float> commissionProgress = new LinkedHashMap<>();
+
+	@Override
+	protected boolean shouldUpdate() {
+		//prevent rendering when tab completing a command
+		if (Minecraft.getMinecraft().currentScreen instanceof GuiChat && (NotEnoughUpdates.INSTANCE.config.mining.forgeDisplayOnlyShowTab||NotEnoughUpdates.INSTANCE.config.mining.starCultDisplayOnlyShowTab)) {
+			return false;
+		}
+
+		//prevent rendering when tab completing in ah search overlay
+		if (AuctionSearchOverlay.shouldReplace()) {
+			return false;
+		}
+
+		return true;
+	}
 
 	@Override
 	public void updateFrequent() {

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
@@ -76,21 +76,6 @@ public class MiningOverlay extends TextTabOverlay {
 	public static Map<String, Float> commissionProgress = new LinkedHashMap<>();
 
 	@Override
-	protected boolean shouldUpdate() {
-		//prevent rendering when tab completing a command
-		if (Minecraft.getMinecraft().currentScreen instanceof GuiChat && (NotEnoughUpdates.INSTANCE.config.mining.forgeDisplayOnlyShowTab||NotEnoughUpdates.INSTANCE.config.mining.starCultDisplayOnlyShowTab)) {
-			return false;
-		}
-
-		//prevent rendering when tab completing in ah search overlay
-		if (AuctionSearchOverlay.shouldReplace()) {
-			return false;
-		}
-
-		return true;
-	}
-
-	@Override
 	public void updateFrequent() {
 		if (Minecraft.getMinecraft().currentScreen instanceof GuiChest) {
 			GuiChest chest = (GuiChest) Minecraft.getMinecraft().currentScreen;
@@ -466,8 +451,8 @@ public class MiningOverlay extends TextTabOverlay {
 			if (starCultDisplay) {
 				if(overlayStrings == null) overlayStrings = new ArrayList<>();
 
-				if (!NotEnoughUpdates.INSTANCE.config.mining.forgeDisplayOnlyShowTab ||
-					Keyboard.isKeyDown(Minecraft.getMinecraft().gameSettings.keyBindPlayerList.getKeyCode())) {
+				if (!NotEnoughUpdates.INSTANCE.config.mining.starCultDisplayOnlyShowTab ||
+					lastTabState) {
 					if (NotEnoughUpdates.INSTANCE.config.mining.starCultDisplayEnabledLocations == 1 &&
 						!SBInfo.getInstance().isInDungeon) {
 						overlayStrings.add(
@@ -485,7 +470,7 @@ public class MiningOverlay extends TextTabOverlay {
 				if(overlayStrings == null) 	overlayStrings = new ArrayList<>();
 
 				if (!NotEnoughUpdates.INSTANCE.config.mining.forgeDisplayOnlyShowTab ||
-					Keyboard.isKeyDown(Minecraft.getMinecraft().gameSettings.keyBindPlayerList.getKeyCode())) {
+					lastTabState) {
 					if (NotEnoughUpdates.INSTANCE.config.mining.forgeDisplayEnabledLocations == 1 &&
 						!SBInfo.getInstance().isInDungeon) {
 						overlayStrings.addAll(getForgeStrings(profileConfig.forgeItems));

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/TextTabOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/TextTabOverlay.java
@@ -36,7 +36,7 @@ public abstract class TextTabOverlay extends TextOverlay {
 		super(position, dummyStrings, styleSupplier);
 	}
 
-	private boolean lastTabState = false;
+	protected boolean lastTabState = false;
 	private boolean shouldUpdateOverlay = true;
 
 	@Override
@@ -48,7 +48,7 @@ public abstract class TextTabOverlay extends TextOverlay {
 
 	public void realTick() {
 		shouldUpdateOverlay = shouldUpdate();
-		if (shouldUpdateOverlay) {
+		if (!(Minecraft.getMinecraft().currentScreen instanceof GuiChat)) {
 			int keycode = Minecraft.getMinecraft().gameSettings.keyBindPlayerList.getKeyCode();
 			boolean currentTabState;
 			if (keycode > 0) {
@@ -58,17 +58,14 @@ public abstract class TextTabOverlay extends TextOverlay {
 			}
 			if (lastTabState != currentTabState) {
 				lastTabState = currentTabState;
-				update();
 			}
+		} else lastTabState = false; // disallow showing overlays that use tab while having chat open
+		if (shouldUpdateOverlay) {
+				update();
 		}
 	}
 
-	protected boolean shouldUpdate() {
-		//prevent rendering when tab completing a command
-		if (Minecraft.getMinecraft().currentScreen instanceof GuiChat) {
-			return false;
-		}
-
+	private boolean shouldUpdate() {
 		//prevent rendering when tab completing in ah search overlay
 		if (AuctionSearchOverlay.shouldReplace()) {
 			return false;

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/TextTabOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/TextTabOverlay.java
@@ -63,7 +63,7 @@ public abstract class TextTabOverlay extends TextOverlay {
 		}
 	}
 
-	private boolean shouldUpdate() {
+	protected boolean shouldUpdate() {
 		//prevent rendering when tab completing a command
 		if (Minecraft.getMinecraft().currentScreen instanceof GuiChat) {
 			return false;

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
@@ -242,7 +242,7 @@ public class TimersOverlay extends TextTabOverlay {
 		if (hidden == null) return;
 
 		if (NotEnoughUpdates.INSTANCE.config.miscOverlays.todoOverlayOnlyShowTab &&
-			!Keyboard.isKeyDown(Minecraft.getMinecraft().gameSettings.keyBindPlayerList.getKeyCode())) {
+			!lastTabState) {
 			overlayStrings = null;
 			return;
 		}


### PR DESCRIPTION
- Fixes #479 
- Makes use of a lastTabState variable that was never used (even though its modified every tick)
- Makes Star Cult Tab Toggle actually work (previously it checked for forge toggle) 