### PR TITLE
fixed calculation of average crops gained/minute

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/FarmingSkillOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/FarmingSkillOverlay.java
@@ -286,7 +286,8 @@ public class FarmingSkillOverlay extends TextOverlay {
 			int last = counterQueue.getLast();
 			int first = counterQueue.getFirst();
 
-			cropsPerSecond = (first - last) / 3f;
+			// correct once counterQueue.size() == 3
+			cropsPerSecond = (first - last) / 2f;
 		}
 
 		if (counter != -1) {


### PR DESCRIPTION
Current calculation for `cropsPerSecond ` (crops/m) on the farming overlay was incorrect. `counterQueue` can only store up to 3 values, so taking the difference of `first` and `last` actually represents the amount of crops collected over the last 2 seconds, so we must divide by 2.