### PR TITLE
RepoEditing: Allow opening files in the external editor

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUManager.java
@@ -288,7 +288,7 @@ public class NEUManager {
 	public void loadItem(String internalName) {
 		itemstackCache.remove(internalName);
 		try {
-			JsonObject json = getJsonFromFile(new File(new File(repoLocation, "items"), internalName + ".json"));
+			JsonObject json = getJsonFromFile(getItemFileForInternalName(internalName));
 			if (json == null) {
 				return;
 			}
@@ -971,6 +971,10 @@ public class NEUManager {
 		return getUUIDFromNBT(tag);
 	}
 
+	public File getItemFileForInternalName(String internalName) {
+		return new File(new File(repoLocation, "items"), internalName + ".json");
+	}
+
 	public void writeItemToFile(ItemStack stack) {
 		String internalname = getInternalNameForItem(stack);
 
@@ -984,7 +988,7 @@ public class NEUManager {
 		json.addProperty("modver", NotEnoughUpdates.VERSION);
 
 		try {
-			writeJson(json, new File(new File(repoLocation, "items"), internalname + ".json"));
+			writeJson(json, getItemFileForInternalName(internalname));
 		} catch (IOException ignored) {
 		}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -46,6 +46,7 @@ import io.github.moulberry.notenoughupdates.util.LerpingFloat;
 import io.github.moulberry.notenoughupdates.util.NotificationHandler;
 import io.github.moulberry.notenoughupdates.util.SpecialColour;
 import io.github.moulberry.notenoughupdates.util.Utils;
+import lombok.var;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.Gui;
@@ -84,8 +85,10 @@ import org.lwjgl.opengl.GL14;
 import org.lwjgl.util.vector.Vector2f;
 
 import java.awt.*;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1156,8 +1159,30 @@ public class NEUOverlay extends Gui {
 									manager.jsonToStack(item));
 							}
 						} else if (NotEnoughUpdates.INSTANCE.config.apiData.repositoryEditing &&
-							Keyboard.getEventCharacter() == 'k') {
-							Minecraft.getMinecraft().displayGuiScreen(new NEUItemEditor(internalname.get(), item));
+							keyPressed == Keyboard.KEY_K) {
+							if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)) {
+								var externalEditorCommand = NotEnoughUpdates.INSTANCE.config.hidden.externalEditor;
+								if (externalEditorCommand == null) {
+									Utils.addChatMessage(
+										"§e[NEU] §3No external editor set! Run §b/neudevtest exteditor <editorcommand>§3 " +
+											"to set your external editor. Optionally use {} as a placeholder for the filename.");
+								} else {
+									var externalFileName = manager.getItemFileForInternalName(internalname.get()).getAbsolutePath();
+									if (externalEditorCommand.contains("{}")) {
+										externalEditorCommand = externalEditorCommand.replace("{}", externalFileName);
+									} else {
+										externalEditorCommand += " " + externalFileName;
+									}
+									try {
+										Runtime.getRuntime().exec(externalEditorCommand);
+									} catch (IOException e) {
+										Utils.addChatMessage("§e[NEU]§4 Could not open external editor.");
+										e.printStackTrace();
+									}
+								}
+							} else {
+								Minecraft.getMinecraft().displayGuiScreen(new NEUItemEditor(internalname.get(), item));
+							}
 							return true;
 						} else if (keyPressed == manager.keybindItemSelect.getKeyCode() &&
 							NotEnoughUpdates.INSTANCE.config.toolbar.searchBar) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/commands/dev/DevTestCommand.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/commands/dev/DevTestCommand.java
@@ -19,20 +19,17 @@
 
 package io.github.moulberry.notenoughupdates.commands.dev;
 
-import com.google.gson.Gson;
 import io.github.moulberry.notenoughupdates.BuildFlags;
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.commands.ClientCommandBase;
 import io.github.moulberry.notenoughupdates.core.config.GuiPositionEditor;
 import io.github.moulberry.notenoughupdates.core.util.MiscUtils;
 import io.github.moulberry.notenoughupdates.miscfeatures.FishingHelper;
-import io.github.moulberry.notenoughupdates.miscfeatures.PetInfoOverlay;
 import io.github.moulberry.notenoughupdates.miscfeatures.customblockzones.CustomBiomes;
 import io.github.moulberry.notenoughupdates.miscfeatures.customblockzones.LocationChangeEvent;
 import io.github.moulberry.notenoughupdates.miscfeatures.customblockzones.SpecialBlockZone;
 import io.github.moulberry.notenoughupdates.miscgui.GuiPriceGraph;
 import io.github.moulberry.notenoughupdates.miscgui.minionhelper.MinionHelperManager;
-import io.github.moulberry.notenoughupdates.profileviewer.GuiProfileViewer;
 import io.github.moulberry.notenoughupdates.util.PronounDB;
 import io.github.moulberry.notenoughupdates.util.SBInfo;
 import io.github.moulberry.notenoughupdates.util.TabListUtils;
@@ -140,6 +137,16 @@ public class DevTestCommand extends ClientCommandBase {
 					BuildFlags.getAllFlags().entrySet().stream()
 										.map(it -> " + " + it.getKey() + " - " + it.getValue())
 										.collect(Collectors.joining("\n"))));
+			return;
+		}
+		if (args.length >= 1 && args[0].equalsIgnoreCase("exteditor")) {
+			if (args.length > 1) {
+				NotEnoughUpdates.INSTANCE.config.hidden.externalEditor = String.join(
+					" ",
+					Arrays.copyOfRange(args, 1, args.length)
+				);
+			}
+			Utils.addChatMessage("§e[NEU] §fYour external editor is: §Z" + NotEnoughUpdates.INSTANCE.config.hidden.externalEditor);
 			return;
 		}
 		if (args.length >= 1 && args[0].equalsIgnoreCase("pricetest")) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
@@ -456,6 +456,9 @@ public class NEUConfig extends Config {
 		@Expose
 		public boolean hasOpenedWaypointMenu = false;
 
+		@Expose
+		public String externalEditor = null;
+
 	}
 
 	public static ArrayList<String> createDefaultEnchantColours() {

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
@@ -357,6 +357,7 @@ public class TimersOverlay extends TextTabOverlay {
 					String clean = line.replaceAll("(\u00a7.)", "");
 					String[] cleanSplit = clean.split(" ");
 					hidden.cookieBuffRemaining = 0;
+					if (line.contains("Not")) break;
 
 					for (int i = 0; i + 1 < cleanSplit.length; i++) {
 						if (i % 2 == 1) continue;


### PR DESCRIPTION
Press SHIFT+K to open in external editor and run /neudevtest exteditor <editorcommand> to configure

Also: TimersOverlay: Fix 0 cookie timer left spamming logs