### PR TITLE
Fix leveling info related crash

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/DungeonPage.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/DungeonPage.java
@@ -127,6 +127,9 @@ public class DungeonPage extends GuiProfileViewerPage {
 		}
 
 		Map<String, ProfileViewer.Level> levelingInfo = selectedProfile.getLevelingInfo();
+		if (levelingInfo == null) {
+			return;
+		}
 		JsonObject profileInfo = selectedProfile.getProfileJson();
 		JsonObject hypixelInfo = GuiProfileViewer.getProfile().getHypixelProfile();
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/MiningPage.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/MiningPage.java
@@ -19,6 +19,7 @@
 
 package io.github.moulberry.notenoughupdates.profileviewer;
 
+import io.github.moulberry.notenoughupdates.profileviewer.ProfileViewer;
 import com.google.common.collect.Lists;
 import com.google.gson.JsonObject;
 import io.github.moulberry.notenoughupdates.core.util.StringUtils;
@@ -151,11 +152,15 @@ public class MiningPage extends GuiProfileViewerPage {
 			molePerkPct = 100;
 		}
 
-		ProfileViewer.Level hotmLevelingInfo = selectedProfile.getLevelingInfo().get("hotm");
-
 		// Render stats
-		// HOTM
-		getInstance().renderXpBar(EnumChatFormatting.RED + "HOTM", hotmSkillIcon, x, y, sectionWidth, hotmLevelingInfo, mouseX, mouseY);
+		Map<String, ProfileViewer.Level> levelingInfo = selectedProfile.getLevelingInfo();
+		if (levelingInfo != null) {
+			ProfileViewer.Level hotmLevelingInfo = levelingInfo.get("hotm");
+			
+			// HOTM
+			getInstance().renderXpBar(EnumChatFormatting.RED + "HOTM", hotmSkillIcon, x, y, sectionWidth, hotmLevelingInfo, mouseX, mouseY);
+		}
+
 
 		// Powder
 		Utils.renderAlignedString(

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/XPInformation.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/XPInformation.java
@@ -233,6 +233,9 @@ public class XPInformation {
 
 	private void onApiUpdated(SkyblockProfiles profile) {
 		Map<String, ProfileViewer.Level> skyblockInfo = profile.getLatestProfile().getLevelingInfo();
+		if (skyblockInfo == null) {
+			return;
+		}
 
 		for (String skill : skills) {
 			SkillInfo info = new SkillInfo();


### PR DESCRIPTION
Fixes https://github.com/NotEnoughUpdates/NotEnoughUpdates/issues/765

The crash was caused due to `SkyblockProfile#getLevelingInfo` returning null if the repo constants are not up to date