### PR TITLE
Allow world render to use players alpha config value

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/core/util/render/RenderUtils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/core/util/render/RenderUtils.java
@@ -40,7 +40,6 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Vec3;
 import net.minecraft.util.Vec3i;
-import net.minecraftforge.client.event.RenderWorldLastEvent;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL14;
 import org.lwjgl.util.vector.Vector3f;
@@ -329,7 +328,7 @@ public class RenderUtils {
 		GlStateManager.disableDepth();
 		GlStateManager.disableCull();
 		GlStateManager.disableTexture2D();
-		CustomItemEffects.drawFilledBoundingBox(bb, 1f, SpecialColour.special(0, 100, rgb));
+		CustomItemEffects.drawFilledBoundingBox(bb, 1f, SpecialColour.special(0, (rgb >> 24) & 0xFF, rgb));
 		GlStateManager.enableTexture2D();
 		GlStateManager.enableCull();
 		GlStateManager.enableDepth();

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/world/EnderNodeHighlighter.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/world/EnderNodeHighlighter.java
@@ -94,6 +94,6 @@ public class EnderNodeHighlighter extends GenericBlockHighlighter {
 
 	@Override
 	protected int getColor(BlockPos blockPos) {
-		return SpecialColour.specialToChromaRGB(NotEnoughUpdates.INSTANCE.config.world.enderNodeColor);
+		return SpecialColour.specialToChromaRGB(NotEnoughUpdates.INSTANCE.config.world.enderNodeColor2);
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/world/FrozenTreasuresHighlighter.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/world/FrozenTreasuresHighlighter.java
@@ -121,6 +121,6 @@ public class FrozenTreasuresHighlighter extends GenericBlockHighlighter {
 
 	@Override
 	protected int getColor(BlockPos blockPos) {
-		return SpecialColour.specialToChromaRGB(NotEnoughUpdates.INSTANCE.config.world.frozenTreasuresColor);
+		return SpecialColour.specialToChromaRGB(NotEnoughUpdates.INSTANCE.config.world.frozenTreasuresColor2);
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/world/GlowingMushroomHighlighter.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/world/GlowingMushroomHighlighter.java
@@ -68,7 +68,7 @@ public class GlowingMushroomHighlighter extends GenericBlockHighlighter {
 
 	@Override
 	protected int getColor(BlockPos blockPos) {
-		return SpecialColour.specialToChromaRGB(NotEnoughUpdates.INSTANCE.config.world.glowingMushroomColor);
+		return SpecialColour.specialToChromaRGB(NotEnoughUpdates.INSTANCE.config.world.glowingMushroomColor2);
 	}
 
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/WorldConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/WorldConfig.java
@@ -52,7 +52,7 @@ public class WorldConfig {
 	)
 	@ConfigEditorColour
 	@ConfigAccordionId(id = 1)
-	public String glowingMushroomColor = "0:255:142:88:36";
+	public String glowingMushroomColor = "0:100:142:88:36";
 
 	@Expose
 	@ConfigOption(
@@ -78,7 +78,7 @@ public class WorldConfig {
 	)
 	@ConfigEditorColour
 	@ConfigAccordionId(id = 2)
-	public String enderNodeColor = "0:255:0:255:0";
+	public String enderNodeColor = "0:100:0:255:0";
 
 	@Expose
 	@ConfigOption(
@@ -104,6 +104,6 @@ public class WorldConfig {
 	)
 	@ConfigEditorColour
 	@ConfigAccordionId(id = 3)
-	public String frozenTreasuresColor = "0:255:0:255:0";
+	public String frozenTreasuresColor = "0:100:0:255:0";
 
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/WorldConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/WorldConfig.java
@@ -52,7 +52,7 @@ public class WorldConfig {
 	)
 	@ConfigEditorColour
 	@ConfigAccordionId(id = 1)
-	public String glowingMushroomColor = "0:100:142:88:36";
+	public String glowingMushroomColor2 = "0:100:142:88:36";
 
 	@Expose
 	@ConfigOption(
@@ -78,7 +78,7 @@ public class WorldConfig {
 	)
 	@ConfigEditorColour
 	@ConfigAccordionId(id = 2)
-	public String enderNodeColor = "0:100:0:255:0";
+	public String enderNodeColor2 = "0:100:0:255:0";
 
 	@Expose
 	@ConfigOption(
@@ -104,6 +104,6 @@ public class WorldConfig {
 	)
 	@ConfigEditorColour
 	@ConfigAccordionId(id = 3)
-	public String frozenTreasuresColor = "0:100:0:255:0";
+	public String frozenTreasuresColor2 = "0:100:0:255:0";
 
 }


### PR DESCRIPTION
the options were to either
1. reset everyones colour
2. not do anything and everyones thingy becomes full alpha and they complain frown face