### PR TITLE
Fixed colour formatting on sb levels >= 360

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
@@ -963,30 +963,29 @@ public class ProfileViewer {
 			}
 
 			double skyblockLevel = getSkyblockLevel(profileName);
+			EnumChatFormatting levelColour = EnumChatFormatting.WHITE;
 
-			EnumChatFormatting previousColor = EnumChatFormatting.WHITE;
 			if (Constants.SBLEVELS == null || !Constants.SBLEVELS.has("sblevel_colours")) {
 				Utils.showOutdatedRepoNotification();
 				return EnumChatFormatting.WHITE;
 			}
+
 			JsonObject sblevelColours = Constants.SBLEVELS.getAsJsonObject("sblevel_colours");
 			try {
 				for (Map.Entry<String, JsonElement> stringJsonElementEntry : sblevelColours.entrySet()) {
-					int key = Integer.parseInt(stringJsonElementEntry.getKey());
+					int nextLevelBracket = Integer.parseInt(stringJsonElementEntry.getKey());
 					EnumChatFormatting valueByName = EnumChatFormatting.getValueByName(stringJsonElementEntry
 						.getValue()
 						.getAsString());
-					if (skyblockLevel <= key) {
-						skyBlockExperienceColour.put(profileName, previousColor);
-						return previousColor;
+					if (skyblockLevel >= nextLevelBracket) {
+						levelColour = valueByName;
 					}
-					previousColor = valueByName;
 				}
 			} catch (RuntimeException ignored) {
 				// catch both numberformat and getValueByName being wrong
 			}
-			skyBlockExperienceColour.put(profileName, EnumChatFormatting.WHITE);
-			return EnumChatFormatting.WHITE;
+			skyBlockExperienceColour.put(profileName, levelColour);
+			return levelColour;
 		}
 
 		public double getSkyblockLevel(String profileName) {


### PR DESCRIPTION
Previous level colour logic assumed the player's level would always be less than a level from the sblevel constants, however that isn't the case with DeathStreeks, so the new logic only updates the colour if the player level is higher than the level in the iteration.

Fixes #636 

![image](https://user-images.githubusercontent.com/52578495/221721643-6a6c3ad8-0fd1-451b-abc2-162cddcb698f.png)
