### PR TITLE
Meet Your New Dungeon Group Members in Seconds!

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/ChatListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/ChatListener.java
@@ -55,12 +55,15 @@ import static io.github.moulberry.notenoughupdates.overlays.SlayerOverlay.timeSi
 import static io.github.moulberry.notenoughupdates.overlays.SlayerOverlay.timeSinceLastBoss2;
 
 public class ChatListener {
-	private final NotEnoughUpdates neu;
-	private static final Pattern SLAYER_XP = Pattern.compile(
-		"   (Spider|Zombie|Wolf|Enderman|Blaze) Slayer LVL (\\d) - (?:Next LVL in ([\\d,]+) XP!|LVL MAXED OUT!)");
 
-	private static final Pattern SKYBLOCK_LVL_MESSAGE = Pattern.compile("\\[(\\d{1,4})\\] .*");
-	AtomicBoolean missingRecipe = new AtomicBoolean(false);
+	private final NotEnoughUpdates neu;
+
+	private static final Pattern slayerExpPattern = Pattern.compile(
+		"   (Spider|Zombie|Wolf|Enderman|Blaze) Slayer LVL (\\d) - (?:Next LVL in ([\\d,]+) XP!|LVL MAXED OUT!)");
+	private static final Pattern skyBlockLevelPattern = Pattern.compile("\\[(\\d{1,4})\\] .*");
+	private final Pattern partyFinderPattern = Pattern.compile("§dParty Finder §r§f> (.*)§ejoined the dungeon group!");
+
+	private AtomicBoolean missingRecipe = new AtomicBoolean(false);
 
 	public ChatListener(NotEnoughUpdates neu) {
 		this.neu = neu;
@@ -210,7 +213,7 @@ public class ChatListener {
 
 		String r = null;
 		String unformatted = Utils.cleanColour(e.message.getUnformattedText());
-		Matcher matcher = SLAYER_XP.matcher(unformatted);
+		Matcher matcher = slayerExpPattern.matcher(unformatted);
 		if (unformatted.startsWith("You are playing on profile: ")) {
 			SBInfo.getInstance().setCurrentProfile(unformatted
 				.substring("You are playing on profile: ".length())
@@ -305,7 +308,7 @@ public class ChatListener {
 			"  You've earned a Crystal Loot Bundle!"))
 			OverlayManager.crystalHollowOverlay.message(unformatted);
 
-		Matcher LvlMatcher = SKYBLOCK_LVL_MESSAGE.matcher(unformatted);
+		Matcher LvlMatcher = skyBlockLevelPattern.matcher(unformatted);
 		if (LvlMatcher.matches()) {
 			if (Integer.parseInt(LvlMatcher.group(1)) < NotEnoughUpdates.INSTANCE.config.misc.filterChatLevel &&
 				NotEnoughUpdates.INSTANCE.config.misc.filterChatLevel != 0) {
@@ -327,8 +330,7 @@ public class ChatListener {
 
 	private IChatComponent dungeonPartyJoinPV(IChatComponent message) {
 		String text = message.getFormattedText();
-		Pattern pattern = Pattern.compile("§dParty Finder §r§f> (.*)§ejoined the dungeon group!");
-		Matcher matcher = pattern.matcher(text);
+		Matcher matcher = partyFinderPattern.matcher(text);
 
 		if (matcher.find()) {
 			String name = StringUtils.stripControlCodes(matcher.group(1)).trim();

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/ChatListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/ChatListener.java
@@ -58,10 +58,10 @@ public class ChatListener {
 
 	private final NotEnoughUpdates neu;
 
-	private static final Pattern slayerExpPattern = Pattern.compile(
+	private static final Pattern SLAYER_EXP_PATTERN = Pattern.compile(
 		"   (Spider|Zombie|Wolf|Enderman|Blaze) Slayer LVL (\\d) - (?:Next LVL in ([\\d,]+) XP!|LVL MAXED OUT!)");
-	private static final Pattern skyBlockLevelPattern = Pattern.compile("\\[(\\d{1,4})\\] .*");
-	private final Pattern partyFinderPattern = Pattern.compile("§dParty Finder §r§f> (.*)§ejoined the dungeon group!");
+	private static final Pattern SKY_BLOCK_LEVEL_PATTERN = Pattern.compile("\\[(\\d{1,4})\\] .*");
+	private final Pattern PARTY_FINDER_PATTERN = Pattern.compile("§dParty Finder §r§f> (.*)§ejoined the dungeon group!");
 
 	private AtomicBoolean missingRecipe = new AtomicBoolean(false);
 
@@ -213,7 +213,7 @@ public class ChatListener {
 
 		String r = null;
 		String unformatted = Utils.cleanColour(e.message.getUnformattedText());
-		Matcher matcher = slayerExpPattern.matcher(unformatted);
+		Matcher matcher = SLAYER_EXP_PATTERN.matcher(unformatted);
 		if (unformatted.startsWith("You are playing on profile: ")) {
 			SBInfo.getInstance().setCurrentProfile(unformatted
 				.substring("You are playing on profile: ".length())
@@ -308,7 +308,7 @@ public class ChatListener {
 			"  You've earned a Crystal Loot Bundle!"))
 			OverlayManager.crystalHollowOverlay.message(unformatted);
 
-		Matcher LvlMatcher = skyBlockLevelPattern.matcher(unformatted);
+		Matcher LvlMatcher = SKY_BLOCK_LEVEL_PATTERN.matcher(unformatted);
 		if (LvlMatcher.matches()) {
 			if (Integer.parseInt(LvlMatcher.group(1)) < NotEnoughUpdates.INSTANCE.config.misc.filterChatLevel &&
 				NotEnoughUpdates.INSTANCE.config.misc.filterChatLevel != 0) {
@@ -330,7 +330,7 @@ public class ChatListener {
 
 	private IChatComponent dungeonPartyJoinPV(IChatComponent message) {
 		String text = message.getFormattedText();
-		Matcher matcher = partyFinderPattern.matcher(text);
+		Matcher matcher = PARTY_FINDER_PATTERN.matcher(text);
 
 		if (matcher.find()) {
 			String name = StringUtils.stripControlCodes(matcher.group(1)).trim();

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Misc.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Misc.java
@@ -295,4 +295,12 @@ public class Misc {
 	@ConfigEditorBoolean
 	public boolean abiphoneFavourites = true;
 
+	@Expose
+	@ConfigOption(
+		name = "Dungeon Groups PV",
+		desc = "View another player's profile by clicking on the chat message when they join in a dungeon group."
+	)
+	@ConfigEditorBoolean
+	public boolean dungeonGroupsPV = true;
+
 }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/24389977/210030257-413efe2a-1e94-48d3-916f-ea89e12f4672.png)


This feature allows players to quickly view the profile of another player who has joined their dungeon group through the party finder by hovering and clicking on the chat message announcing the player's arrival. This is a useful feature for several reasons.

First, it allows players to get to know their new group members better before embarking on their dungeon adventure together. For example, if a player is a tank, they may want to know more about the healer's gear and skills to ensure that they are well-equipped to support the group. Similarly, a player who is new to the game may want to learn more about their group members' achievements and experience to get a sense of their expertise.

Second, the profile viewer provides detailed information about the player's character, including their gear, skills, and achievements. This is useful for players who want to optimize their group composition and strategize for their dungeon run. For example, if a player is looking for a specific type of gear or skill, they can use the profile viewer to find a group member who meets those requirements.

Third, this feature helps foster a sense of community and collaboration within the game. By allowing players to connect with and learn more about their fellow adventurers, it encourages teamwork and cooperation during dungeon runs. This can lead to a more enjoyable and successful gaming experience for all group members.

Overall, the ability to quickly view the profile of another player who has joined their dungeon group is a valuable and convenient feature that enhances the gameplay experience for players.