### PR TITLE
Changes that happened in alpha 17

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/TooltipTweaks.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/TooltipTweaks.java
@@ -109,7 +109,7 @@ public class TooltipTweaks {
 	)
 	@ConfigEditorBoolean
 	@ConfigAccordionId(id = 0)
-	public boolean museumDonationStatus = true;
+	public boolean museumDonationStatus = false;
 
 	@Expose
 	@ConfigOption(

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/misc/SetKeyCommand.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/misc/SetKeyCommand.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 NotEnoughUpdates contributors
+ *
+ * This file is part of NotEnoughUpdates.
+ *
+ * NotEnoughUpdates is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * NotEnoughUpdates is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.moulberry.notenoughupdates.commands.misc
+
+import com.mojang.brigadier.arguments.StringArgumentType.string
+import io.github.moulberry.notenoughupdates.NotEnoughUpdates
+import io.github.moulberry.notenoughupdates.autosubscribe.NEUAutoSubscribe
+import io.github.moulberry.notenoughupdates.events.RegisterBrigadierCommandEvent
+import io.github.moulberry.notenoughupdates.util.brigadier.*
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@NEUAutoSubscribe
+class SetKeyCommand {
+    @SubscribeEvent
+    fun onCommands(event: RegisterBrigadierCommandEvent) {
+        event.command("neusetkey") {
+            thenArgument("key", string()) { key ->
+                thenExecute {
+                    NotEnoughUpdates.INSTANCE.config.apiData.apiKey = this[key]
+                    reply("Set your key to ${this[key]}")
+
+                }
+            }.withHelp("Set your API key found at https://developer.hypixel.net/")
+        }
+    }
+}

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/IQTest.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/IQTest.kt
@@ -66,7 +66,7 @@ object IQTest {
 
     val answerOption = ProcessedOption(
         "IQ Test Question",
-        "Please type out the answer to §a$question",
+        "Please type out the answer to §a$question\n§cIf you just want to set your api key do §6/neusetkey <key>",
         -1,
         javaClass.getField("answer"),
         this,


### PR DESCRIPTION
- Set the museum donation status tooltip tweak to false by default
- Add /neusetkey and a disclaimer to the iq test thingy telling them to use that command instead