### PR TITLE
Use ursa-minor as API proxy

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUManager.java
@@ -39,6 +39,7 @@ import io.github.moulberry.notenoughupdates.util.ApiUtil;
 import io.github.moulberry.notenoughupdates.util.Constants;
 import io.github.moulberry.notenoughupdates.util.ItemResolutionQuery;
 import io.github.moulberry.notenoughupdates.util.ItemUtils;
+import io.github.moulberry.notenoughupdates.util.UrsaClient;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.KeyBinding;
@@ -127,6 +128,7 @@ public class NEUManager {
 	public long viewItemAttemptTime = 0;
 
 	public final ApiUtil apiUtils = new ApiUtil();
+	public final UrsaClient ursaClient = new UrsaClient(apiUtils);
 
 	private final Map<String, ItemStack> itemstackCache = new HashMap<>();
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/customtypes/NEUDebugFlag.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/customtypes/NEUDebugFlag.java
@@ -19,7 +19,9 @@
 
 package io.github.moulberry.notenoughupdates.options.customtypes;
 
+import io.github.moulberry.notenoughupdates.util.MinecraftExecutor;
 import io.github.moulberry.notenoughupdates.util.NEUDebugLogger;
+import net.minecraft.client.Minecraft;
 
 import java.util.Arrays;
 import java.util.List;
@@ -46,7 +48,7 @@ public enum NEUDebugFlag {
 	}
 
 	public void log(String message) {
-		NEUDebugLogger.log(this, message);
+			NEUDebugLogger.log(this, message);
 	}
 
 	public boolean isSet() {

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/ApiData.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/ApiData.java
@@ -134,7 +134,7 @@ public class ApiData {
 		desc = "§4Do §lNOT §r§4change this, unless you know exactly what you are doing"
 	)
 	@ConfigEditorText
-	public String ursaApi = "http://ursa.notenoughupdates.org";
+	public String ursaApi = "https://ursa.notenoughupdates.org/";
 
 	public String getCommitApiUrl() {
 		return String.format("https://api.github.com/repos/%s/%s/commits/%s", repoUser, repoName, repoBranch);

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/ApiData.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/ApiData.java
@@ -127,6 +127,15 @@ public class ApiData {
 	@ConfigEditorText
 	public String moulberryCodesApi = "moulberry.codes";
 
+
+	@Expose
+	@ConfigOption(
+		name = "Ursa Minor Proxy",
+		desc = "§4Do §lNOT §r§4change this, unless you know exactly what you are doing"
+	)
+	@ConfigEditorText
+	public String ursaApi = "http://ursa.notenoughupdates.org";
+
 	public String getCommitApiUrl() {
 		return String.format("https://api.github.com/repos/%s/%s/commits/%s", repoUser, repoName, repoBranch);
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
@@ -22,6 +22,7 @@ package io.github.moulberry.notenoughupdates.profileviewer;
 import com.google.gson.JsonObject;
 import io.github.moulberry.notenoughupdates.NEUManager;
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
+import io.github.moulberry.notenoughupdates.util.UrsaClient;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import lombok.Getter;
 import net.minecraft.init.Blocks;
@@ -474,7 +475,7 @@ public class ProfileViewer {
 		updatingResourceCollection.set(true);
 
 		NotEnoughUpdates.INSTANCE.manager.apiUtils
-			.newHypixelApiRequest("resources/skyblock/collections")
+			.newAnonymousHypixelApiRequest("resources/skyblock/collections")
 			.requestJson()
 			.thenAccept(jsonObject -> {
 				updatingResourceCollection.set(false);
@@ -528,11 +529,8 @@ public class ProfileViewer {
 					callback.accept(null);
 				} else {
 					if (!uuidToHypixelProfile.containsKey(uuid)) {
-						manager.apiUtils
-							.newHypixelApiRequest("player")
-							.queryArgument("uuid", uuid)
-							.maxCacheAge(Duration.ofSeconds(30))
-							.requestJson()
+						manager.ursaClient
+							.get(UrsaClient.player(Utils.parseDashlessUUID(uuid)))
 							.thenAccept(playerJson -> {
 									if (
 										playerJson != null &&

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/SkyblockProfiles.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/SkyblockProfiles.java
@@ -643,9 +643,7 @@ public class SkyblockProfiles {
 
 			updatingMuseumData.set(true);
 			String profileId = getOuterProfileJson().get("profile_id").getAsString();
-			profileViewer.getManager().apiUtils.newHypixelApiRequest("skyblock/museum")
-			 .queryArgument("profile", profileId)
-			 .requestJson()
+			profileViewer.getManager().ursaClient.get(UrsaClient.museumForProfile(profileId))
 			 .handle((museumJson, throwable) -> {
 				 if (museumJson != null && museumJson.has("success")
 					 && museumJson.get("success").getAsBoolean() && museumJson.has("members")) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/SkyblockProfiles.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/SkyblockProfiles.java
@@ -28,6 +28,7 @@ import io.github.moulberry.notenoughupdates.profileviewer.bestiary.BestiaryData;
 import io.github.moulberry.notenoughupdates.profileviewer.weight.senither.SenitherWeight;
 import io.github.moulberry.notenoughupdates.profileviewer.weight.weight.Weight;
 import io.github.moulberry.notenoughupdates.util.Constants;
+import io.github.moulberry.notenoughupdates.util.UrsaClient;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import io.github.moulberry.notenoughupdates.util.hypixelapi.ProfileCollectionInfo;
 import lombok.Getter;
@@ -84,6 +85,7 @@ public class SkyblockProfiles {
 		"social"
 	);
 	private final ProfileViewer profileViewer;
+	// TODO: replace with UUID type
 	private final String uuid;
 	private final AtomicBoolean updatingSkyblockProfilesState = new AtomicBoolean(false);
 	private final AtomicBoolean updatingGuildInfoState = new AtomicBoolean(false);
@@ -119,10 +121,8 @@ public class SkyblockProfiles {
 		lastStatusInfoState = currentTime;
 		updatingPlayerStatusState.set(true);
 
-		profileViewer.getManager().apiUtils
-			.newHypixelApiRequest("status")
-			.queryArgument("uuid", uuid)
-			.requestJson()
+		profileViewer.getManager().ursaClient
+			.get(UrsaClient.status(Utils.parseDashlessUUID(uuid)))
 			.handle((jsonObject, ex) -> {
 				updatingPlayerStatusState.set(false);
 
@@ -143,10 +143,8 @@ public class SkyblockProfiles {
 		lastBingoInfoState = currentTime;
 		updatingBingoInfo.set(true);
 
-		NotEnoughUpdates.INSTANCE.manager.apiUtils
-			.newHypixelApiRequest("skyblock/bingo")
-			.queryArgument("uuid", uuid)
-			.requestJson()
+		NotEnoughUpdates.INSTANCE.manager.ursaClient
+			.get(UrsaClient.bingo(Utils.parseDashlessUUID(uuid)))
 			.handle(((jsonObject, throwable) -> {
 				updatingBingoInfo.set(false);
 
@@ -317,10 +315,8 @@ public class SkyblockProfiles {
 		lastPlayerInfoState = currentTime;
 		updatingSkyblockProfilesState.set(true);
 
-		profileViewer.getManager().apiUtils
-			.newHypixelApiRequest("skyblock/profiles")
-			.queryArgument("uuid", uuid)
-			.requestJson()
+		profileViewer.getManager().ursaClient
+			.get(UrsaClient.profiles(Utils.parseDashlessUUID(uuid)))
 			.handle((profilesJson, throwable) -> {
 				if (profilesJson != null && profilesJson.has("success")
 					&& profilesJson.get("success").getAsBoolean() && profilesJson.has("profiles")) {
@@ -388,10 +384,8 @@ public class SkyblockProfiles {
 		lastGuildInfoState = currentTime;
 		updatingGuildInfoState.set(true);
 
-		profileViewer.getManager().apiUtils
-			.newHypixelApiRequest("guild")
-			.queryArgument("player", uuid)
-			.requestJson()
+		profileViewer.getManager().ursaClient
+			.get(UrsaClient.guild(Utils.parseDashlessUUID(uuid)))
 			.handle((jsonObject, ex) -> {
 				updatingGuildInfoState.set(false);
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/ApiUtil.java
@@ -58,10 +58,12 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 public class ApiUtil {
@@ -251,7 +253,11 @@ public class ApiUtil {
 						if (shouldGunzip || "gzip".equals(conn.getContentEncoding())) {
 							inputStream = new GZIPInputStream(inputStream);
 						}
-						responseHeaders = conn.getHeaderFields();
+						responseHeaders = conn.getHeaderFields().entrySet().stream()
+																	.collect(Collectors.toMap(
+																		it -> it.getKey() == null ? null : it.getKey().toLowerCase(Locale.ROOT),
+																		it -> new ArrayList<>(it.getValue())
+																	));
 
 						// While the assumption of UTF8 isn't always true; it *should* always be true.
 						// Not in the sense that this will hold in most cases (although that as well),

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/NEUDebugLogger.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/NEUDebugLogger.java
@@ -22,7 +22,6 @@ package io.github.moulberry.notenoughupdates.util;
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.options.customtypes.NEUDebugFlag;
 import net.minecraft.client.Minecraft;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 
 import java.util.function.Consumer;
@@ -34,7 +33,7 @@ public class NEUDebugLogger {
 	public static boolean allFlagsEnabled = false;
 
 	private static void chatLogger(String message) {
-		Utils.addChatMessage(EnumChatFormatting.YELLOW + "[NEU DEBUG] " + message);
+		mc.addScheduledTask(() -> Utils.addChatMessage(EnumChatFormatting.YELLOW + "[NEU DEBUG] " + message));
 	}
 
 	public static boolean isFlagEnabled(NEUDebugFlag flag) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/ProfileApiSyncer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/ProfileApiSyncer.java
@@ -19,6 +19,7 @@
 
 package io.github.moulberry.notenoughupdates.util;
 
+import com.google.gson.JsonObject;
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.profileviewer.SkyblockProfiles;
 import net.minecraft.client.Minecraft;
@@ -89,9 +90,15 @@ public class ProfileApiSyncer {
 		if (Minecraft.getMinecraft().thePlayer == null) return;
 
 		String uuid = Minecraft.getMinecraft().thePlayer.getUniqueID().toString().replace("-", "");
-		NotEnoughUpdates.profileViewer.getOrLoadSkyblockProfiles(uuid, (profile) -> {
-			for (Consumer<SkyblockProfiles> c : finishSyncCallbacks.values()) c.accept(profile);
-			finishSyncCallbacks.clear();
-		});
+		NotEnoughUpdates.INSTANCE.manager.apiUtils
+			.newHypixelApiRequest("/skyblock/profiles")
+			.queryArgument("uuid", uuid)
+			.requestJson()
+			.thenAcceptAsync((profile) -> {
+				SkyblockProfiles skyblockProfiles = new SkyblockProfiles(NotEnoughUpdates.profileViewer, uuid);
+				for (Consumer<SkyblockProfiles> c : finishSyncCallbacks.values())
+					c.accept((skyblockProfiles));
+				finishSyncCallbacks.clear();
+			}, MinecraftExecutor.OnThread);
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
@@ -459,7 +459,7 @@ public class SBInfo {
 
 	public void updateMayor() {
 		NotEnoughUpdates.INSTANCE.manager.apiUtils
-			.newHypixelApiRequest("resources/skyblock/election")
+			.newAnonymousHypixelApiRequest("resources/skyblock/election")
 			.requestJson()
 			.thenAccept(newJson -> mayorJson = newJson);
 	}

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/dev/DevTestCommand.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/dev/DevTestCommand.kt
@@ -19,7 +19,9 @@
 
 package io.github.moulberry.notenoughupdates.commands.dev
 
+import com.google.gson.JsonObject
 import com.mojang.brigadier.arguments.StringArgumentType
+import com.mojang.brigadier.arguments.StringArgumentType.string
 import io.github.moulberry.notenoughupdates.BuildFlags
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates
 import io.github.moulberry.notenoughupdates.autosubscribe.NEUAutoSubscribe
@@ -36,7 +38,6 @@ import io.github.moulberry.notenoughupdates.util.brigadier.*
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiScreen
 import net.minecraft.command.ICommandSender
-import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.launchwrapper.Launch
 import net.minecraft.util.ChatComponentText
@@ -199,6 +200,16 @@ class DevTestCommand {
                         reply("Fishing particles set to ${FishingHelper.type}")
                     }
                 }
+            }
+            thenLiteral("callUrsa") {
+                thenArgument("path", string()) { path ->
+                    thenExecute {
+                        NotEnoughUpdates.INSTANCE.manager.ursaClient.get(this[path], JsonObject::class.java)
+                            .thenAccept {
+                                reply(it.toString())
+                            }
+                    }
+                }.withHelp("Send an authenticated request to the current ursa server")
             }
             thenLiteralExecute("dev") {
                 NotEnoughUpdates.INSTANCE.config.hidden.dev = !NotEnoughUpdates.INSTANCE.config.hidden.dev

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/dev/DevTestCommand.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/dev/DevTestCommand.kt
@@ -210,7 +210,8 @@ class DevTestCommand {
             }.withHelp("Force sync the config to disk")
             thenLiteralExecute("clearapicache") {
                 ApiCache.clear()
-                reply("Cleared API cache")
+                NotEnoughUpdates.INSTANCE.manager.ursaClient.clearToken()
+                reply("Cleared API cache and reset ursa token")
             }.withHelp("Clear the API cache")
             thenLiteralExecute("searchmode") {
                 NotEnoughUpdates.INSTANCE.config.hidden.firstTimeSearchFocus = true

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/dev/DevTestCommand.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/dev/DevTestCommand.kt
@@ -202,9 +202,9 @@ class DevTestCommand {
                 }
             }
             thenLiteral("callUrsa") {
-                thenArgument("path", string()) { path ->
+                thenArgument("path", RestArgumentType) { path ->
                     thenExecute {
-                        NotEnoughUpdates.INSTANCE.manager.ursaClient.get(this[path], JsonObject::class.java)
+                        NotEnoughUpdates.INSTANCE.manager.ursaClient.getString(this[path])
                             .thenAccept {
                                 reply(it.toString())
                             }

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/misc/ProfileViewerCommands.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/misc/ProfileViewerCommands.kt
@@ -45,16 +45,11 @@ class ProfileViewerCommands {
                 reply("${RED}Some parts of the profile viewer do not work with OptiFine Fast Render. Go to ESC > Options > Video Settings > Performance > Fast Render to disable it.")
             }
 
-            if (NotEnoughUpdates.INSTANCE.config.apiData.apiKey.isNullOrBlank()) {
-                reply("${RED}Can't view profile, an API key is not set. Run /api new and put the result in settings.")
-                return
-            }
-
             NotEnoughUpdates.profileViewer.loadPlayerByName(
                 name ?: Minecraft.getMinecraft().thePlayer.name
             ) { profile ->
                 if (profile == null) {
-                    reply("${RED}Invalid player name/API key. Maybe the API is down? Try /api new.")
+                    reply("${RED}Invalid player name. Maybe the API is down? Try again later.")
                 } else {
                     profile.resetCache()
                     ProfileViewerUtils.saveSearch(name)

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/util/HttpStatusCodeException.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/util/HttpStatusCodeException.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 NotEnoughUpdates contributors
+ *
+ * This file is part of NotEnoughUpdates.
+ *
+ * NotEnoughUpdates is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * NotEnoughUpdates is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.moulberry.notenoughupdates.util
+
+import java.net.URL
+
+data class HttpStatusCodeException(
+    val url: URL,
+    val statusCode: Int,
+    val serverMessage: String,
+) : RuntimeException("Server returned HTTP Status Code: $statusCode:\n$serverMessage")

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/util/UrsaClient.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/util/UrsaClient.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2023 NotEnoughUpdates contributors
+ *
+ * This file is part of NotEnoughUpdates.
+ *
+ * NotEnoughUpdates is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * NotEnoughUpdates is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.moulberry.notenoughupdates.util
+
+import com.google.gson.JsonObject
+import io.github.moulberry.notenoughupdates.options.customtypes.NEUDebugFlag
+import io.github.moulberry.notenoughupdates.util.kotlin.Coroutines.await
+import io.github.moulberry.notenoughupdates.util.kotlin.Coroutines.continueOn
+import io.github.moulberry.notenoughupdates.util.kotlin.Coroutines.launchCoroutine
+import io.github.moulberry.notenoughupdates.util.kotlin.Coroutines.launchCoroutineOnCurrentThread
+import net.minecraft.client.Minecraft
+import java.time.Duration
+import java.time.Instant
+import java.util.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentLinkedQueue
+
+class UrsaClient(val apiUtil: ApiUtil) {
+    private data class Token(
+        val obtainedAt: Instant,
+        val token: String,
+    ) {
+        val isValid get() = Duration.between(obtainedAt, Instant.now()).seconds < 3500
+    }
+
+    val logger = NEUDebugFlag.API_CACHE
+    private var token: Token? = null
+    private var isPollingForToken = false
+
+    private data class Request<T>(
+        val path: String,
+        val objectMapping: Class<T>,
+        val consumer: CompletableFuture<T>,
+    )
+
+    private val queue = ConcurrentLinkedQueue<Request<*>>()
+    val ursaRoot = "http://localhost:3000"
+
+    private suspend fun authorizeRequest(connection: ApiUtil.Request) {
+        val t = token
+        if (t != null && t.isValid) {
+            logger.log("Authorizing request using token")
+            connection.header("x-ursa-token", t.token)
+        } else {
+            logger.log("Authorizing request using username and serverId")
+            val serverId = UUID.randomUUID().toString()
+            val session = Minecraft.getMinecraft().session
+            val name = session.username
+            connection.header("x-ursa-username", name).header("x-ursa-serverid", serverId)
+            continueOn(MinecraftExecutor.OffThread)
+            Minecraft.getMinecraft().sessionService.joinServer(session.profile, session.token, serverId)
+            logger.log("Authorizing request using username and serverId complete")
+        }
+    }
+
+    private fun saveToken(connection: ApiUtil.Request) {
+        logger.log("Attempting to save token")
+        val token = connection.responseHeaders["x-ursa-token"]?.firstOrNull()
+        if (token == null) {
+            isPollingForToken = false
+            logger.log("No token found. Marking as non polling")
+            return
+        }
+        synchronized(this) {
+            this.token = Token(Instant.now(), token)
+            isPollingForToken = false
+            logger.log("Token saving successful")
+        }
+        launchCoroutineOnCurrentThread {
+            continueOn(MinecraftExecutor.OnThread)
+            bumpRequests()
+        }
+    }
+
+    private suspend fun <T> performRequest(request: Request<T>) {
+        val apiRequest = apiUtil.request().url("$ursaRoot/${request.path}")
+        try {
+            logger.log("Ursa Request started")
+            authorizeRequest(apiRequest)
+            val response = apiRequest.requestJson(request.objectMapping).await()
+            logger.log("Request completed")
+            saveToken(apiRequest)
+            request.consumer.complete(response)
+        } catch (e: Exception) {
+            logger.log("Request failed")
+            isPollingForToken = false
+            request.consumer.completeExceptionally(e)
+        }
+    }
+
+    private fun bumpRequests() {
+        logger.log("Bumping ursa requests")
+        if (isPollingForToken) return
+        logger.log("Not currently polling for token")
+        val nextRequest = queue.poll()
+        if (nextRequest == null) {
+            logger.log("No request to bump found")
+            return
+        }
+        logger.log("Request found")
+        synchronized(this) {
+            if (token?.isValid != true) {
+                isPollingForToken = true
+                logger.log("No token saved. Marking this request as a token poll request")
+            }
+        }
+        launchCoroutine { performRequest(nextRequest) }
+        bumpRequests()
+    }
+
+    fun clearToken() {
+        synchronized(this) {
+            token = null
+        }
+    }
+
+    fun <T> get(path: String, clazz: Class<T>): CompletableFuture<T> {
+        val c = CompletableFuture<T>()
+        queue.add(Request(path, clazz, c))
+        bumpRequests()
+        return c
+    }
+
+    fun <T> get(knownRequest: KnownRequest<T>): CompletableFuture<T> {
+        return get(knownRequest.path, knownRequest.type)
+    }
+
+    data class KnownRequest<T>(val path: String, val type: Class<T>) {
+        fun <N> typed(newType: Class<N>) = KnownRequest(path, newType)
+        inline fun <reified N> typed() = typed(N::class.java)
+    }
+
+    companion object {
+        @JvmStatic
+        fun profiles(uuid: UUID) = KnownRequest("v1/hypixel/profiles/${uuid}", JsonObject::class.java)
+        @JvmStatic
+        fun player(uuid: UUID) = KnownRequest("v1/hypixel/player/${uuid}", JsonObject::class.java)
+        @JvmStatic
+        fun guild(uuid: UUID) = KnownRequest("v1/hypixel/guild/${uuid}", JsonObject::class.java)
+        @JvmStatic
+        fun bingo(uuid: UUID) = KnownRequest("v1/hypixel/bingo/${uuid}", JsonObject::class.java)
+        @JvmStatic
+        fun status(uuid: UUID) = KnownRequest("v1/hypixel/status/${uuid}", JsonObject::class.java)
+    }
+}

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/util/UrsaClient.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/util/UrsaClient.kt
@@ -188,8 +188,13 @@ class UrsaClient(val apiUtil: ApiUtil) {
 
         @JvmStatic
         fun guild(uuid: UUID) = KnownRequest("v1/hypixel/guild/${uuid}", JsonObject::class.java)
+
         @JvmStatic
         fun bingo(uuid: UUID) = KnownRequest("v1/hypixel/bingo/${uuid}", JsonObject::class.java)
+
+        @JvmStatic
+        fun museumForProfile(profileUuid: String) = KnownRequest("v1/hypixel/museum/${profileUuid}", JsonObject::class.java)
+
         @JvmStatic
         fun status(uuid: UUID) = KnownRequest("v1/hypixel/status/${uuid}", JsonObject::class.java)
     }

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/util/hypixelapi/Collection.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/util/hypixelapi/Collection.kt
@@ -95,7 +95,7 @@ data class ProfileCollectionInfo(
 
         val hypixelCollectionInfo: CompletableFuture<CollectionMetadata> by lazy {
             NotEnoughUpdates.INSTANCE.manager.apiUtils
-                .newHypixelApiRequest("resources/skyblock/collections")
+                .newAnonymousHypixelApiRequest("resources/skyblock/collections")
                 .requestJson()
                 .thenApply {
                     NotEnoughUpdates.INSTANCE.manager.gson.fromJson(it, CollectionMetadata::class.java)


### PR DESCRIPTION
See https://github.com/NotEnoughUpdates/ursa-minor for the server implementation. Does not replace the user profile used by the minion API, since I feel like we should reserve the API proxy only for things that cannot be scraped in game (such as /pv)

Please discuss server design and implementation in [the discord](https://discord.com/channels/516977525906341928/1126315104401641522)