### PR TITLE
Make ApiUtil accept gzip encoding

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
@@ -69,12 +69,14 @@ public class ApiUtil {
 		.thenComparing(NameValuePair::getValue);
 
 	private static final ExecutorService executorService = Executors.newFixedThreadPool(3);
+
 	private static String getUserAgent() {
 		if (NotEnoughUpdates.INSTANCE.config.hidden.customUserAgent != null) {
 			return NotEnoughUpdates.INSTANCE.config.hidden.customUserAgent;
 		}
 		return "NotEnoughUpdates/" + NotEnoughUpdates.VERSION;
 	}
+
 	private static SSLContext ctx;
 	private final Map<String, CompletableFuture<Void>> updateTasks = new HashMap<>();
 
@@ -207,7 +209,9 @@ public class ApiUtil {
 						if (this.postContentType != null) {
 							conn.setRequestProperty("Content-Type", this.postContentType);
 						}
-						conn.setRequestProperty("Accept-Encoding", "gzip"); // Tell the server we can accept gzip
+						if (!shouldGunzip) {
+							conn.setRequestProperty("Accept-Encoding", "gzip"); // Tell the server we can accept gzip
+						}
 						if (this.postData != null) {
 							conn.setDoOutput(true);
 							OutputStream os = conn.getOutputStream();

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
@@ -207,6 +207,7 @@ public class ApiUtil {
 						if (this.postContentType != null) {
 							conn.setRequestProperty("Content-Type", this.postContentType);
 						}
+						conn.setRequestProperty("Accept-Encoding", "gzip"); // Tell the server we can accept gzip
 						if (this.postData != null) {
 							conn.setDoOutput(true);
 							OutputStream os = conn.getOutputStream();
@@ -219,7 +220,7 @@ public class ApiUtil {
 
 						inputStream = conn.getInputStream();
 
-						if (shouldGunzip) {
+						if (shouldGunzip || conn.getContentEncoding().equals("gzip")) {
 							inputStream = new GZIPInputStream(inputStream);
 						}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
@@ -220,7 +220,7 @@ public class ApiUtil {
 
 						inputStream = conn.getInputStream();
 
-						if (shouldGunzip || conn.getContentEncoding().equals("gzip")) {
+						if (shouldGunzip || "gzip".equals(conn.getContentEncoding())) {
 							inputStream = new GZIPInputStream(inputStream);
 						}
 


### PR DESCRIPTION
Tell the server we support gzip encoding, so they can send gzipped data instead of raw data.
Can speed up things like fetching bazaar prices and pv on slow connections since hypixel will send gzipped data if we say we accept it.