### PR TITLE
PetLeveling: Allow for defining custom level offsets for pets

### DIFF
--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/util/PetLeveling.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/util/PetLeveling.kt
@@ -100,7 +100,7 @@ object PetLeveling {
         val petConstants = this.petConstants ?: Constants.PETS ?: return stubExpLadder
         var levels = petConstants["pet_levels"]?.asJsonArray?.map { it.asLong }?.toMutableList() ?: return stubExpLadder
         val customLeveling = petConstants["custom_pet_leveling"]?.asJsonObject?.get(petIdWithoutRarity)
-        val offset = petConstants["pet_rarity_offset"]?.asJsonObject?.get(rarity.name)?.asInt ?: return stubExpLadder
+        var rarityOffsets = petConstants["pet_rarity_offset"]?.asJsonObject
         var maxLevel = 100
         if (customLeveling is JsonObject) {
             val customLevels by lazy { customLeveling["pet_levels"]?.asJsonArray?.map { it.asLong } }
@@ -109,7 +109,10 @@ object PetLeveling {
                 2 -> levels = customLevels?.toMutableList() ?: return stubExpLadder
             }
             maxLevel = customLeveling["max_level"]?.asInt ?: maxLevel
+            rarityOffsets = customLeveling["rarity_offset"]?.asJsonObject ?: rarityOffsets
         }
+        val offset = rarityOffsets?.get(rarity.name)?.asInt ?: return stubExpLadder
+
         return ExpLadder(levels.drop(offset).take(maxLevel - 1))
     }
 

--- a/src/test/kotlin/io/github/moulberry/notenoughupdates/util/PetLevelingTest.kt
+++ b/src/test/kotlin/io/github/moulberry/notenoughupdates/util/PetLevelingTest.kt
@@ -265,6 +265,16 @@ internal class PetLevelingTest {
                 1886700
               ],
               "max_level": 200
+            },
+            "BINGO": {
+                "rarity_offset": {
+                    "COMMON": 0,
+                    "UNCOMMON": 0,
+                    "RARE": 0,
+                    "EPIC": 0,
+                    "LEGENDARY": 0,
+                    "MYTHIC": 0
+                }
             }
           },
           "pet_types": {
@@ -355,6 +365,14 @@ internal class PetLevelingTest {
         Assertions.assertEquals(100, level.currentLevel)
         Assertions.assertEquals(100, level.maxLevel)
     }
+
+    @Test
+    fun testBingoPetsLevelLikeCommon() {
+        val levelingC = PetLeveling.getPetLevelingForPet0("BINGO", PetInfoOverlay.Rarity.COMMON)
+        val levelingE = PetLeveling.getPetLevelingForPet0("BINGO", PetInfoOverlay.Rarity.EPIC)
+        Assertions.assertEquals(levelingC.getPetLevel(67790664.0), levelingE.getPetLevel(67790664.0))
+    }
+
 
     @Test
     fun testPetLevelGrandmaWolf() {


### PR DESCRIPTION
Intended for bingo pet. Use like so in custom pet leveling constants:
```json
"BINGO":
{	"rarity_offset":
	{	"COMMON": 0
	,	"UNCOMMON": 0
	,	"RARE": 0
	,	"EPIC": 0
	,	"LEGENDARY": 0
	}
}
``` 

Either *all* or *none* of the rarities need to be overridden (or you'll get a stub ladder)