### PR TITLE
local backup repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -227,19 +227,17 @@ val kotlinDependencyCollectionJar by tasks.creating(Zip::class) {
 	into("neu-kotlin-libraries-wrapped")
 }
 
-tasks.register("updateBackupRepo") {
+tasks.register("includeBackupRepo") {
 	doLast {
 		val url = URL("https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/archive/refs/heads/master.zip")
-		val destination = File(
-			project.layout.projectDirectory.asFile.absolutePath
-				.plus("/src/main/resources/assets/notenoughupdates/repo.zip")
-		)
+		val destinationFolder = project.buildDir.resolve("classes/java/main/assets/notenoughupdates/")
+		destinationFolder.mkdirs()
+		val destination = destinationFolder.resolve("repo.zip")
 		destination.createNewFile()
 
 		destination.outputStream().use {
 			url.openStream().copyTo(it)
 		}
-		println("done downloading")
 	}
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -21,16 +21,17 @@
 import neubs.NEUBuildFlags
 import neubs.applyPublishingInformation
 import neubs.setVersionFromEnvironment
+import java.net.URL
 
 plugins {
-		idea
-		java
-		id("gg.essential.loom") version "0.10.0.+"
-		id("dev.architectury.architectury-pack200") version "0.1.3"
-		id("com.github.johnrengelman.shadow") version "7.1.2"
-		id("io.github.juuxel.loom-quiltflower") version "1.7.3"
-		`maven-publish`
-		kotlin("jvm") version "1.8.21"
+	idea
+	java
+	id("gg.essential.loom") version "0.10.0.+"
+	id("dev.architectury.architectury-pack200") version "0.1.3"
+	id("com.github.johnrengelman.shadow") version "7.1.2"
+	id("io.github.juuxel.loom-quiltflower") version "1.7.3"
+	`maven-publish`
+	kotlin("jvm") version "1.8.21"
 	id("io.gitlab.arturbosch.detekt") version "1.23.0"
 	id("com.google.devtools.ksp") version "1.8.21-1.0.11"
 }
@@ -46,27 +47,27 @@ setVersionFromEnvironment("2.1.1")
 
 // Minecraft configuration:
 loom {
-		launchConfigs {
-				"client" {
-						property("mixin.debug", "true")
-						property("asmhelper.verbose", "true")
-						arg("--tweakClass", "io.github.moulberry.notenoughupdates.loader.NEUDelegatingTweaker")
-						arg("--mixin", "mixins.notenoughupdates.json")
-				}
+	launchConfigs {
+		"client" {
+			property("mixin.debug", "true")
+			property("asmhelper.verbose", "true")
+			arg("--tweakClass", "io.github.moulberry.notenoughupdates.loader.NEUDelegatingTweaker")
+			arg("--mixin", "mixins.notenoughupdates.json")
 		}
-		runConfigs {
-				"server" {
-						isIdeConfigGenerated = false
-				}
+	}
+	runConfigs {
+		"server" {
+			isIdeConfigGenerated = false
 		}
-		forge {
-				pack200Provider.set(dev.architectury.pack200.java.Pack200Adapter())
-				mixinConfig("mixins.notenoughupdates.json")
-		}
-		@Suppress("UnstableApiUsage")
-		mixin {
-				defaultRefmapName.set("mixins.notenoughupdates.refmap.json")
-		}
+	}
+	forge {
+		pack200Provider.set(dev.architectury.pack200.java.Pack200Adapter())
+		mixinConfig("mixins.notenoughupdates.json")
+	}
+	@Suppress("UnstableApiUsage")
+	mixin {
+		defaultRefmapName.set("mixins.notenoughupdates.refmap.json")
+	}
 }
 
 
@@ -220,29 +221,45 @@ tasks.remapSourcesJar {
 /* Bypassing https://github.com/johnrengelman/shadow/issues/111 */
 // Use Zip instead of Jar as to not include META-INF
 val kotlinDependencyCollectionJar by tasks.creating(Zip::class) {
-		archiveFileName.set("kotlin-libraries-wrapped.jar")
-		destinationDirectory.set(project.layout.buildDirectory.dir("kotlinwrapper"))
-		from(kotlinDependencies)
-		into("neu-kotlin-libraries-wrapped")
+	archiveFileName.set("kotlin-libraries-wrapped.jar")
+	destinationDirectory.set(project.layout.buildDirectory.dir("kotlinwrapper"))
+	from(kotlinDependencies)
+	into("neu-kotlin-libraries-wrapped")
+}
+
+tasks.register("updateBackupRepo") {
+	doLast {
+		val url = URL("https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/archive/refs/heads/master.zip")
+		val destination = File(
+			project.layout.projectDirectory.asFile.absolutePath
+				.plus("/src/main/resources/assets/notenoughupdates/repo.zip")
+		)
+		destination.createNewFile()
+
+		destination.outputStream().use {
+			url.openStream().copyTo(it)
+		}
+		println("done downloading")
+	}
 }
 
 
 tasks.shadowJar {
-		archiveClassifier.set("dep-dev")
-		configurations = listOf(shadowImplementation, shadowApi, shadowOnly)
-		archiveBaseName.set("NotEnoughUpdates")
-		exclude("**/module-info.class", "LICENSE.txt")
-		dependencies {
-				exclude {
-						it.moduleGroup.startsWith("org.apache.") || it.moduleName in
-										listOf("logback-classic", "commons-logging", "commons-codec", "logback-core")
-				}
+	archiveClassifier.set("dep-dev")
+	configurations = listOf(shadowImplementation, shadowApi, shadowOnly)
+	archiveBaseName.set("NotEnoughUpdates")
+	exclude("**/module-info.class", "LICENSE.txt")
+	dependencies {
+		exclude {
+			it.moduleGroup.startsWith("org.apache.") || it.moduleName in
+				listOf("logback-classic", "commons-logging", "commons-codec", "logback-core")
 		}
-		from(oneconfigQuarantineSourceSet.output)
-		from(kotlinDependencyCollectionJar)
-		dependsOn(kotlinDependencyCollectionJar)
-		fun relocate(name: String) = relocate(name, "io.github.moulberry.notenoughupdates.deps.$name")
-		relocate("com.mojang.brigadier")
+	}
+	from(oneconfigQuarantineSourceSet.output)
+	from(kotlinDependencyCollectionJar)
+	dependsOn(kotlinDependencyCollectionJar)
+	fun relocate(name: String) = relocate(name, "io.github.moulberry.notenoughupdates.deps.$name")
+	relocate("com.mojang.brigadier")
 }
 
 tasks.assemble.get().dependsOn(remapJar)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -229,7 +229,7 @@ val kotlinDependencyCollectionJar by tasks.creating(Zip::class) {
 
 tasks.register("includeBackupRepo") {
 	doLast {
-		val url = URL("https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/archive/refs/heads/master.zip")
+		val url = URL("https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/archive/refs/heads/prerelease.zip")
 		val destinationFolder = project.buildDir.resolve("classes/java/main/assets/notenoughupdates/")
 		destinationFolder.mkdirs()
 		val destination = destinationFolder.resolve("repo.zip")

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -72,6 +72,9 @@ import java.io.Reader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -145,6 +148,8 @@ public class NEUManager {
 
 	public CraftingOverlay craftingOverlay;
 
+	private static boolean repoDownloadFailed = false;
+
 	public NEUManager(NotEnoughUpdates neu, File configLocation) {
 		this.neu = neu;
 		this.configLocation = configLocation;
@@ -198,15 +203,16 @@ public class NEUManager {
 				} catch (Exception e) {
 					e.printStackTrace();
 				}
-				if (latestRepoCommit == null || latestRepoCommit.isEmpty()) return false;
+				if (latestRepoCommit == null || latestRepoCommit.isEmpty()) {
+					repoDownloadFailed = true;
+					return false;
+				}
 
 				if (new File(configLocation, "repo").exists() && new File(configLocation, "repo/items").exists()) {
 					if (currentCommitJSON != null && currentCommitJSON.get("sha").getAsString().equals(latestRepoCommit)) {
 						return false;
 					}
 				}
-				Utils.recursiveDelete(repoLocation);
-				repoLocation.mkdirs();
 
 				File itemsZip = new File(repoLocation, "neu-items-master.zip");
 				try {
@@ -220,11 +226,14 @@ public class NEUManager {
 				urlConnection.setConnectTimeout(15000);
 				urlConnection.setReadTimeout(30000);
 
+				Utils.recursiveDelete(repoLocation);
+				repoLocation.mkdirs();
 				try (InputStream is = urlConnection.getInputStream()) {
 					FileUtils.copyInputStreamToFile(is, itemsZip);
 				} catch (IOException e) {
 					e.printStackTrace();
 					System.err.println("Failed to download NEU Repo! Please report this issue to the mod creator");
+					repoDownloadFailed = true;
 					return false;
 				}
 
@@ -250,10 +259,45 @@ public class NEUManager {
 	 * downloading of new/updated files. This then calls the "loadItem" method for every item in the local repository.
 	 */
 	public void loadItemInformation() {
-		if (NotEnoughUpdates.INSTANCE.config.apiData.autoupdate) {
-			fetchRepository().thenRun(this::reloadRepository);
+		if (NotEnoughUpdates.INSTANCE.config.apiData.autoupdate_new) {
+			fetchRepository().thenRun(() -> {
+				if (repoDownloadFailed) {
+					System.out.println("switching over to the backup repo");
+					switchToBackupRepo();
+				}
+			}).thenRun(this::reloadRepository);
 		} else {
 			reloadRepository();
+		}
+	}
+
+	/**
+	 * Copies the included backup repo to the location of the download, then pretends that the download worked and continues as normal
+	 */
+	public void switchToBackupRepo() {
+		Path destination = new File(repoLocation, "neu-items-master.zip").toPath();
+
+		try (
+			InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(
+				"assets/notenoughupdates/repo.zip")
+		) {
+			if (inputStream == null) {
+				System.out.println("Failed to copy backup repo");
+				return;
+			}
+			Files.copy(inputStream, destination, StandardCopyOption.REPLACE_EXISTING);
+
+			unzipIgnoreFirstFolder(destination.toAbsolutePath().toString(), repoLocation.getAbsolutePath());
+			JsonObject newCurrentCommitJSON = new JsonObject();
+			newCurrentCommitJSON.addProperty("sha", "backuprepo");
+			try {
+				writeJson(newCurrentCommitJSON, new File(configLocation, "currentCommit.json"));
+			} catch (IOException ignored) {
+			}
+			System.out.println("Successfully switched to backup repo");
+		} catch (IOException e) {
+			e.printStackTrace();
+			System.out.println("Failed to load backup repo");
 		}
 	}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/ApiData.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/ApiData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -57,7 +57,7 @@ public class ApiData {
 	)
 	@ConfigEditorBoolean()
 	@ConfigAccordionId(id = 0)
-	public boolean autoupdate = true;
+	public boolean autoupdate_new = true;
 
 	@ConfigAccordionId(id = 0)
 	@ConfigOption(


### PR DESCRIPTION
Should stop the constant stream of repo issues in the support channel.
If the request to github fails, the local backup, which is included in the assets, is used instead.

The transition should not be noticable. Since the repo at release contains the required data for all features, this should make `Utils.showOutdatedRepoNotification()` unreachable (if everything works as intended)

To include it in the build: `./gradlew includeBackupRepo build`


I renamed the autoupdate variable since most people who have it disabled shouldn't need it anymore and and would be missing the opportunity to have the latest items.


Tested by blocking the github domain and it works on my machine:tm: