### PR TITLE
Align level in Basic PV page to center

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/BasicPage.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/BasicPage.java
@@ -586,7 +586,7 @@ public class BasicPage extends GuiProfileViewerPage {
 		Utils.drawItemStack(skull, 0, 0);
 		GlStateManager.popMatrix();
 		Utils.drawStringCenteredScaled(skyblockLevelColour.toString() + (int) skyblockLevel, fr,
-			sbLevelX + 8, sbLevelY - 12, true, 1.5f
+			sbLevelX + 9, sbLevelY - 12, true, 1.5f
 		);
 
 		float progress = (float) (skyblockLevel - (long) skyblockLevel);

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/BasicPage.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/BasicPage.java
@@ -572,7 +572,7 @@ public class BasicPage extends GuiProfileViewerPage {
 			);
 		}
 
-		// sb lvlL
+		// sb lvl
 
 		int sbLevelX = guiLeft + 162;
 		int sbLevelY = guiTop + 90;
@@ -585,8 +585,8 @@ public class BasicPage extends GuiProfileViewerPage {
 		GlStateManager.scale(1.5f, 1.5f, 1);
 		Utils.drawItemStack(skull, 0, 0);
 		GlStateManager.popMatrix();
-		Utils.drawStringScaled(skyblockLevelColour.toString() + (int) skyblockLevel, fr,
-			sbLevelX - 2, sbLevelY - 15, true, 0, 1.5f
+		Utils.drawStringCenteredScaled(skyblockLevelColour.toString() + (int) skyblockLevel, fr,
+			sbLevelX + 8, sbLevelY - 12, true, 1.5f
 		);
 
 		float progress = (float) (skyblockLevel - (long) skyblockLevel);

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/level/task/DungeonTaskLevel.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/level/task/DungeonTaskLevel.java
@@ -106,7 +106,7 @@ public class DungeonTaskLevel {
 		lore.add(levelPage.buildLore("Complete Dungeons", sbLevelGainedFloor, completeDungeon, false));
 
 		levelPage.renderLevelBar(
-			"Dungeon",
+			"Dungeon Task",
 			NotEnoughUpdates.INSTANCE.manager
 				.createItemResolutionQuery()
 				.withKnownInternalName("WITHER_RELIC")

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
@@ -1229,6 +1229,22 @@ public class Utils {
 		drawStringScaled(str, fr, x - len / 2, y - fontHeight / 2, shadow, colour, factor);
 	}
 
+	public static void drawStringCenteredScaled(
+		String str,
+		FontRenderer fr,
+		float x,
+		float y,
+		boolean shadow,
+		float factor
+	) {
+		int strLen = fr.getStringWidth(str);
+
+		float x2 = x - strLen / 2f;
+		float y2 = y - fr.FONT_HEIGHT / 2f;
+
+		drawStringScaled(str, fr, x2, y2, shadow, 0, factor);
+	}
+
 	public static void drawStringCenteredYScaled(
 		String str,
 		FontRenderer fr,


### PR DESCRIPTION
This PR aligns the skyblock level in basic PV to the center even if they are a lower level.
This PR also changes "Dungeon" to "Dungeon Task" in the level page.

Before:
![image](https://user-images.githubusercontent.com/69400149/216780476-ea3e675c-ea98-4784-b337-2334fed7b815.png)

After:
![image](https://user-images.githubusercontent.com/69400149/216780407-aad9317e-bd67-48af-8fda-a23c04b04a89.png)

Fixes #584 