### PR TITLE
NEUConfig: Add manadatory IQ test to api tab

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
@@ -30,6 +30,7 @@ import io.github.moulberry.notenoughupdates.core.config.annotations.Category;
 import io.github.moulberry.notenoughupdates.core.config.gui.GuiPositionEditor;
 import io.github.moulberry.notenoughupdates.dungeons.GuiDungeonMapEditor;
 import io.github.moulberry.notenoughupdates.miscfeatures.FairySouls;
+import io.github.moulberry.notenoughupdates.miscfeatures.IQTest;
 import io.github.moulberry.notenoughupdates.miscgui.GuiEnchantColour;
 import io.github.moulberry.notenoughupdates.miscgui.GuiInvButtonEditor;
 import io.github.moulberry.notenoughupdates.miscgui.NEUOverlayPlacements;
@@ -172,6 +173,9 @@ public class NEUConfig extends Config {
 				return;
 			case 26:
 				OverlayManager.powderGrindingOverlay.reset();
+				return;
+			case 27:
+				IQTest.testIQ();
 				return;
 			default:
 				System.err.printf("Unknown runnableId = %d in category %s%n", runnableId, activeConfigCategory);

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfigEditor.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfigEditor.java
@@ -32,6 +32,7 @@ import io.github.moulberry.notenoughupdates.core.util.lerp.LerpUtils;
 import io.github.moulberry.notenoughupdates.core.util.lerp.LerpingInteger;
 import io.github.moulberry.notenoughupdates.core.util.render.RenderUtils;
 import io.github.moulberry.notenoughupdates.core.util.render.TextRenderUtils;
+import io.github.moulberry.notenoughupdates.miscfeatures.IQTest;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
@@ -120,14 +121,14 @@ public class NEUConfigEditor extends GuiElement {
 		if (categoryOpen != null) {
 			for (Map.Entry<String, ConfigProcessor.ProcessedCategory> category : processedConfig.entrySet()) {
 				if (category.getValue().name.equalsIgnoreCase(categoryOpen)) {
-					selectedCategory = category.getKey();
+					setSelectedCategory(category.getKey());
 					break;
 				}
 			}
 			if (selectedCategory == null) {
 				for (Map.Entry<String, ConfigProcessor.ProcessedCategory> category : processedConfig.entrySet()) {
 					if (category.getValue().name.toLowerCase().startsWith(categoryOpen.toLowerCase())) {
-						selectedCategory = category.getKey();
+						setSelectedCategory(category.getKey());
 						break;
 					}
 				}
@@ -135,7 +136,7 @@ public class NEUConfigEditor extends GuiElement {
 			if (selectedCategory == null) {
 				for (Map.Entry<String, ConfigProcessor.ProcessedCategory> category : processedConfig.entrySet()) {
 					if (category.getValue().name.toLowerCase().contains(categoryOpen.toLowerCase())) {
-						selectedCategory = category.getKey();
+						setSelectedCategory(category.getKey());
 						break;
 					}
 				}
@@ -152,6 +153,9 @@ public class NEUConfigEditor extends GuiElement {
 	}
 
 	private LinkedHashMap<String, ConfigProcessor.ProcessedOption> getOptionsInCategory(ConfigProcessor.ProcessedCategory cat) {
+		if (cat.options.containsKey("apiDataUnlocked") && !NotEnoughUpdates.INSTANCE.config.apiData.apiDataUnlocked) {
+			return IQTest.getOptions();
+		}
 		LinkedHashMap<String, ConfigProcessor.ProcessedOption> newMap = new LinkedHashMap<>(cat.options);
 
 		if (searchedOptions != null) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/ApiData.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/ApiData.java
@@ -28,6 +28,15 @@ import io.github.moulberry.notenoughupdates.core.config.annotations.ConfigEditor
 import io.github.moulberry.notenoughupdates.core.config.annotations.ConfigOption;
 
 public class ApiData {
+
+	@Expose
+	@ConfigOption(
+		name = "Unlock the API data tab",
+		desc = "If you turn this off, you will need to re-do the IQ test"
+	)
+	@ConfigEditorBoolean
+	public boolean apiDataUnlocked = false;
+
 	@Expose
 	@ConfigOption(
 		name = "Api Key",

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/IQTest.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/IQTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2023 NotEnoughUpdates contributors
+ *
+ * This file is part of NotEnoughUpdates.
+ *
+ * NotEnoughUpdates is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * NotEnoughUpdates is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.moulberry.notenoughupdates.miscfeatures
+
+import io.github.moulberry.notenoughupdates.NotEnoughUpdates
+import io.github.moulberry.notenoughupdates.core.config.gui.GuiOptionEditorButton
+import io.github.moulberry.notenoughupdates.core.config.gui.GuiOptionEditorFSR
+import io.github.moulberry.notenoughupdates.core.config.gui.GuiOptionEditorText
+import io.github.moulberry.notenoughupdates.core.config.struct.ConfigProcessor.ProcessedOption
+import io.github.moulberry.notenoughupdates.util.Calculator
+import io.github.moulberry.notenoughupdates.util.Calculator.CalculatorException
+import java.math.BigDecimal
+import kotlin.random.Random
+
+object IQTest {
+    fun randOperator() = listOf("+", "*").random()
+    fun randNum() = Random.nextInt(1, 20)
+    val question = "${randNum()} ${randOperator()} ${randNum()} ${randOperator()} ${randNum()}"
+
+    @JvmStatic
+    fun testIQ() {
+        val testedAnswer = try {
+            Calculator.calculate(answer)
+        } catch (e: CalculatorException) {
+            wrongAnswer()
+            return
+        }
+        val realAnswer = Calculator.calculate(question)
+        if (testedAnswer.subtract(realAnswer).abs() < BigDecimal.valueOf(0.1)) {
+            NotEnoughUpdates.INSTANCE.config.apiData.apiDataUnlocked = true
+            lastAnsweredTimestamp = 0L
+        } else {
+            wrongAnswer()
+        }
+    }
+
+    private fun wrongAnswer() {
+        lastAnsweredTimestamp = System.currentTimeMillis()
+    }
+
+    var lastAnsweredTimestamp = 0L
+
+    @JvmField
+    @Suppress("UNUSED")
+    var buttonPlaceHolder = false
+
+    @JvmField
+    var answer = ""
+
+    val answerOption = ProcessedOption(
+        "IQ Test Question",
+        "Please type out the answer to §a$question",
+        -1,
+        javaClass.getField("answer"),
+        this,
+        arrayOf()
+    ).also {
+        it.editor = GuiOptionEditorText(it)
+    }
+    val warningOption = ProcessedOption(
+        "§4§lWARNING",
+        "§4§lThis page is dangerous. Please make sure you know what you are doing!",
+        -1,
+        javaClass.getField("buttonPlaceHolder"),
+        this,
+        arrayOf()
+    ).also {
+        it.editor = GuiOptionEditorButton(it, 27, "SUBMIT", NotEnoughUpdates.INSTANCE.config)
+    }
+    val wrongOption = ProcessedOption(
+        "§4Wrong Answer",
+        "§4Please think twice before accessing it.",
+        -1,
+        javaClass.getField("buttonPlaceHolder"),
+        this,
+        arrayOf()
+    ).also {
+        it.editor = GuiOptionEditorFSR(it, -1, "", NotEnoughUpdates.INSTANCE.config)
+    }
+
+
+    @get:JvmStatic
+    val options
+        get() = LinkedHashMap<String, ProcessedOption>().also {
+            it["iqTestAnswer"] = answerOption
+            it["iqTestSubmit"] = warningOption
+
+            if (System.currentTimeMillis() - lastAnsweredTimestamp < 10_000L) {
+                it["iqTestWrong"] = wrongOption
+            }
+        }
+}


### PR DESCRIPTION
Since time and time again people are changing options that should not be changed, I added this "IQ test" as an inhibitor that makes it impossible for people to just click through warnings (like the one on the moulberry api). For easy bypassing (and for people who need things changed in support), you can just type in the question into the answer field, since the answer field will get evaluated as a math expression.