### PR TITLE
Only render active overlays in location editor

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -646,6 +646,11 @@ public class PetInfoOverlay extends TextOverlay {
 				}
 			}
 		}};
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return NotEnoughUpdates.INSTANCE.config.petOverlay.enablePetInfo;
 	}
 
 	public void update() {

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -69,7 +69,6 @@ import io.github.moulberry.notenoughupdates.options.seperateSections.Toolbar;
 import io.github.moulberry.notenoughupdates.options.seperateSections.TooltipTweaks;
 import io.github.moulberry.notenoughupdates.options.seperateSections.TradeMenu;
 import io.github.moulberry.notenoughupdates.options.seperateSections.WardrobeKeybinds;
-import io.github.moulberry.notenoughupdates.options.seperateSections.WorldConfig;
 import io.github.moulberry.notenoughupdates.overlays.MiningOverlay;
 import io.github.moulberry.notenoughupdates.overlays.OverlayManager;
 import io.github.moulberry.notenoughupdates.overlays.TextOverlay;
@@ -96,10 +95,7 @@ public class NEUConfig extends Config {
 		}
 		GuiScreen savedGui = Minecraft.getMinecraft().currentScreen;
 		Minecraft.getMinecraft().displayGuiScreen(new GuiPositionEditor(overlayPositions, () -> {
-		}, () -> {
-		}, () -> {
-			NotEnoughUpdates.INSTANCE.openGui = savedGui;
-		}));
+		}, () -> NotEnoughUpdates.INSTANCE.openGui = savedGui));
 	}
 
 	@Override

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/BonemerangOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/BonemerangOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -55,6 +55,11 @@ public class BonemerangOverlay extends TextOverlay {
 	public final Set<EntityLivingBase> bonemeragedEntities = new HashSet<>();
 
 	@Override
+	public boolean isEnabled() {
+		return NotEnoughUpdates.INSTANCE.config.itemOverlays.enableBonemerangOverlay;
+	}
+
+	@Override
 	public void updateFrequent() {
 		if (NotEnoughUpdates.INSTANCE.config.itemOverlays.bonemerangFastUpdate) {
 			updateOverlay();
@@ -69,7 +74,7 @@ public class BonemerangOverlay extends TextOverlay {
 	}
 
 	private void updateOverlay() {
-		if (!NotEnoughUpdates.INSTANCE.config.itemOverlays.enableBonemerangOverlay &&
+		if (!isEnabled() &&
 			NotEnoughUpdates.INSTANCE.config.itemOverlays.highlightTargeted) {
 			overlayStrings = null;
 			return;

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/CombatSkillOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/CombatSkillOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -79,8 +79,13 @@ public class CombatSkillOverlay
 	}
 
 	@Override
+	public boolean isEnabled() {
+		return NotEnoughUpdates.INSTANCE.config.skillOverlays.combatSkillOverlay;
+	}
+
+	@Override
 	public void update() {
-		if (!NotEnoughUpdates.INSTANCE.config.skillOverlays.combatSkillOverlay) {
+		if (!isEnabled()) {
 			kill = -1;
 			championXp = -1;
 			overlayStrings = null;

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/CrystalHollowOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/CrystalHollowOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -129,9 +129,14 @@ public class CrystalHollowOverlay extends TextOverlay {
 	}
 
 	@Override
+	public boolean isEnabled() {
+		return NotEnoughUpdates.INSTANCE.config.mining.crystalHollowOverlay;
+	}
+
+	@Override
 	public void update() {
 		overlayStrings = null;
-		if (!NotEnoughUpdates.INSTANCE.config.mining.crystalHollowOverlay || SBInfo.getInstance().getLocation() == null ||
+		if (!isEnabled() || SBInfo.getInstance().getLocation() == null ||
 			!SBInfo.getInstance().getLocation().equals("crystal_hollows"))
 			return;
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/FarmingSkillOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/FarmingSkillOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -132,8 +132,13 @@ public class FarmingSkillOverlay extends TextOverlay {
 	private static ArrayList<Float> cropsOverLastXSeconds = new ArrayList<>();
 
 	@Override
+	public boolean isEnabled() {
+		return NotEnoughUpdates.INSTANCE.config.skillOverlays.farmingOverlay;
+	}
+
+	@Override
 	public void update() {
-		if (!NotEnoughUpdates.INSTANCE.config.skillOverlays.farmingOverlay) {
+		if (!isEnabled()) {
 			counter = -1;
 			overlayStrings = null;
 			return;

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/FishingSkillOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/FishingSkillOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -86,8 +86,14 @@ public class FishingSkillOverlay
 	}
 
 	@Override
+	public boolean isEnabled() {
+		// NopoTheGamer named this variable
+		return NotEnoughUpdates.INSTANCE.config.skillOverlays.FishingSkillOverlay;
+	}
+
+	@Override
 	public void update() {
-		if (!NotEnoughUpdates.INSTANCE.config.skillOverlays.FishingSkillOverlay) {
+		if (!isEnabled()) {
 			expertise = -1;
 			overlayStrings = null;
 			return;

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/FuelBarDummy.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/FuelBarDummy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -21,6 +21,7 @@ package io.github.moulberry.notenoughupdates.overlays;
 
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.core.config.Position;
+import io.github.moulberry.notenoughupdates.core.config.gui.GuiPositionEditor;
 import org.lwjgl.util.vector.Vector2f;
 
 import java.util.List;
@@ -33,13 +34,19 @@ public class FuelBarDummy extends TextOverlay {
 		Supplier<TextOverlayStyle> styleSupplier
 	) {
 		super(position, dummyStrings, styleSupplier);
-		super.shouldRenderInGuiEditor = false;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		GuiPositionEditor.renderDrill = NotEnoughUpdates.INSTANCE.config.mining.drillFuelBar;
+		return NotEnoughUpdates.INSTANCE.config.mining.drillFuelBar;
 	}
 
 	@Override
 	public void update() {
 
 	}
+
 	@Override
 	public Vector2f getDummySize() {
 		return new Vector2f(NotEnoughUpdates.INSTANCE.config.mining.drillFuelBarWidth, 12);

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -231,6 +231,11 @@ public class MiningOverlay extends TextTabOverlay {
 		".*[1-5]\\) (?<ItemName>.*): ((?<Ready>Ready!)|(((?<days>[0-9]+)d)? ?((?<hours>[0-9]+)h)? ?((?<minutes>[0-9]+)m)? ?((?<seconds>[0-9]+)s)?))");
 	private static final Pattern forgesHeaderPattern = Pattern.compile(
 		"\\xa7r\\xa79\\xa7lForges \\xa7r(?:\\xa7f\\(\\+1 more\\)\\xa7r)?");
+
+	@Override
+	public boolean isEnabled() {
+		return NotEnoughUpdates.INSTANCE.config.mining.dwarvenOverlay;
+	}
 
 	@Override
 	public void update() {

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningSkillOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningSkillOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -79,8 +79,13 @@ public class MiningSkillOverlay
 	}
 
 	@Override
+	public boolean isEnabled() {
+		return NotEnoughUpdates.INSTANCE.config.skillOverlays.miningSkillOverlay;
+	}
+
+	@Override
 	public void update() {
-		if (!NotEnoughUpdates.INSTANCE.config.skillOverlays.miningSkillOverlay) {
+		if (!isEnabled()) {
 			compact = -1;
 			overlayStrings = null;
 			return;

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/PowderGrindingOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/PowderGrindingOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -77,8 +77,13 @@ public class PowderGrindingOverlay extends TextTabOverlay {
 	}
 
 	@Override
+	public boolean isEnabled() {
+		return NotEnoughUpdates.INSTANCE.config.mining.powderGrindingTrackerEnabled;
+	}
+
+	@Override
 	public void update() {
-		if (NotEnoughUpdates.INSTANCE.config.mining.powderGrindingTrackerEnabled) {
+		if (isEnabled()) {
 			lastUpdate = System.currentTimeMillis();
 			lastMithrilPowderFound = this.mithrilPowderFound;
 			lastMithrilPowderAverage = this.openedChestCount > 0 ?

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -106,9 +106,14 @@ public class SlayerOverlay extends TextOverlay {
 	}
 
 	@Override
+	public boolean isEnabled() {
+		return NotEnoughUpdates.INSTANCE.config.slayerOverlay.slayerOverlay;
+	}
+
+	@Override
 	public void update() {
 		shouldUpdate = shouldUpdate();
-		if (!NotEnoughUpdates.INSTANCE.config.slayerOverlay.slayerOverlay || !shouldUpdate) {
+		if (!isEnabled() || !shouldUpdate) {
 			overlayStrings = null;
 			return;
 		}

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/TextOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/TextOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -44,8 +44,6 @@ public abstract class TextOverlay {
 
 	public boolean shouldUpdateFrequent = false;
 
-	public boolean shouldRenderInGuiEditor = true;
-
 	private static final int PADDING_X = 5;
 	private static final int PADDING_Y = 5;
 
@@ -66,6 +64,10 @@ public abstract class TextOverlay {
 			return getSize(dummyStrings);
 		}
 		return new Vector2f(100, 50);
+	}
+
+	public boolean isEnabled() {
+		return true;
 	}
 
 	public void tick() {

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -242,6 +242,11 @@ public class TimersOverlay extends TextTabOverlay {
 	}
 
 	boolean hasErrorMessage = false;
+
+	@Override
+	public boolean isEnabled() {
+		return NotEnoughUpdates.INSTANCE.config.miscOverlays.todoOverlay2;
+	}
 
 	@Override
 	public void update() {


### PR DESCRIPTION
Checks if the overlay is actually enabled in the config before rendering it in the location editor.

closes #670