### PR TITLE
Custom default font color in storage overlay

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/commands/dev/EnableStorageCommand.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/commands/dev/EnableStorageCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -21,8 +21,11 @@ package io.github.moulberry.notenoughupdates.commands.dev;
 
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.commands.ClientCommandBase;
+import net.minecraft.client.Minecraft;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.EnumChatFormatting;
 
 public class EnableStorageCommand extends ClientCommandBase {
 
@@ -34,6 +37,7 @@ public class EnableStorageCommand extends ClientCommandBase {
 	public void processCommand(ICommandSender sender, String[] args) throws CommandException {
 		NotEnoughUpdates.INSTANCE.config.storageGUI.enableStorageGUI3 = true;
 		NotEnoughUpdates.INSTANCE.saveConfig();
+		Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.YELLOW + "[NEU] Enabled custom storage GUI"));
 	}
 
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/commands/dev/EnableStorageCommand.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/commands/dev/EnableStorageCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 NotEnoughUpdates contributors
+ * Copyright (C) 2022 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -21,11 +21,8 @@ package io.github.moulberry.notenoughupdates.commands.dev;
 
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.commands.ClientCommandBase;
-import net.minecraft.client.Minecraft;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
-import net.minecraft.util.ChatComponentText;
-import net.minecraft.util.EnumChatFormatting;
 
 public class EnableStorageCommand extends ClientCommandBase {
 
@@ -37,7 +34,6 @@ public class EnableStorageCommand extends ClientCommandBase {
 	public void processCommand(ICommandSender sender, String[] args) throws CommandException {
 		NotEnoughUpdates.INSTANCE.config.storageGUI.enableStorageGUI3 = true;
 		NotEnoughUpdates.INSTANCE.saveConfig();
-		Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.YELLOW + "[NEU] Enabled custom storage GUI"));
 	}
 
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/StorageOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/StorageOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -55,7 +55,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.util.IChatComponent;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.ClientCommandHandler;
 import org.lwjgl.input.Keyboard;
@@ -390,6 +389,10 @@ public class StorageOverlay extends GuiElement {
 		} else if (displayStyle == 0) {
 			textColour = 0x909090;
 			searchTextColour = 0xa0a0a0;
+		}
+
+		if (NotEnoughUpdates.INSTANCE.config.storageGUI.useCustomTextColour) {
+			textColour = ChromaColour.specialToChromaRGB(NotEnoughUpdates.INSTANCE.config.storageGUI.customTextColour);
 		}
 
 		long currentTime = System.currentTimeMillis();

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/StorageGUI.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/StorageGUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -152,6 +152,26 @@ public class StorageGUI {
 	@ConfigEditorColour
 	@ConfigAccordionId(id = 1)
 	public String selectedStorageColour = "0:255:255:223:0";
+
+	@Expose
+	@ConfigOption(
+		name = "Custom Text Colour",
+		desc = "Use a custom default text colour.\nOverrides the colour set by the overlay style.\nCan be overridden by using colour codes in the page title.",
+		searchTags = "color"
+	)
+	@ConfigEditorBoolean
+	@ConfigAccordionId(id = 1)
+	public boolean useCustomTextColour = false;
+
+	@Expose
+	@ConfigOption(
+		name = "Custom Text Colour",
+		desc = "Requires the above option to be set to true",
+		searchTags = "color"
+	)
+	@ConfigEditorColour
+	@ConfigAccordionId(id = 1)
+	public String customTextColour = "0:255:144:144:144";
 
 	@Expose
 	@ConfigOption(


### PR DESCRIPTION
Overrides the color from the Overlay Style option.


Can be overriden by using color codes in the page title.

Useful for changing the "Inventory" text color, for example.