### PR TITLE
Fixed NPE in AuctionBINWarning

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/AuctionBINWarning.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/AuctionBINWarning.java
@@ -105,6 +105,8 @@ public class AuctionBINWarning extends GuiElement {
 		}
 
 		ItemStack sellStack = event.guiContainer.inventorySlots.getSlot(13).getStack();
+		if (sellStack == null) return;
+
 		String internalname = NotEnoughUpdates.INSTANCE.manager.getInternalNameForItem(sellStack);
 		sellStackAmount = sellStack.stackSize;
 


### PR DESCRIPTION
```
java.lang.NullPointerException: Updating screen events
	at io.github.moulberry.notenoughupdates.miscfeatures.AuctionBINWarning.onMouseClick(AuctionBINWarning.java:109)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_154_AuctionBINWarning_onMouseClick_SlotClickEvent.invoke(.dynamic)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:49)
	at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:140)
	at io.github.moulberry.notenoughupdates.events.NEUEvent.post(NEUEvent.java:27)
	at net.minecraft.client.gui.inventory.GuiContainer.handler$bhc000$handleMouseClick(GuiContainer.java:6067)
	at net.minecraft.client.gui.inventory.GuiContainer.handleMouseClick(GuiContainer.java)
```