### PR TITLE
Issue with "god pot" in Todo list resolved

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
@@ -37,7 +37,6 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import org.lwjgl.input.Keyboard;
 import org.lwjgl.util.vector.Vector2f;
 
 import java.time.ZoneId;
@@ -302,10 +301,14 @@ public class TimersOverlay extends TextTabOverlay {
 
 		boolean foundCookieBuffText = false;
 		boolean foundGodPotText = false;
+		boolean foundEffectsText = false;
 		if (SBInfo.getInstance().getLocation() != null && !SBInfo.getInstance().getLocation().equals("dungeon") &&
 			SBInfo.getInstance().footer != null) {
 			String formatted = SBInfo.getInstance().footer.getFormattedText();
 			for (String line : formatted.split("\n")) {
+				if (line.contains("Active Effects")) {
+					foundEffectsText = true;
+				}
 				Matcher activeEffectsMatcher = PATTERN_ACTIVE_EFFECTS.matcher(line);
 				if (activeEffectsMatcher.matches()) {
 					foundGodPotText = true;
@@ -411,7 +414,7 @@ public class TimersOverlay extends TextTabOverlay {
 			}
 		}
 
-		if (!foundGodPotText) {
+		if (!foundGodPotText && foundEffectsText) {
 			hidden.godPotionDuration = 0;
 		}
 


### PR DESCRIPTION
I have successfully resolved an issue that caused the Todo list to display the "god pod" as missing when the tab list was not fully loaded. This issue occurred during server switches and resulted in the Todo list flickering.