### PR TITLE
Add museum donation status to tooltip

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/ItemPriceInformation.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/ItemPriceInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -24,6 +24,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.github.moulberry.notenoughupdates.auction.APIManager;
 import io.github.moulberry.notenoughupdates.core.config.KeybindHelper;
+import io.github.moulberry.notenoughupdates.miscfeatures.inventory.MuseumTooltipManager;
 import io.github.moulberry.notenoughupdates.util.Constants;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import io.github.moulberry.notenoughupdates.util.hypixelapi.HypixelItemAPI;
@@ -462,6 +463,17 @@ public class ItemPriceInformation {
 			if (!added)
 				tooltip.add("");
 			tooltip.add(formatPrice("NPC Sell Price: ", npcSellPrice * stackMultiplier));
+		}
+
+		if (NotEnoughUpdates.INSTANCE.config.tooltipTweaks.museumDonationStatus) {
+			if (!MuseumTooltipManager.INSTANCE.hasPlayerVisitedMuseum()) {
+				tooltip.add(EnumChatFormatting.RED + EnumChatFormatting.BOLD.toString() +
+					"[NEU] Visit your Museum to display donation status");
+			}
+			if (MuseumTooltipManager.INSTANCE.isItemDonated(internalname)) {
+				tooltip.add(
+					EnumChatFormatting.YELLOW + "Item already donated to museum");
+			}
 		}
 	}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/TooltipTweaks.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/TooltipTweaks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -101,6 +101,15 @@ public class TooltipTweaks {
 	@ConfigEditorBoolean
 	@ConfigAccordionId(id = 0)
 	public boolean npcSellPrice = false;
+
+	@Expose
+	@ConfigOption(
+		name = "Display donation status",
+		desc = "Add an extra line on items you have already donated to the museum. Visit all pages of the museum to populate this list."
+	)
+	@ConfigEditorBoolean
+	@ConfigAccordionId(id = 0)
+	public boolean museumDonationStatus = true;
 
 	@Expose
 	@ConfigOption(

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/inventory/MuseumItemHighlighter.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/inventory/MuseumItemHighlighter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Linnea Gräf
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -26,14 +26,13 @@ import io.github.moulberry.notenoughupdates.core.util.StringUtils
 import io.github.moulberry.notenoughupdates.events.GuiContainerBackgroundDrawnEvent
 import io.github.moulberry.notenoughupdates.events.ReplaceItemEvent
 import io.github.moulberry.notenoughupdates.events.RepositoryReloadEvent
-import io.github.moulberry.notenoughupdates.util.ItemResolutionQuery
 import io.github.moulberry.notenoughupdates.util.ItemUtils
 import io.github.moulberry.notenoughupdates.util.LRUCache
 import io.github.moulberry.notenoughupdates.util.MuseumUtil
+import io.github.moulberry.notenoughupdates.util.MuseumUtil.isMuseumInventory
 import net.minecraft.client.gui.Gui
 import net.minecraft.init.Items
 import net.minecraft.inventory.ContainerChest
-import net.minecraft.inventory.IInventory
 import net.minecraft.item.EnumDyeColor
 import net.minecraft.item.ItemStack
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -74,10 +73,6 @@ object MuseumItemHighlighter {
 
     fun isCompletedRetrievedItem(itemStack: ItemStack): Boolean {
         return itemStack.hasDisplayName() && itemStack.item == Items.dye && EnumDyeColor.byDyeDamage(itemStack.itemDamage) == EnumDyeColor.LIME
-    }
-
-    fun isMuseumInventory(inventory: IInventory): Boolean {
-        return StringUtils.cleanColour(inventory.displayName.unformattedText).startsWith("Museum ➜")
     }
 
     @SubscribeEvent

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/inventory/MuseumTooltipManager.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/inventory/MuseumTooltipManager.kt
@@ -38,7 +38,7 @@ object MuseumTooltipManager {
 
     @KSerializable
     data class MuseumData(
-        val profiles: HashMap<String, ProfileSpecificMuseumData>
+        val profiles: MutableMap<String, ProfileSpecificMuseumData> = mutableMapOf()
     )
 
     @KSerializable
@@ -48,7 +48,7 @@ object MuseumTooltipManager {
     )
 
     private val loadedMuseumDataDelegate = lazy {
-        var data = MuseumData(hashMapOf())
+        var data = MuseumData()
         if (file.exists()) {
             val content = file.readText()
             data = Gson().fromJson(content, MuseumData::class.java)

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/inventory/MuseumTooltipManager.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/inventory/MuseumTooltipManager.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2023 NotEnoughUpdates contributors
+ *
+ * This file is part of NotEnoughUpdates.
+ *
+ * NotEnoughUpdates is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * NotEnoughUpdates is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.moulberry.notenoughupdates.miscfeatures.inventory
+
+import com.google.gson.Gson
+import io.github.moulberry.notenoughupdates.NotEnoughUpdates
+import io.github.moulberry.notenoughupdates.autosubscribe.NEUAutoSubscribe
+import io.github.moulberry.notenoughupdates.events.GuiContainerBackgroundDrawnEvent
+import io.github.moulberry.notenoughupdates.util.MuseumUtil
+import io.github.moulberry.notenoughupdates.util.SBInfo
+import io.github.moulberry.notenoughupdates.util.Utils
+import io.github.moulberry.notenoughupdates.util.kotlin.KSerializable
+import io.github.moulberry.notenoughupdates.util.stripControlCodes
+import net.minecraft.inventory.ContainerChest
+import net.minecraftforge.event.world.WorldEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import java.io.File
+
+@NEUAutoSubscribe
+object MuseumTooltipManager {
+
+    @KSerializable
+    data class MuseumData(
+        val profiles: HashMap<String, ProfileSpecificMuseumData>
+    )
+
+    @KSerializable
+    data class ProfileSpecificMuseumData(
+        val donatedItems: MutableSet<String>,
+        val visitedOnce: Boolean
+    )
+
+    val loadedMuseumData by lazy {
+        var data = MuseumData(hashMapOf())
+        if (file.exists()) {
+            val content = file.readText()
+            data = Gson().fromJson(content, MuseumData::class.java)
+        } else {
+            file.createNewFile()
+            file.writeText(Gson().toJson(data))
+        }
+        data
+    }
+
+    private val file = File(NotEnoughUpdates.INSTANCE.neuDir, "donated_museum_items.json")
+
+    private val donatedStates = listOf(
+        MuseumUtil.DonationState.DONATED_PRESENT,
+        MuseumUtil.DonationState.DONATED_VACANT,
+        MuseumUtil.DonationState.DONATED_PRESENT_PARTIAL
+    )
+
+    private fun addItemToDonatedList(itemsToAdd: List<String>) {
+        val profile = SBInfo.getInstance().currentProfile ?: return
+
+        for (internalName in itemsToAdd) {
+            loadedMuseumData.profiles.computeIfAbsent(profile) { ProfileSpecificMuseumData(mutableSetOf(), false) }
+
+            val profileData = loadedMuseumData.profiles[profile]!!
+            profileData.donatedItems.add(internalName)
+        }
+    }
+
+    /***
+     * Check if the given item has been donated to the museum on the current profile
+     *
+     * This will only work if the player has visited the museum before
+     */
+    fun isItemDonated(item: String): Boolean {
+        val profile = SBInfo.getInstance().currentProfile ?: return false
+
+        val profileData = loadedMuseumData.profiles[profile] ?: return false
+        return profileData.donatedItems.contains(item)
+
+    }
+
+    /***
+     * Check if the player has visited the museum at least once on this profile
+     */
+    fun hasPlayerVisitedMuseum(): Boolean {
+        val profile = SBInfo.getInstance().currentProfile ?: return false
+
+        val profileData = loadedMuseumData.profiles[profile] ?: return false
+        return profileData.visitedOnce
+    }
+
+    @SubscribeEvent
+    fun onBackgroundDrawn(event: GuiContainerBackgroundDrawnEvent) {
+        val gui = event.container ?: return
+        val chest = gui.inventorySlots as? ContainerChest ?: return
+        if (!MuseumUtil.isMuseumInventory(chest.lowerChestInventory)) return
+
+        val armor = Utils.getOpenChestName().stripControlCodes().endsWith("Armor Sets")
+        for (slot in chest.inventorySlots) {
+            if (slot == null || slot.stack == null) continue
+            val item = MuseumUtil.findMuseumItem(slot.stack, armor) ?: continue
+            if (donatedStates.contains(item.state)) {
+                addItemToDonatedList(item.skyblockItemIds)
+            }
+        }
+    }
+
+    @SubscribeEvent
+    fun onWorldLoad(@Suppress("UNUSED_PARAMETER") event: WorldEvent.Load) {
+        // Only save when the Museum has actually been opened
+        if ((::loadedMuseumData.getDelegate() as Lazy<*>).isInitialized()) {
+            if (!file.exists()) {
+                file.createNewFile()
+            }
+            file.writeText(Gson().toJson(loadedMuseumData))
+        }
+    }
+}

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/inventory/MuseumTooltipManager.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/inventory/MuseumTooltipManager.kt
@@ -69,7 +69,6 @@ object MuseumTooltipManager {
     )
 
     private fun addItemToDonatedList(itemsToAdd: List<String>) {
-        println(itemsToAdd)
         val profile = SBInfo.getInstance().currentProfile ?: return
 
         for (internalName in itemsToAdd) {

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/util/MuseumUtil.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/util/MuseumUtil.kt
@@ -21,6 +21,8 @@ package io.github.moulberry.notenoughupdates.util
 
 import io.github.moulberry.notenoughupdates.NEUManager
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates
+import io.github.moulberry.notenoughupdates.core.util.StringUtils
+import net.minecraft.inventory.IInventory
 import net.minecraft.item.EnumDyeColor
 import net.minecraft.item.ItemDye
 import net.minecraft.item.ItemStack
@@ -109,5 +111,7 @@ object MuseumUtil {
         }
     }
 
-
+    fun isMuseumInventory(inventory: IInventory): Boolean {
+        return StringUtils.cleanColour(inventory.displayName.unformattedText).startsWith("Museum ➜")
+    }
 }


### PR DESCRIPTION
Adds a message at the end of the tooltip for items you have already donated. Stores donated items in a file once you view them in the museum.

closes #645