### PR TITLE
Restrict texture https upgrading to only minecraft.net

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/hooks/ThreadDownloadImageHook.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/hooks/ThreadDownloadImageHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Linnea Gräf
+ * Copyright (C) 2022-2023 Linnea Gräf
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -26,15 +26,22 @@ import javax.net.ssl.HttpsURLConnection;
 import java.net.HttpURLConnection;
 
 public class ThreadDownloadImageHook {
+	public static String hookThreadImageLink(String originalLink) {
+		if (!NotEnoughUpdates.INSTANCE.config.misc.fixSteveSkulls || originalLink == null || !originalLink.startsWith(
+			"http://textures.minecraft.net"))
+			return originalLink;
+		return originalLink.replace("http://", "https://");
+	}
+
 	public static void hookThreadImageConnection(HttpURLConnection connection) {
 		if ((connection instanceof HttpsURLConnection) && NotEnoughUpdates.INSTANCE.config.misc.fixSteveSkulls) {
 			ApiUtil.patchHttpsRequest((HttpsURLConnection) connection);
 		}
 	}
 
-	public static String hookThreadImageLink(String originalLink) {
-		if (!NotEnoughUpdates.INSTANCE.config.misc.fixSteveSkulls || originalLink == null)
-			return originalLink;
-		return originalLink.replace("http://", "https://");
+	public interface AccessorThreadDownloadImageData {
+		String getOriginalUrl();
+
+		String getPatchedUrl();
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinThreadDownloadImageData.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinThreadDownloadImageData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Linnea Gräf
+ * Copyright (C) 2022-2023 Linnea Gräf
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -30,11 +30,13 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ThreadDownloadImageData.class)
-public class MixinThreadDownloadImageData {
+public class MixinThreadDownloadImageData implements ThreadDownloadImageHook.AccessorThreadDownloadImageData{
 	@Mutable
 	@Shadow
 	@Final
 	private String imageUrl;
+
+	private String originalUrl;
 
 	@Redirect(
 		method = "<init>",
@@ -44,5 +46,16 @@ public class MixinThreadDownloadImageData {
 			opcode = Opcodes.PUTFIELD))
 	public void useHttpsDownloadLinks(ThreadDownloadImageData instance, String value) {
 		this.imageUrl = ThreadDownloadImageHook.hookThreadImageLink(value);
+		this.originalUrl = value;
+	}
+
+	@Override
+	public String getOriginalUrl() {
+		return originalUrl;
+	}
+
+	@Override
+	public String getPatchedUrl() {
+		return imageUrl;
 	}
 }


### PR DESCRIPTION
```
[09:49:53] [Texture Downloader #2/INFO] [STDOUT]: Patched https into http://s.optifine.net/capes/Pikaahhh.png (redirected to https://s.optifine.net/capes/Pikaahhh.png)
```