### PR TITLE
Craft cost price calculation fixed

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/auction/APIManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/auction/APIManager.java
@@ -27,6 +27,8 @@ import io.github.moulberry.notenoughupdates.NEUManager;
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.miscgui.GuiPriceGraph;
 import io.github.moulberry.notenoughupdates.recipes.Ingredient;
+import io.github.moulberry.notenoughupdates.recipes.ItemShopRecipe;
+import io.github.moulberry.notenoughupdates.recipes.KatRecipe;
 import io.github.moulberry.notenoughupdates.recipes.NeuRecipe;
 import io.github.moulberry.notenoughupdates.util.Constants;
 import io.github.moulberry.notenoughupdates.util.Utils;
@@ -902,6 +904,12 @@ public class APIManager {
 		if (recipes != null)
 			RECIPE_ITER:
 				for (NeuRecipe recipe : recipes) {
+					if (recipe instanceof KatRecipe) continue;
+					if (recipe instanceof ItemShopRecipe) {
+						if (vanillaItem) {
+							continue;
+						}
+					}
 					if (recipe.hasVariableCost() || !recipe.shouldUseForCraftCost()) continue;
 					float craftPrice = 0;
 					for (Ingredient i : recipe.getIngredients()) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/auction/APIManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/auction/APIManager.java
@@ -28,7 +28,6 @@ import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.miscgui.GuiPriceGraph;
 import io.github.moulberry.notenoughupdates.recipes.Ingredient;
 import io.github.moulberry.notenoughupdates.recipes.ItemShopRecipe;
-import io.github.moulberry.notenoughupdates.recipes.KatRecipe;
 import io.github.moulberry.notenoughupdates.recipes.NeuRecipe;
 import io.github.moulberry.notenoughupdates.util.Constants;
 import io.github.moulberry.notenoughupdates.util.Utils;
@@ -904,7 +903,6 @@ public class APIManager {
 		if (recipes != null)
 			RECIPE_ITER:
 				for (NeuRecipe recipe : recipes) {
-					if (recipe instanceof KatRecipe) continue;
 					if (recipe instanceof ItemShopRecipe) {
 						if (vanillaItem) {
 							continue;

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/recipes/KatRecipe.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/recipes/KatRecipe.kt
@@ -161,4 +161,6 @@ data class KatRecipe(
     override fun getBackground(): ResourceLocation {
         return ResourceLocation("notenoughupdates:textures/gui/katting_tall.png")
     }
+
+    override fun shouldUseForCraftCost() = false
 }


### PR DESCRIPTION
This PR fixes the craft cost price calculation for certain items by removing the NPC prices of vanilla items and KAT recipes from the equation.