### PR TITLE
Fix champion showing -1 on combat overlay if you dont have it

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/CombatSkillOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/CombatSkillOverlay.java
@@ -245,7 +245,7 @@ public class CombatSkillOverlay
 				lineMap.put(0, EnumChatFormatting.AQUA + "Kills: " + EnumChatFormatting.YELLOW + format.format(counterInterp));
 			}
 
-			if (championTier <= 9) {
+			if (championTier <= 9 && championXp >= 0) {
 				int counterInterp = (int) interp(championXp, championXpLast);
 				lineMap.put(
 					6,


### PR DESCRIPTION
https://cdn.discordapp.com/attachments/780181693553704973/1081529372990767114/43BCBD34-56B7-485C-8606-326AC9F217C4.jpg