### PR TITLE
Update loom and gradle

### DIFF
--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -26,6 +26,10 @@ repositories {
 		mavenCentral()
 }
 
+java {
+  	toolchain.languageVersion.set(JavaLanguageVersion.of(8))
+}
+
 tasks.withType<JavaCompile> {
 		if (JavaVersion.current().isJava9Compatible) {
 				options.release.set(8)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,9 +25,9 @@ import neubs.setVersionFromEnvironment
 plugins {
 		idea
 		java
-		id("gg.essential.loom") version "0.10.0.+"
+		id("gg.essential.loom") version "1.2.polyfrost.2" // eventually this can be replaced with actual essential loom but polyfrost's fork has critical fixes
 		id("dev.architectury.architectury-pack200") version "0.1.3"
-		id("com.github.johnrengelman.shadow") version "7.1.2"
+		id("com.github.johnrengelman.shadow") version "8.1.1"
 		id("io.github.juuxel.loom-quiltflower") version "1.7.3"
 		`maven-publish`
 		kotlin("jvm") version "1.8.21"
@@ -45,12 +45,12 @@ setVersionFromEnvironment("2.1.1")
 
 // Minecraft configuration:
 loom {
-		launchConfigs {
-				"client" {
+		runs {
+				named("client") {
 						property("mixin.debug", "true")
 						property("asmhelper.verbose", "true")
-						arg("--tweakClass", "io.github.moulberry.notenoughupdates.loader.NEUDelegatingTweaker")
-						arg("--mixin", "mixins.notenoughupdates.json")
+					  programArgs("--tweakClass", "io.github.moulberry.notenoughupdates.loader.NEUDelegatingTweaker")
+				  	programArgs("--mixin", "mixins.notenoughupdates.json")
 				}
 		}
 		runConfigs {
@@ -164,7 +164,7 @@ dependencies {
 
 java {
 		withSourcesJar()
-//		toolchain.languageVersion.set(JavaLanguageVersion.of(8))
+		toolchain.languageVersion.set(JavaLanguageVersion.of(8))
 }
 
 // Tasks:
@@ -172,8 +172,6 @@ java {
 tasks.withType(JavaCompile::class) {
 		options.encoding = "UTF-8"
 		options.isFork = true
-		if (JavaVersion.current().isJava9Compatible)
-				options.release.set(8)
 }
 tasks.named("compileOneconfigJava", JavaCompile::class) {
 		doFirst {
@@ -205,7 +203,7 @@ tasks.withType(Jar::class) {
 val remapJar by tasks.named<net.fabricmc.loom.task.RemapJarTask>("remapJar") {
 		archiveClassifier.set("dep")
 		from(tasks.shadowJar)
-		input.set(tasks.shadowJar.get().archiveFile)
+		inputFile.set(tasks.shadowJar.get().archiveFile)
 		doLast {
 				println("Jar name: ${archiveFile.get().asFile}")
 		}
@@ -258,7 +256,7 @@ idea {
 		module {
 				// Not using += due to https://github.com/gradle/gradle/issues/8749
 				sourceDirs = sourceDirs + file("build/generated/ksp/main/kotlin") // or tasks["kspKotlin"].destination
-				testSourceDirs = testSourceDirs + file("build/generated/ksp/test/kotlin")
+			  testSources.from(file("build/generated/ksp/test/kotlin"))
 				generatedSourceDirs = generatedSourceDirs + file("build/generated/ksp/main/kotlin") + file("build/generated/ksp/test/kotlin")
 		}
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,15 +45,13 @@ setVersionFromEnvironment("2.1.1")
 
 // Minecraft configuration:
 loom {
-		runs {
-				named("client") {
-						property("mixin.debug", "true")
-						property("asmhelper.verbose", "true")
-					  programArgs("--tweakClass", "io.github.moulberry.notenoughupdates.loader.NEUDelegatingTweaker")
-				  	programArgs("--mixin", "mixins.notenoughupdates.json")
-				}
-		}
 		runConfigs {
+			  "client" {
+					  property("mixin.debug", "true")
+					  property("asmhelper.verbose", "true")
+					  programArgs("--mixin", "mixins.notenoughupdates.json")
+					  programArgs("--tweakClass", "io.github.moulberry.notenoughupdates.loader.NEUDelegatingTweaker")
+				}
 				"server" {
 						isIdeConfigGenerated = false
 				}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/oneconfigquarantine/build.gradle.kts
+++ b/oneconfigquarantine/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
 		mappings("de.oceanlabs.mcp:mcp_stable:22-1.8.9")
 		forge("net.minecraftforge:forge:1.8.9-11.15.1.2318-1.8.9")
 
-		modApi("cc.polyfrost:oneconfig-1.8.9-forge:0.1.0-alpha+") // Don't you just love 0.1.0-alpha+
+		modApi("cc.polyfrost:oneconfig-1.8.9-forge:0.2.0-alpha+") // no
 }
 
 tasks.withType<JavaCompile> {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,7 @@ pluginManagement {
 				maven(url = "https://repo.spongepowered.org/maven/")
 				maven(url = "https://repo.sk1er.club/repository/maven-releases/")
 				maven(url = "https://maven.architectury.dev/")
+			  maven(url = "https://repo.polyfrost.cc/releases") // keep this at the end to avoid polyfrost's repo mirrors
 		}
 		resolutionStrategy {
 				eachPlugin {

--- a/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinThreadDownloadImageDataThread.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinThreadDownloadImageDataThread.java
@@ -37,7 +37,8 @@ public class MixinThreadDownloadImageDataThread {
 			value = "INVOKE",
 			target = "Ljava/net/HttpURLConnection;setDoOutput(Z)V"
 		),
-		locals = LocalCapture.CAPTURE_FAILSOFT
+		locals = LocalCapture.CAPTURE_FAILSOFT,
+		remap = false
 	)
 	public void patchHttpConnection(CallbackInfo ci, HttpURLConnection httpURLConnection) {
 		ThreadDownloadImageHook.hookThreadImageConnection(httpURLConnection);


### PR DESCRIPTION
Updates loom to 1.2, gradle to 8.1.1, and OneConfig to 0.2.0.

Essential's fork currently needs a lot of fixes that are waiting to be merged, so we use the Polyfrost fork