### PR TITLE
API errors in console

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/core/config/annotations/ConfigOption.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/core/config/annotations/ConfigOption.java
@@ -30,6 +30,7 @@ public @interface ConfigOption {
 	String name();
 
 	String desc();
+
 	String[] searchTags() default "";
 
 	int subcategoryId() default -1;

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
@@ -184,6 +184,9 @@ public class ApiUtil {
 							OutputStream os = conn.getOutputStream();
 							try {
 								os.write(this.postData.getBytes("utf-8"));
+							} catch (Throwable t) {
+								t.printStackTrace();
+								throw new Error(t);
 							} finally {
 								os.close();
 							}
@@ -199,6 +202,9 @@ public class ApiUtil {
 						// Not in the sense that this will hold in most cases (although that as well),
 						// but in the sense that any violation of this better have a good reason.
 						return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+					} catch (Throwable t) {
+						t.printStackTrace();
+						throw new Error(t);
 					} finally {
 						try {
 							if (inputStream != null) {


### PR DESCRIPTION
Prints API errors in the console as stack trace instead of hiding them entirely. This should help with future API debugging stuff.
Shows the API of the player in the log files when an error occurs. But since API keys are easy to regenerate, and they are NO reason to get ratted, it doesn't matter at all.

Should not cause merge conflicts with api cache pr.