### PR TITLE
No More Guessing - Find Out Exactly How Much Time is Left in Star Cult Events

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/util/StarCultCalculator.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/StarCultCalculator.java
@@ -101,7 +101,7 @@ public class StarCultCalculator {
 		}
 
 		if (active && activeTill != 0) {
-			return "Active!";
+			return "Active! (" + Utils.prettyTime(activeTill - System.currentTimeMillis()) + ")";
 		}
 
 		return Utils.prettyTime(cultStart.toEpochMilli() - l);


### PR DESCRIPTION
The Star Cult timer now includes the time remaining until the event ends while the event is active. 