### PR TITLE
Profit per RNGMeter fixes

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/core/util/StringUtils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/core/util/StringUtils.java
@@ -85,7 +85,8 @@ public class StringUtils {
 	}
 
 	public static String shortNumberFormat(double n, int iteration) {
-		if (n < 1000 && n > -1000) {
+		if (n < 0) return "-" + shortNumberFormat(-n, iteration);
+		if (n < 1000) {
 			if (n % 1 == 0) {
 				return Integer.toString((int) n);
 			} else {
@@ -95,7 +96,7 @@ public class StringUtils {
 
 		double d = ((long) n / 100) / 10.0;
 		boolean isRound = (d * 10) % 10 == 0;
-		return (d < 1000 && d > -1000) ? (isRound || (d > 9.99 || d < -9.99) ? (int) d * 10 / 10 : d + "") + "" + sizeSuffix[iteration] : shortNumberFormat(d, iteration + 1);
+		return d < 1000 ? (isRound || d > 9.99 ? (int) d * 10 / 10 : d + "") + "" + sizeSuffix[iteration] : shortNumberFormat(d, iteration + 1);
 	}
 
 	public static String urlEncode(String something) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/core/util/StringUtils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/core/util/StringUtils.java
@@ -85,7 +85,7 @@ public class StringUtils {
 	}
 
 	public static String shortNumberFormat(double n, int iteration) {
-		if (n < 1000) {
+		if (n < 1000 && n > -1000) {
 			if (n % 1 == 0) {
 				return Integer.toString((int) n);
 			} else {
@@ -95,7 +95,7 @@ public class StringUtils {
 
 		double d = ((long) n / 100) / 10.0;
 		boolean isRound = (d * 10) % 10 == 0;
-		return d < 1000 ? (isRound || d > 9.99 ? (int) d * 10 / 10 : d + "") + "" + sizeSuffix[iteration] : shortNumberFormat(d, iteration + 1);
+		return (d < 1000 && d > -1000) ? (isRound || (d > 9.99 || d < -9.99) ? (int) d * 10 / 10 : d + "") + "" + sizeSuffix[iteration] : shortNumberFormat(d, iteration + 1);
 	}
 
 	public static String urlEncode(String something) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/ItemTooltipRngListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/ItemTooltipRngListener.java
@@ -346,8 +346,9 @@ public class ItemTooltipRngListener {
 			Matcher amountMatcher = TIER_AMOUNT.matcher(line);
 			if (amountMatcher.matches()) {
 				try {
-					// group(2) will get the lower bound of number of drops that is dropped from each of the tiers (i.e. if "2 to 4" we get 2)
-					tierToAmount.put(Utils.parseRomanNumeral(amountMatcher.group(1)), Integer.valueOf(amountMatcher.group(2)));
+					int tier = Utils.parseRomanNumeral(amountMatcher.group(1));
+					int lowerBoundDrop = Integer.parseInt(amountMatcher.group(2));
+					tierToAmount.put(tier, lowerBoundDrop);
 				} catch (NumberFormatException e) {
 					e.printStackTrace();
 				}

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/ItemTooltipRngListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/ItemTooltipRngListener.java
@@ -31,12 +31,14 @@ import io.github.moulberry.notenoughupdates.util.ItemResolutionQuery;
 import io.github.moulberry.notenoughupdates.util.ItemUtils;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.lwjgl.input.Keyboard;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +60,8 @@ public class ItemTooltipRngListener {
 	private final Pattern RUNS_SELECTED_PATTERN = Pattern.compile("§5§o§d-(.+)- §d(.*)§5/§d(.+)");
 
 	private final Pattern SLAYER_INVENTORY_TITLE_PATTERN = Pattern.compile("(.+) RNG Meter");
+
+	private final Pattern TIER_AMOUNT = Pattern.compile("§5§o§7Tier (.+) amount: §a(\\d+).*");
 
 	private final Map<String, Integer> dungeonData = new LinkedHashMap<>();
 	private final Map<String, LinkedHashMap<String, Integer>> slayerData = new LinkedHashMap<>();
@@ -115,7 +119,7 @@ public class ItemTooltipRngListener {
 					if (NotEnoughUpdates.INSTANCE.config.tooltipTweaks.rngMeterProfitPerUnit) {
 						if (!NotEnoughUpdates.INSTANCE.config.tooltipTweaks.rngMeterRunsNeeded) {
 							String name = Utils.getOpenChestName().contains("Catacombs") ? "Score" : "XP";
-							String formatCoinsPer = getFormatCoinsPer(event.itemStack, needed, 1, name);
+							String formatCoinsPer = getFormatCoinsPer(event.itemStack, needed, 1, 1, 0, name);
 							if (formatCoinsPer != null) {
 								newToolTip.add(line);
 								newToolTip.add(formatCoinsPer);
@@ -137,18 +141,19 @@ public class ItemTooltipRngListener {
 		event.toolTip.addAll(newToolTip);
 	}
 
-	private String getFormatCoinsPer(ItemStack stack, int needed, int multiplier, String label) {
+	private String getFormatCoinsPer(ItemStack stack, int needed, int multiplier, int amountPerTier, int cost, String label) {
 		String internalName = neu.manager.createItemResolutionQuery().withItemStack(stack).resolveInternalName();
-		double profit = neu.manager.auctionManager.getBazaarOrBin(internalName, false);
+		double profit = neu.manager.auctionManager.getBazaarOrBin(internalName, false) * amountPerTier;
 		if (profit <= 0) return null;
 
 		//ask hypixel nicely to release a 'chest price api' with 4 dimensions for us. the 4 dimensions needed are: item name, floor, normal/mm, s/s+
 //		double chestPrice = grabChestPrice(stack, internalName);
 //		profit -= chestPrice;
 
-		double coinsPer = (profit / needed) * multiplier;
+		double coinsPer = ((profit / needed) * multiplier) - cost;
 		String format = StringUtils.shortNumberFormat(coinsPer);
-		return "§7Coins per " + label + ": §6" + format + " coins";
+		EnumChatFormatting profitIndicator = coinsPer >= 0 ? EnumChatFormatting.GREEN : EnumChatFormatting.RED;
+		return "§7Coins per " + label + ": " + profitIndicator + format + " coins";
 	}
 
 	private void fractionDisplay(List<String> newToolTip, String line) {
@@ -311,8 +316,18 @@ public class ItemTooltipRngListener {
 		toolTip.add(
 			"   §7" + labelPlural + " completed: §e" + runsHavingFormat + " §7(of §e" + runsNeededFormat + " §7needed)");
 
+		int amountPerTier = parseAmountFromTooltip(toolTip);
+
+		int cost = 0;
+		if (repoCategory.equals("slayer")) {
+			JsonObject slayerCost = Constants.MISC;
+			if (slayerCost.has("slayer_cost")) {
+				cost = slayerCost.getAsJsonArray("slayer_cost").get(currentSelected).getAsInt();
+			}
+		}
+
 		if (NotEnoughUpdates.INSTANCE.config.tooltipTweaks.rngMeterProfitPerUnit) {
-			String formatCoinsPer = getFormatCoinsPer(stack, needed, gainPerRun, labelSingular);
+			String formatCoinsPer = getFormatCoinsPer(stack, needed, gainPerRun, amountPerTier, cost, labelSingular);
 			if (formatCoinsPer != null) {
 				toolTip.add("   " + formatCoinsPer);
 			}
@@ -322,6 +337,24 @@ public class ItemTooltipRngListener {
 		if (progressString != null) {
 			toolTip.add(progressString);
 		}
+	}
+
+	private int parseAmountFromTooltip(List<String> tooltip) {
+		Map<Integer, Integer> tierToAmount = new HashMap<>();
+
+		for (String line : tooltip) {
+			Matcher amountMatcher = TIER_AMOUNT.matcher(line);
+			if (amountMatcher.matches()) {
+				try {
+					// group(2) will get the lower bound of number of drops that is dropped from each of the tiers (i.e. if "2 to 4" we get 2)
+					tierToAmount.put(Utils.parseRomanNumeral(amountMatcher.group(1)), Integer.valueOf(amountMatcher.group(2)));
+				} catch (NumberFormatException e) {
+					e.printStackTrace();
+				}
+			}
+		}
+
+		return tierToAmount.get(currentSelected + 1) == null ? 1 : tierToAmount.get(currentSelected + 1);
 	}
 
 	private int getRepoScore(ItemStack stack, String repoCategory) {


### PR DESCRIPTION
Mostly resolves #456 and #457, the slayer cost is now accounted for and the amount of loot that rng drops at each tier. Cost of dungeon chests haven't been included since there is a lot of variation of chest cost depending on the items in it.

Turns out every single slayer drop is a loss other than a Judgement Core. (obviously this feature doesn't take into account any other drops other than the RNG itself) 👍 

shortNumberFormat function also updated to work with negative numbers