### PR TITLE
Scoreboard Parse Fix

### DIFF
--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/util/SidebarUtil.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/util/SidebarUtil.kt
@@ -38,7 +38,7 @@ object SidebarUtil {
     }
 
     private fun cleanSB(scoreboard: String) =
-        scoreboard.toCharArray().filter { it.code in 21..126 || it.code == 167 }.joinToString(separator = "")
+        scoreboard.toCharArray().filter { it.code in 21..126 || it.code == 167 || it.code == 9187 }.joinToString(separator = "")
 
     private fun fetchScoreboardLines(): List<String> {
         val scoreboard = Minecraft.getMinecraft().theWorld?.scoreboard ?: return emptyList()


### PR DESCRIPTION
Cobble's SidebarUtil.kt file cleans every line in the scoreboard to only keep the basic characters, in which removes symbols such as ⏣ which is used in [this line](https://github.com/NotEnoughUpdates/NotEnoughUpdates/blob/100ec81fc2f2af8f19cf034e2130ca7ba2661d4e/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java#L431) so the condition never resolved to true, effectively breaking the location tracking, and so everything that relied on querying `SBInfo.getInstance().getScoreboardLocation()` would be returning an empty string. Which was what broke the Frozen Treasure Highlighter feature since it needed to know the player was in the Glacial Cave.

My fix was just to add the ⏣ symbol to the filter in the `cleanSB` function, I'm not entirely sure this is the best fix since I think other symbols in the scoreboard are checked, but for now this should fix features relying on knowing the location of the player.