### PR TITLE
Remove console spam by no cookie/pot

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
@@ -341,7 +341,6 @@ public class TimersOverlay extends TextTabOverlay {
 							}
 						}
 					} catch (Exception e) {
-						e.printStackTrace();
 						if (!hasErrorMessage) {
 							Utils.addChatMessage(EnumChatFormatting.YELLOW + "[NEU] Unable to work out your god pot timer");
 							hasErrorMessage = true;
@@ -395,7 +394,6 @@ public class TimersOverlay extends TextTabOverlay {
 									break;
 							}
 						} catch (NumberFormatException e) {
-							e.printStackTrace();
 							hidden.cookieBuffRemaining = 0;
 							if (!hasErrorMessage) {
 								Utils.addChatMessage(EnumChatFormatting.YELLOW + "[NEU] Unable to work out your cookie buff timer");


### PR DESCRIPTION
I guess logs on an alpha jar shouldn't look like this xD
![image](https://user-images.githubusercontent.com/25665974/208305258-6678a248-eeb1-4bba-a319-de69c2b05e2f.png)
