### PR TITLE
Metal detector solution speed improvements

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CrystalMetalDetectorSolver.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CrystalMetalDetectorSolver.java
@@ -155,7 +155,7 @@ public class CrystalMetalDetectorSolver {
 				return;
 			}
 
-			chestLastFoundMillis = 0;
+			chestLastFoundMillis = System.currentTimeMillis();
 			chestRecentlyFound = false;
 		}
 
@@ -204,7 +204,8 @@ public class CrystalMetalDetectorSolver {
 	}
 
 	static void findPossibleSolutions(double distToTreasure, Vec3Comparable playerPos, boolean centerNewlyDiscovered) {
-		if (prevDistToTreasure == distToTreasure && prevPlayerPos.equals(playerPos) &&
+		if (Math.abs(prevDistToTreasure - distToTreasure) < 0.2 &&
+			prevPlayerPos.distanceTo(playerPos) <= 0.1 &&
 			!evaluatedPlayerPositions.containsKey(playerPos)) {
 			evaluatedPlayerPositions.put(playerPos, distToTreasure);
 			if (possibleBlocks.size() == 0) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CrystalMetalDetectorSolver.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CrystalMetalDetectorSolver.java
@@ -148,14 +148,8 @@ public class CrystalMetalDetectorSolver {
 		// Delay to keep old chest location from being treated as the new chest location
 		if (chestRecentlyFound) {
 			long currentTimeMillis = System.currentTimeMillis();
-			if (chestLastFoundMillis == 0) {
-				chestLastFoundMillis = currentTimeMillis;
-				return;
-			} else if (currentTimeMillis - chestLastFoundMillis < 1000 && distToTreasure < 5.0) {
-				return;
-			}
-
-			chestLastFoundMillis = System.currentTimeMillis();
+			if (currentTimeMillis - chestLastFoundMillis < 1000 && distToTreasure < 5.0) return;
+			chestLastFoundMillis = currentTimeMillis;
 			chestRecentlyFound = false;
 		}
 


### PR DESCRIPTION
- Set chest last found to the current time rather than 0 after a chest is recently found. This improves response time significantly by only requiring 2 action bar updates after a chest is found, rather than 3.

- Allow +/- 0.1 meter offset in action bar distance and in actual player position. This doesn't seem to affect the reliability of the solver and means that small residual velocity doesn't force the player to wait for another action bar update.

