### PR TITLE
Workaround for NEUOverlay crash

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -1500,7 +1500,15 @@ public class NEUOverlay extends Gui {
 			int actualIndex = index + getSlotsXSize() * getSlotsYSize() * page;
 			List<JsonObject> searchedItems = getSearchedItems();
 			if (0 <= actualIndex && actualIndex < searchedItems.size()) {
-				return searchedItems.get(actualIndex);
+				try {
+					return searchedItems.get(actualIndex);
+				} catch (IndexOutOfBoundsException e) {
+					int size = searchedItems.size();
+					System.out.println("searchedItems size: " + size);
+					System.out.println("actualIndex: " + actualIndex);
+					e.printStackTrace();
+					return null;
+				}
 			} else {
 				return null;
 			}

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -1503,8 +1503,7 @@ public class NEUOverlay extends Gui {
 				try {
 					return searchedItems.get(actualIndex);
 				} catch (IndexOutOfBoundsException e) {
-					int size = searchedItems.size();
-					System.out.println("searchedItems size: " + size);
+					System.out.println("searchedItems size: " + searchedItems.size());
 					System.out.println("actualIndex: " + actualIndex);
 					e.printStackTrace();
 					return null;


### PR DESCRIPTION
This is only a workaround to prevent the crash in `NEUOverlay` because of the `IndexOutOfBoundsException`.

```IndexOutOfBoundsException: Index: 222, Size: 0 
at java.util.ArrayList.rangeCheck(Unknown Source) 
at java.util.ArrayList.get(Unknown Source) 
at io.github.moulberry.notenoughupdates.NEUOverlay.getSearchedItemPage(NEUOverlay.java:1503) 
at io.github.moulberry.notenoughupdates.NEUOverlay$10.consume(NEUOverlay.java:2372) 
at io.github.moulberry.notenoughupdates.NEUOverlay.iterateItemSlots(NEUOverlay.java:1555) 
at io.github.moulberry.notenoughupdates.NEUOverlay.iterateItemSlots(NEUOverlay.java:1529) 
at io.github.moulberry.notenoughupdates.NEUOverlay.renderEnchOverlay(NEUOverlay.java:2370)