### PR TITLE
Make MinionHelper show North Stars without a price

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/minionhelper/render/MinionHelperOverlayHover.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/minionhelper/render/MinionHelperOverlayHover.java
@@ -256,7 +256,7 @@ public class MinionHelperOverlayHover {
 			if (internalName.equals("SKYBLOCK_NORTH_STAR")) {
 				// North Stars are not in the API
 
-				lines.add(" §8- §5" + "§d" + amount + " North Stars");
+				lines.add(" §8- §a" + amount + "§7x §d" + "North Stars");
 				continue;
 			}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/minionhelper/render/MinionHelperOverlayHover.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/minionhelper/render/MinionHelperOverlayHover.java
@@ -253,6 +253,12 @@ public class MinionHelperOverlayHover {
 				lines.add(" §8- §5" + peltCount + "§8/§5" + amount + " Pelts");
 				continue;
 			}
+			if (internalName.equals("SKYBLOCK_NORTH_STAR")) {
+				// North Stars are not in the API
+
+				lines.add(" §8- §5" + "§d" + amount + " North Stars");
+				continue;
+			}
 
 			String name = NotEnoughUpdates.INSTANCE.manager.getDisplayName(internalName);
 			double price = manager.getPriceCalculation().getPrice(internalName);

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/minionhelper/render/MinionHelperOverlayHover.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/minionhelper/render/MinionHelperOverlayHover.java
@@ -256,7 +256,7 @@ public class MinionHelperOverlayHover {
 			if (internalName.equals("SKYBLOCK_NORTH_STAR")) {
 				// North Stars are not in the API
 
-				lines.add(" §8- §a" + amount + "§7x §d" + "North Stars");
+				lines.add(" §8- §a" + amount + "§7x §d" + "North Star");
 				continue;
 			}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/minionhelper/util/MinionHelperPriceCalculation.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/minionhelper/util/MinionHelperPriceCalculation.java
@@ -84,6 +84,10 @@ public class MinionHelperPriceCalculation {
 				int amount = items.get("SKYBLOCK_PELT").get(0);
 				result += " §7+ §5" + amount + " Pelts";
 			}
+			if (items.containsKey("SKYBLOCK_NORTH_STAR")) {
+				int amount = items.get("SKYBLOCK_NORTH_STAR").get(0);
+				result += " §7+ §d" + amount + " North Stars";
+			}
 		}
 
 		if (upgradeOnly) {


### PR DESCRIPTION
hopefully fixes #472

Not sure if it's how we want to keep it, but I made it look like this
![image](https://user-images.githubusercontent.com/25665974/206299975-19e05623-05f1-441f-a543-a93c90ac8195.png)

why was this bug in the first place? NEU thought that north star was an useless ah item (like wooden axe) and it gave it the default of 1 coin, I've overriden it as pelts do it