### PR TITLE
 ApiUtil: Add cache with per request timeout and per class histogram 

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/auction/APIManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/auction/APIManager.java
@@ -292,7 +292,7 @@ public class APIManager {
 			.newMoulberryRequest("lowestbin.json.gz")
 			.gunzip()
 			.requestJson()
-			.thenAccept(jsonObject -> {
+			.thenAcceptAsync(jsonObject -> {
 				if (lowestBins == null) {
 					lowestBins = new JsonObject();
 				}
@@ -465,12 +465,12 @@ public class APIManager {
 		};
 
 		manager.apiUtils.newMoulberryRequest("auctionLast.json.gz")
-										.gunzip().requestJson().thenAccept(process);
+										.gunzip().requestJson().thenAcceptAsync(process);
 
 		manager.apiUtils
 			.newMoulberryRequest("auction.json.gz")
 			.gunzip().requestJson()
-			.thenAccept(jsonObject -> {
+			.thenAcceptAsync(jsonObject -> {
 				if (jsonObject.get("success").getAsBoolean()) {
 					long apiUpdate = (long) jsonObject.get("time").getAsFloat();
 					if (lastApiUpdate == apiUpdate) {
@@ -683,7 +683,7 @@ public class APIManager {
 		manager.apiUtils
 			.newAnonymousHypixelApiRequest("skyblock/auctions")
 			.requestJson()
-			.thenAccept(jsonObject -> {
+			.thenAcceptAsync(jsonObject -> {
 				if (jsonObject == null) return;
 
 				if (jsonObject.get("success").getAsBoolean()) {
@@ -733,7 +733,7 @@ public class APIManager {
 		manager.apiUtils
 			.newAnonymousHypixelApiRequest("skyblock/bazaar")
 			.requestJson()
-			.thenAccept(jsonObject -> {
+			.thenAcceptAsync(jsonObject -> {
 				if (!jsonObject.get("success").getAsBoolean()) return;
 
 				craftCost.clear();
@@ -789,7 +789,7 @@ public class APIManager {
 	public void updateAvgPrices() {
 		manager.apiUtils
 			.newMoulberryRequest("auction_averages/3day.json.gz")
-			.gunzip().requestJson().thenAccept((jsonObject) -> {
+			.gunzip().requestJson().thenAcceptAsync((jsonObject) -> {
 						 craftCost.clear();
 						 auctionPricesJson = jsonObject;
 						 lastAuctionAvgUpdate = System.currentTimeMillis();
@@ -797,7 +797,7 @@ public class APIManager {
 		manager.apiUtils
 			.newMoulberryRequest("auction_averages_lbin/1day.json.gz")
 			.gunzip().requestJson()
-			.thenAccept((jsonObject) -> {
+			.thenAcceptAsync((jsonObject) -> {
 				auctionPricesAvgLowestBinJson = jsonObject;
 			});
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/commands/dev/DevTestCommand.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/commands/dev/DevTestCommand.java
@@ -33,11 +33,13 @@ import io.github.moulberry.notenoughupdates.miscfeatures.customblockzones.Locati
 import io.github.moulberry.notenoughupdates.miscfeatures.customblockzones.SpecialBlockZone;
 import io.github.moulberry.notenoughupdates.miscgui.GuiPriceGraph;
 import io.github.moulberry.notenoughupdates.miscgui.minionhelper.MinionHelperManager;
+import io.github.moulberry.notenoughupdates.util.ApiCache;
 import io.github.moulberry.notenoughupdates.util.PronounDB;
 import io.github.moulberry.notenoughupdates.util.SBInfo;
 import io.github.moulberry.notenoughupdates.util.TabListUtils;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import io.github.moulberry.notenoughupdates.util.hypixelapi.ProfileCollectionInfo;
+import lombok.var;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.command.CommandException;
@@ -125,6 +127,24 @@ public class DevTestCommand extends ClientCommandBase {
 			}
 			Utils.addChatMessage(EnumChatFormatting.RED + DEV_FAIL_STRINGS[devFailIndex++]);
 			return;
+		}
+		if (args.length == 1 && args[0].equalsIgnoreCase("dumpapihistogram")) {
+			synchronized (ApiCache.INSTANCE) {
+				Utils.addChatMessage("§e[NEU] API Request Histogram");
+				Utils.addChatMessage("§e[NEU] §bClass Name§e: §aCached§e/§cNonCached§e/§dTotal");
+				ApiCache.INSTANCE.getHistogramTotalRequests().forEach((className, totalRequests) -> {
+					var nonCachedRequests = ApiCache.INSTANCE.getHistogramNonCachedRequests().getOrDefault(className, 0);
+					var cachedRequests = totalRequests - nonCachedRequests;
+					Utils.addChatMessage(
+						String.format(
+							"§e[NEU] §b%s §a%d§e/§c%d§e/§d%d",
+							className,
+							cachedRequests,
+							nonCachedRequests,
+							totalRequests
+						));
+				});
+			}
 		}
 		if (args.length == 1 && args[0].equalsIgnoreCase("testprofile")) {
 			NotEnoughUpdates.INSTANCE.manager.apiUtils.newHypixelApiRequest("skyblock/profiles")

--- a/src/main/java/io/github/moulberry/notenoughupdates/commands/misc/PronounsCommand.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/commands/misc/PronounsCommand.java
@@ -88,7 +88,7 @@ public class PronounsCommand extends ClientCommandBase {
 				"§e[NEU] Pronouns for §b" + user + " §eon §b" + platform + "§e:"), id);
 			betterPronounChoice.render().forEach(it -> nc.printChatMessage(new ChatComponentText("§e[NEU] §a" + it)));
 			return null;
-		}, MinecraftExecutor.INSTANCE);
+		}, MinecraftExecutor.OnThread);
 
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/cosmetics/CapeManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/cosmetics/CapeManager.java
@@ -150,7 +150,7 @@ public class CapeManager {
 		NotEnoughUpdates.INSTANCE.manager.apiUtils
 			.newMoulberryRequest("activecapes.json")
 			.requestJson()
-			.thenAccept(jsonObject -> {
+			.thenAcceptAsync(jsonObject -> {
 				if (jsonObject.get("success").getAsBoolean()) {
 					lastJsonSync = jsonObject;
 
@@ -171,7 +171,7 @@ public class CapeManager {
 			NotEnoughUpdates.INSTANCE.manager.apiUtils
 				.newMoulberryRequest("permscapes.json")
 				.requestJson()
-				.thenAccept(jsonObject -> {
+				.thenAcceptAsync(jsonObject -> {
 					if (!jsonObject.get("success").getAsBoolean()) return;
 
 					permSyncTries = 0;

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/minionhelper/loaders/MinionHelperApiLoader.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/minionhelper/loaders/MinionHelperApiLoader.java
@@ -47,7 +47,6 @@ import java.util.Map;
 public class MinionHelperApiLoader {
 	private final MinionHelperManager manager;
 	private boolean dirty = true;
-	private int ticks = 0;
 	private boolean collectionApiEnabled = true;
 	private boolean ignoreWorldSwitches = false;
 	private boolean readyToUse = false;
@@ -72,11 +71,7 @@ public class MinionHelperApiLoader {
 		if (Minecraft.getMinecraft().thePlayer == null) return;
 		if (!NotEnoughUpdates.INSTANCE.hasSkyblockScoreboard()) return;
 		if (!NotEnoughUpdates.INSTANCE.config.minionHelper.gui) return;
-		ticks++;
-
-		if (ticks % 20 != 0) return;
-
-		if (dirty) {
+		if (dirty && "Crafted Minions".equals(Utils.getOpenChestName())) {
 			load();
 		} else {
 			if (System.currentTimeMillis() > lastLoaded + 60_000 * 3) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/customtypes/NEUDebugFlag.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/customtypes/NEUDebugFlag.java
@@ -31,6 +31,7 @@ public enum NEUDebugFlag {
 	WISHING("Wishing Compass Solver"),
 	MAP("Dungeon Map Player Information"),
 	SEARCH("SearchString Matches"),
+	API_CACHE("Api Cache"),
 	;
 
 	private final String description;
@@ -41,6 +42,10 @@ public enum NEUDebugFlag {
 
 	public String getDescription() {
 		return description;
+	}
+
+	public void log(String message) {
+		NEUDebugLogger.log(this, message);
 	}
 
 	public boolean isSet() {

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
@@ -42,6 +42,7 @@ import net.minecraft.util.EnumChatFormatting;
 import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -537,6 +538,7 @@ public class ProfileViewer {
 		manager.apiUtils
 			.newHypixelApiRequest("player")
 			.queryArgument("name", nameF)
+			.maxCacheAge(Duration.ofSeconds(30))
 			.requestJson()
 			.thenAccept(jsonObject -> {
 					if (

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
@@ -56,6 +56,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.zip.GZIPInputStream;
@@ -210,7 +211,7 @@ public class ApiUtil {
 							conn.setDoOutput(true);
 							OutputStream os = conn.getOutputStream();
 							try {
-								os.write(this.postData.getBytes("utf-8"));
+								os.write(this.postData.getBytes(StandardCharsets.UTF_8));
 							} finally {
 								os.close();
 							}
@@ -252,7 +253,7 @@ public class ApiUtil {
 		}
 
 		public <T> CompletableFuture<T> requestJson(Class<? extends T> clazz) {
-			return requestString().thenApply(str -> gson.fromJson(str, clazz));
+			return requestString().thenApplyAsync(str -> gson.fromJson(str, clazz));
 		}
 
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
@@ -48,8 +48,10 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +62,11 @@ import java.util.zip.GZIPInputStream;
 
 public class ApiUtil {
 	private static final Gson gson = new Gson();
+
+	private static final Comparator<NameValuePair> nameValuePairComparator = Comparator
+		.comparing(NameValuePair::getName)
+		.thenComparing(NameValuePair::getValue);
+
 	private static final ExecutorService executorService = Executors.newFixedThreadPool(3);
 	private static String getUserAgent() {
 		if (NotEnoughUpdates.INSTANCE.config.hidden.customUserAgent != null) {
@@ -110,12 +117,22 @@ public class ApiUtil {
 		private final List<NameValuePair> queryArguments = new ArrayList<>();
 		private String baseUrl = null;
 		private boolean shouldGunzip = false;
+		private Duration cacheTimeout = Duration.ofSeconds(500);
 		private String method = "GET";
 		private String postData = null;
 		private String postContentType = null;
 
 		public Request method(String method) {
 			this.method = method;
+			return this;
+		}
+
+		/**
+		 * Specify a cache timeout of {@code null} to signify an uncacheable request.
+		 * Non {@code GET} requests are always uncacheable.
+		 */
+		public Request cacheTimeout(Duration cacheTimeout) {
+			this.cacheTimeout = cacheTimeout;
 			return this;
 		}
 
@@ -160,7 +177,17 @@ public class ApiUtil {
 			return fut;
 		}
 
-		public CompletableFuture<String> requestString() {
+		public String getBaseUrl() {
+			return baseUrl;
+		}
+
+		private ApiCache.CacheKey getCacheKey() {
+			if (!"GET".equals(method)) return null;
+			queryArguments.sort(nameValuePairComparator);
+			return new ApiCache.CacheKey(baseUrl, queryArguments, shouldGunzip);
+		}
+
+		private CompletableFuture<String> requestString0() {
 			return buildUrl().thenApplyAsync(url -> {
 				try {
 					InputStream inputStream = null;
@@ -214,6 +241,10 @@ public class ApiUtil {
 					throw new RuntimeException(e); // We can rethrow, since supplyAsync catches exceptions.
 				}
 			}, executorService);
+		}
+
+		public CompletableFuture<String> requestString() {
+			return ApiCache.INSTANCE.cacheRequest(this, getCacheKey(), this::requestString0, cacheTimeout);
 		}
 
 		public CompletableFuture<JsonObject> requestJson() {

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
@@ -117,7 +117,7 @@ public class ApiUtil {
 		private final List<NameValuePair> queryArguments = new ArrayList<>();
 		private String baseUrl = null;
 		private boolean shouldGunzip = false;
-		private Duration cacheTimeout = Duration.ofSeconds(500);
+		private Duration maxCacheAge = Duration.ofSeconds(500);
 		private String method = "GET";
 		private String postData = null;
 		private String postContentType = null;
@@ -131,8 +131,8 @@ public class ApiUtil {
 		 * Specify a cache timeout of {@code null} to signify an uncacheable request.
 		 * Non {@code GET} requests are always uncacheable.
 		 */
-		public Request cacheTimeout(Duration cacheTimeout) {
-			this.cacheTimeout = cacheTimeout;
+		public Request maxCacheAge(Duration maxCacheAge) {
+			this.maxCacheAge = maxCacheAge;
 			return this;
 		}
 
@@ -244,7 +244,7 @@ public class ApiUtil {
 		}
 
 		public CompletableFuture<String> requestString() {
-			return ApiCache.INSTANCE.cacheRequest(this, getCacheKey(), this::requestString0, cacheTimeout);
+			return ApiCache.INSTANCE.cacheRequest(this, getCacheKey(), this::requestString0, maxCacheAge);
 		}
 
 		public CompletableFuture<JsonObject> requestJson() {

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/util/ApiCache.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/util/ApiCache.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2023 NotEnoughUpdates contributors
+ *
+ * This file is part of NotEnoughUpdates.
+ *
+ * NotEnoughUpdates is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * NotEnoughUpdates is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.moulberry.notenoughupdates.util
+
+import io.github.moulberry.notenoughupdates.NotEnoughUpdates
+import io.github.moulberry.notenoughupdates.options.customtypes.NEUDebugFlag
+import io.github.moulberry.notenoughupdates.util.ApiUtil.Request
+import org.apache.http.NameValuePair
+import java.time.Duration
+import java.util.*
+import java.util.concurrent.CompletableFuture
+import java.util.function.Supplier
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.TimeSource
+import kotlin.time.toKotlinDuration
+
+@OptIn(ExperimentalTime::class)
+
+object ApiCache {
+    data class CacheKey(
+        val baseUrl: String,
+        val requestParameters: List<NameValuePair>,
+        val shouldGunzip: Boolean,
+    )
+
+    data class CacheResult(
+        val future: CompletableFuture<String>,
+        val firedAt: TimeSource.Monotonic.ValueTimeMark,
+    )
+
+    val cachedRequests = mutableMapOf<CacheKey, CacheResult>()
+    val histogramTotalRequests: MutableMap<String, Int> = mutableMapOf()
+    val histogramNonCachedRequests: MutableMap<String, Int> = mutableMapOf()
+    val timeout = 10.seconds
+    val maxCacheAge = 1.hours
+
+    fun log(message: String) {
+        NEUDebugFlag.API_CACHE.log(message)
+    }
+
+    fun traceApiRequest(
+        request: Request,
+        failReason: String?,
+    ) {
+        if (!NotEnoughUpdates.INSTANCE.config.hidden.dev) return
+        val callingClass = Thread.currentThread().stackTrace
+            .find {
+                !it.className.startsWith("java.") &&
+                        !it.className.startsWith("kotlin.") &&
+                        it.className != ApiCache::class.java.name &&
+                        it.className != ApiUtil::class.java.name &&
+                        it.className != Request::class.java.name
+            }
+        val callingClassText = callingClass?.let {
+            "${it.className}.${it.methodName} (${it.fileName}:${it.lineNumber})"
+        } ?: "no calling class found"
+        callingClass?.className?.let {
+            histogramTotalRequests[it] = (histogramTotalRequests[it] ?: 0) + 1
+            if (failReason != null)
+                histogramNonCachedRequests[it] = (histogramNonCachedRequests[it] ?: 0) + 1
+        }
+        if (failReason != null) {
+            log("Executing api request for url ${request.baseUrl} by $callingClassText: $failReason")
+        } else {
+            log("Cache hit for api request for url ${request.baseUrl} by $callingClassText.")
+        }
+
+    }
+
+    fun evictCache() {
+        synchronized(this) {
+            val it = cachedRequests.iterator()
+            while (it.hasNext()) {
+                if (it.next().value.firedAt.elapsedNow() >= maxCacheAge)
+                    it.remove()
+            }
+        }
+    }
+
+    fun cacheRequest(
+        request: Request,
+        cacheKey: CacheKey?,
+        futureSupplier: Supplier<CompletableFuture<String>>,
+        maxAge: Duration?
+    ): CompletableFuture<String> {
+        evictCache()
+        if (cacheKey == null) {
+            traceApiRequest(request, "uncacheable request (probably POST)")
+            return futureSupplier.get()
+        }
+        if (maxAge == null) {
+            traceApiRequest(request, "manually specified as uncacheable")
+            return futureSupplier.get()
+        }
+        fun recache(): CompletableFuture<String> {
+            return futureSupplier.get().also {
+                cachedRequests[cacheKey] = CacheResult(it, TimeSource.Monotonic.markNow())
+            }
+        }
+        synchronized(this) {
+            val cachedRequest = cachedRequests[cacheKey]
+            if (cachedRequest == null) {
+                traceApiRequest(request, "no cache found")
+                return recache()
+            }
+            if (cachedRequest.future.isDone && cachedRequest.firedAt.elapsedNow() > maxAge.toKotlinDuration()) {
+                traceApiRequest(request, "outdated cache")
+                return recache()
+            }
+            if (!cachedRequest.future.isDone && cachedRequest.firedAt.elapsedNow() > timeout) {
+                traceApiRequest(request, "suspiciously slow api response")
+                return recache()
+            }
+            traceApiRequest(request, null)
+            return cachedRequest.future
+        }
+    }
+
+}

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/util/ApiCache.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/util/ApiCache.kt
@@ -47,17 +47,17 @@ object ApiCache {
         val firedAt: TimeSource.Monotonic.ValueTimeMark,
     )
 
-    val cachedRequests = mutableMapOf<CacheKey, CacheResult>()
+    private val cachedRequests = mutableMapOf<CacheKey, CacheResult>()
     val histogramTotalRequests: MutableMap<String, Int> = mutableMapOf()
     val histogramNonCachedRequests: MutableMap<String, Int> = mutableMapOf()
-    val timeout = 10.seconds
-    val maxCacheAge = 1.hours
+    private val timeout = 10.seconds
+    private val maxCacheAge = 1.hours
 
-    fun log(message: String) {
+    private fun log(message: String) {
         NEUDebugFlag.API_CACHE.log(message)
     }
 
-    fun traceApiRequest(
+    private fun traceApiRequest(
         request: Request,
         failReason: String?,
     ) {
@@ -86,7 +86,7 @@ object ApiCache {
 
     }
 
-    fun evictCache() {
+    private fun evictCache() {
         synchronized(this) {
             val it = cachedRequests.iterator()
             while (it.hasNext()) {

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/util/MinecraftExecutor.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/util/MinecraftExecutor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -17,21 +17,31 @@
  * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
  */
 
-package io.github.moulberry.notenoughupdates.util;
+package io.github.moulberry.notenoughupdates.util
 
-import net.minecraft.client.Minecraft;
-import org.jetbrains.annotations.NotNull;
+import net.minecraft.client.Minecraft
+import java.util.concurrent.Executor
+import java.util.concurrent.ForkJoinPool
 
-import java.util.concurrent.Executor;
+object MinecraftExecutor {
 
-public class MinecraftExecutor implements Executor {
+    @JvmField
+    val OnThread = Executor {
+        val mc = Minecraft.getMinecraft()
+        if (mc.isCallingFromMinecraftThread) {
+            it.run()
+        } else {
+            Minecraft.getMinecraft().addScheduledTask(it)
+        }
+    }
 
-	public static MinecraftExecutor INSTANCE = new MinecraftExecutor();
-
-	private MinecraftExecutor() {}
-
-	@Override
-	public void execute(@NotNull Runnable runnable) {
-		Minecraft.getMinecraft().addScheduledTask(runnable);
-	}
+    @JvmField
+    val OffThread = Executor {
+        val mc = Minecraft.getMinecraft()
+        if (mc.isCallingFromMinecraftThread) {
+            ForkJoinPool.commonPool().execute(it)
+        } else {
+            it.run()
+        }
+    }
 }


### PR DESCRIPTION
An alternative to https://github.com/NotEnoughUpdates/NotEnoughUpdates/pull/591. Currently also caches failed responses, which may be should be changed.