### PR TITLE
Added exact number values back to commissions

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
@@ -208,8 +208,8 @@ public class MiningOverlay extends TextTabOverlay {
 							}
 						}
 					}
-					if (line.startsWith("\u00a77\u00a79")) {
-						String textAfter = line.substring(4);
+					if (line.startsWith("\u00a79")) {
+						String textAfter = line.substring(2);
 						if (!textAfter.contains("\u00a7") && !textAfter.equals("Rewards") && !textAfter.equals("Progress")) {
 							commName = textAfter;
 						}


### PR DESCRIPTION
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/94038482/840a757a-2258-48f4-a838-bf0f06e0c85f)

could possibly add 0/1 if it doesn't detect a number but it detects a name (for the crystal comms and participate in events)