### PR TITLE
Crystal Hollows Chest Highlighter

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/core/util/render/RenderUtils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/core/util/render/RenderUtils.java
@@ -311,27 +311,29 @@ public class RenderUtils {
 	public static void renderBoundingBox(
 		BlockPos worldPos,
 		int rgb,
-		float partialTicks
+		float partialTicks,
+		boolean disableDepth
 	) {
 		Vector3f interpolatedPlayerPosition = getInterpolatedPlayerPosition(partialTicks);
 		renderBoundingBoxInViewSpace(
 			worldPos.getX() - interpolatedPlayerPosition.x,
 			worldPos.getY() - interpolatedPlayerPosition.y,
 			worldPos.getZ() - interpolatedPlayerPosition.z,
-			rgb
+			rgb,
+			disableDepth
 		);
 	}
 
-	private static void renderBoundingBoxInViewSpace(double x, double y, double z, int rgb) {
+	private static void renderBoundingBoxInViewSpace(double x, double y, double z, int rgb, boolean disableDepth) {
 		AxisAlignedBB bb = new AxisAlignedBB(x, y, z, x + 1, y + 1, z + 1);
 
-		GlStateManager.disableDepth();
+		if (disableDepth) GlStateManager.disableDepth();
 		GlStateManager.disableCull();
 		GlStateManager.disableTexture2D();
 		CustomItemEffects.drawFilledBoundingBox(bb, 1f, SpecialColour.special(0, (rgb >> 24) & 0xFF, rgb));
 		GlStateManager.enableTexture2D();
 		GlStateManager.enableCull();
-		GlStateManager.enableDepth();
+		if (disableDepth) GlStateManager.enableDepth();
 	}
 
 	public static void renderBeaconBeam(BlockPos block, int rgb, float alphaMult, float partialTicks) {
@@ -395,7 +397,7 @@ public class RenderUtils {
 		if (distSq > 10 * 10) {
 			RenderUtils.renderBeaconBeam(x, y, z, rgb, 1.0f, partialTicks, true);
 		} else {
-			RenderUtils.renderBoundingBoxInViewSpace(x, y, z, rgb);
+			RenderUtils.renderBoundingBoxInViewSpace(x, y, z, rgb, true);
 		}
 	}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/world/CrystalHollowChestHighlighter.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/world/CrystalHollowChestHighlighter.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2023 NotEnoughUpdates contributors
+ *
+ * This file is part of NotEnoughUpdates.
+ *
+ * NotEnoughUpdates is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * NotEnoughUpdates is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.moulberry.notenoughupdates.miscfeatures.world;
+
+import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
+import io.github.moulberry.notenoughupdates.autosubscribe.NEUAutoSubscribe;
+import io.github.moulberry.notenoughupdates.core.util.render.RenderUtils;
+import io.github.moulberry.notenoughupdates.util.SBInfo;
+import io.github.moulberry.notenoughupdates.util.SpecialColour;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.Minecraft;
+import net.minecraft.init.Blocks;
+import net.minecraft.network.play.server.S22PacketMultiBlockChange;
+import net.minecraft.network.play.server.S23PacketBlockChange;
+import net.minecraft.util.BlockPos;
+import net.minecraft.util.Vec3;
+import net.minecraft.world.World;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@NEUAutoSubscribe
+public class CrystalHollowChestHighlighter extends GenericBlockHighlighter {
+
+	// Because ConcurrentModificationException is the bane of me
+	public static CopyOnWriteArrayList<BlockPos> markedBlocks = new CopyOnWriteArrayList<>();
+
+	public static void processBlockChangePacket(S23PacketBlockChange packetIn) {
+		BlockPos pos = packetIn.getBlockPosition();
+		checkForChest(pos, packetIn.blockState);
+	}
+
+	public static void processMultiBlockChangePacket(S22PacketMultiBlockChange packetIn) {
+		for (S22PacketMultiBlockChange.BlockUpdateData blockChanged : packetIn.getChangedBlocks()) {
+			BlockPos pos = blockChanged.getPos();
+			checkForChest(pos, blockChanged.getBlockState());
+		}
+	}
+
+	public static void checkForChest(BlockPos pos, IBlockState blockState) {
+		IBlockState oldState = Minecraft.getMinecraft().theWorld.getBlockState(pos);
+
+		if ((oldState.getBlock() == Blocks.air || oldState.getBlock() == Blocks.stone) &&
+			blockState.getBlock() == Blocks.chest) {
+
+			// Only add if in a 10x10x10 area. Minimises other players' chests being caught
+			if (Minecraft.getMinecraft().thePlayer.getEntityBoundingBox().expand(10, 10, 10).isVecInside(new Vec3(pos))) {
+				markedBlocks.add(pos);
+			}
+		}
+	}
+
+	@SubscribeEvent
+	public void onTick(TickEvent.ClientTickEvent event) {
+		if (!isEnabled()) return;
+
+		markedBlocks.forEach(this::tryRegisterInterest);
+
+		// Here to catch chests that get highlighted by other people after they open them, and
+		// any highlighted blocks in which the chest despawned in
+		List<BlockPos> blockToRemove = new ArrayList<>();
+		highlightedBlocks.forEach(it -> {
+			if (Minecraft.getMinecraft().theWorld.getBlockState(it).getBlock() != Blocks.chest) {
+				blockToRemove.add(it);
+			}
+		});
+
+		blockToRemove.forEach(highlightedBlocks::remove);
+	}
+
+	@SubscribeEvent
+	public void onBlockInteraction(PlayerInteractEvent event) {
+		if (event.action == PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK) {
+			markedBlocks.remove(event.pos);
+			highlightedBlocks.remove(event.pos);
+		}
+	}
+
+	@Override
+	public void onWorldRenderLast(RenderWorldLastEvent event) {
+		if (!isEnabled()) return;
+		World w = Minecraft.getMinecraft().theWorld;
+		if (w == null) return;
+		for (BlockPos blockPos : highlightedBlocks) {
+			RenderUtils.renderBoundingBox(blockPos, getColor(blockPos), event.partialTicks, false);
+		}
+	}
+
+	@Override
+	protected boolean isEnabled() {
+		return "crystal_hollows".equals(SBInfo.getInstance().getLocation()) &&
+			NotEnoughUpdates.INSTANCE.config.world.highlightCrystalHollowChests;
+	}
+
+	@Override
+	protected boolean isValidHighlightSpot(BlockPos key) {
+		World w = Minecraft.getMinecraft().theWorld;
+		if (w == null) return false;
+		Block b = w.getBlockState(key).getBlock();
+		return b == Blocks.chest;
+	}
+
+	@Override
+	protected int getColor(BlockPos blockPos) {
+		return SpecialColour.specialToChromaRGB(NotEnoughUpdates.INSTANCE.config.world.crystalHollowChestColor);
+	}
+}

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/world/GenericBlockHighlighter.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/world/GenericBlockHighlighter.java
@@ -49,7 +49,7 @@ public abstract class GenericBlockHighlighter {
 		World w = Minecraft.getMinecraft().theWorld;
 		if (w == null) return;
 		for (BlockPos blockPos : highlightedBlocks) {
-			RenderUtils.renderBoundingBox(blockPos, getColor(blockPos), event.partialTicks);
+			RenderUtils.renderBoundingBox(blockPos, getColor(blockPos), event.partialTicks, true);
 		}
 	}
 
@@ -108,6 +108,10 @@ public abstract class GenericBlockHighlighter {
 	@SubscribeEvent
 	public void onWorldChange(WorldEvent.Load event) {
 		highlightedBlocks.clear();
+	}
+
+	public boolean tryRegisterInterest(BlockPos pos) {
+		return tryRegisterInterest(pos.getX(), pos.getY(), pos.getZ());
 	}
 
 	public boolean tryRegisterInterest(double x, double y, double z) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinNetHandlerPlayClient.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinNetHandlerPlayClient.java
@@ -26,6 +26,7 @@ import io.github.moulberry.notenoughupdates.miscfeatures.EnchantingSolvers;
 import io.github.moulberry.notenoughupdates.miscfeatures.ItemCooldowns;
 import io.github.moulberry.notenoughupdates.miscfeatures.MiningStuff;
 import io.github.moulberry.notenoughupdates.miscfeatures.StorageManager;
+import io.github.moulberry.notenoughupdates.miscfeatures.world.CrystalHollowChestHighlighter;
 import io.github.moulberry.notenoughupdates.util.SBInfo;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.network.NetHandlerPlayClient;
@@ -33,6 +34,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.client.C01PacketChatMessage;
 import net.minecraft.network.play.client.C0EPacketClickWindow;
+import net.minecraft.network.play.server.S22PacketMultiBlockChange;
 import net.minecraft.network.play.server.S23PacketBlockChange;
 import net.minecraft.network.play.server.S2DPacketOpenWindow;
 import net.minecraft.network.play.server.S2EPacketCloseWindow;
@@ -119,6 +121,12 @@ public class MixinNetHandlerPlayClient {
 	public void handleBlockChange(S23PacketBlockChange packetIn, CallbackInfo ci) {
 		MiningStuff.processBlockChangePacket(packetIn);
 		ItemCooldowns.processBlockChangePacket(packetIn);
+		CrystalHollowChestHighlighter.processBlockChangePacket(packetIn);
+	}
+
+	@Inject(method = "handleMultiBlockChange", at = @At("HEAD"))
+	public void handleMultiBlockChange(S22PacketMultiBlockChange packetIn, CallbackInfo ci) {
+		 CrystalHollowChestHighlighter.processMultiBlockChangePacket(packetIn);
 	}
 
 	@Inject(method = "addToSendQueue", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/WorldConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/WorldConfig.java
@@ -106,4 +106,29 @@ public class WorldConfig {
 	@ConfigAccordionId(id = 3)
 	public String frozenTreasuresColor2 = "0:100:0:255:0";
 
+	@Expose
+	@ConfigOption(
+		name = "Crystal Hollow Chests",
+		desc = ""
+	)
+	@ConfigEditorAccordion(id = 4)
+	public boolean crystalHollowChestsAccordion = true;
+
+	@Expose
+	@ConfigOption(
+		name = "Crystal Hollow Chest Highlighter",
+		desc = "Highlights chests found in the crystal hollows whilst powder mining"
+	)
+	@ConfigEditorBoolean
+	@ConfigAccordionId(id = 4)
+	public boolean highlightCrystalHollowChests = false;
+
+	@Expose
+	@ConfigOption(
+		name = "Chest Highlight Color",
+		desc = "In which color should chests be highlighted"
+	)
+	@ConfigEditorColour
+	@ConfigAccordionId(id = 4)
+	public String crystalHollowChestColor = "0:66:255:0:41";
 }


### PR DESCRIPTION
Adds a chest highlighter to the treasure chests found when powder mining. It's more consistent than Skytils' feature as we check both the `S22PacketMultiBlockChange` and `S23PacketBlockChange` packet (whereas Skytils doesn't) since the chests are loaded from either not just one.