### PR TITLE
Fixes NPE when exiting the Matriarch

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
@@ -944,7 +944,7 @@ public class TimersOverlay extends TextTabOverlay {
 	}
 
 	public static void processActionBar(String msg) {
-		if (SBInfo.getInstance().location.equals("Belly of the Beast")) {
+		if (SBInfo.getInstance().location.equals("Belly of the Beast") && msg.contains("Pearls Collected")) {
 			try {
 				msg = Utils.cleanColour(msg);
 				msg = msg.substring(msg.indexOf("Pearls Collected: ") + 18);


### PR DESCRIPTION
Resolves #454 I guess, the crash for #454 was actually fixed the same day by Cobble but it still gave npe in logs, so this fixes that