### PR TITLE
Fix skyblock level calculations in PV

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/SkyblockProfiles.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/SkyblockProfiles.java
@@ -950,8 +950,13 @@ public class SkyblockProfiles {
 			return levelingInfo = out;
 		}
 
-		public int getBestiaryLevel() {
-			return BestiaryData.calculateTotalBestiaryLevel(BestiaryData.parseBestiaryData(getProfileJson()));
+		/**
+		 * Get the Skyblock XP provided by the bestiary progress for this profile
+		 *
+		 * @return skyblock xp
+		 */
+		public int getBestiaryXp() {
+			return BestiaryData.calculateBestiarySkyblockXp(getProfileJson());
 		}
 
 		public JsonObject getPetsInfo() {

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/bestiary/BestiaryData.kt
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/bestiary/BestiaryData.kt
@@ -23,6 +23,7 @@ import com.google.gson.JsonObject
 import io.github.moulberry.notenoughupdates.util.Constants
 import io.github.moulberry.notenoughupdates.util.ItemUtils
 import io.github.moulberry.notenoughupdates.util.Utils
+import kotlin.math.min
 
 object BestiaryData {
     private val categoriesToParse = listOf(
@@ -51,12 +52,33 @@ object BestiaryData {
      * @see BestiaryPage.parseBestiaryData
      */
     @JvmStatic
-    fun calculateTotalBestiaryLevel(computedCategories: List<Category>): Int {
-        var level = 0.0
+    fun calculateTotalBestiaryTiers(computedCategories: List<Category>): Int {
+        var tiers = 0.0
         computedCategories.forEach {
-            level += countTotalLevels(it)
+            tiers += countTotalLevels(it)
         }
-        return level.toInt() - 1
+        return tiers.toInt()
+    }
+
+    /**
+     * Calculate the skyblock xp awarded for the given bestiary progress
+     */
+    @JvmStatic
+    fun calculateBestiarySkyblockXp(profileInfo: JsonObject): Int {
+        val totalTiers = calculateTotalBestiaryTiers(parseBestiaryData(profileInfo))
+        var skyblockXp = 0
+
+        val slayingTask = Constants.SBLEVELS.getAsJsonObject("slaying_task") ?: return 0
+        val xpPerTier = slayingTask.get("bestiary_family_xp").asInt
+        val xpPerMilestone = slayingTask.get("bestiary_milestone_xp").asInt
+        val maxXp = slayingTask.get("bestiary_progress").asInt
+
+        skyblockXp += totalTiers * xpPerTier
+
+        val milestones = (totalTiers / 100)
+        skyblockXp += milestones * xpPerMilestone
+
+        return min(skyblockXp, maxXp)
     }
 
     private fun countTotalLevels(category: Category): Int {

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/bestiary/BestiaryData.kt
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/bestiary/BestiaryData.kt
@@ -69,7 +69,7 @@ object BestiaryData {
         var skyblockXp = 0
 
         val slayingTask = Constants.SBLEVELS.getAsJsonObject("slaying_task") ?: return 0
-        val xpPerTier = slayingTask.get("bestiary_family_xp").asInt
+        val xpPerTier = (slayingTask.get("bestiary_family_xp") ?: return 0).asInt
         val xpPerMilestone = slayingTask.get("bestiary_milestone_xp").asInt
         val maxXp = slayingTask.get("bestiary_progress").asInt
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/bestiary/BestiaryPage.kt
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/bestiary/BestiaryPage.kt
@@ -21,7 +21,7 @@ package io.github.moulberry.notenoughupdates.profileviewer.bestiary
 import io.github.moulberry.notenoughupdates.core.util.StringUtils
 import io.github.moulberry.notenoughupdates.profileviewer.GuiProfileViewer
 import io.github.moulberry.notenoughupdates.profileviewer.GuiProfileViewerPage
-import io.github.moulberry.notenoughupdates.profileviewer.bestiary.BestiaryData.calculateTotalBestiaryLevel
+import io.github.moulberry.notenoughupdates.profileviewer.bestiary.BestiaryData.calculateTotalBestiaryTiers
 import io.github.moulberry.notenoughupdates.profileviewer.bestiary.BestiaryData.hasMigrated
 import io.github.moulberry.notenoughupdates.profileviewer.bestiary.BestiaryData.parseBestiaryData
 import io.github.moulberry.notenoughupdates.util.Constants
@@ -61,7 +61,7 @@ class BestiaryPage(instance: GuiProfileViewer?) : GuiProfileViewerPage(instance)
     private var lastSelectedCategory = ""
     private var selectedSubCategory = ""
     private var tooltipToDisplay: MutableList<String> = mutableListOf()
-    private var bestiaryLevel = 0
+    private var bestiaryLevel = 0.0
     private var computedCategories: MutableList<Category> = mutableListOf()
 
     private val bestiaryTexture = ResourceLocation("notenoughupdates:pv_bestiary_tab.png")
@@ -90,7 +90,7 @@ class BestiaryPage(instance: GuiProfileViewer?) : GuiProfileViewerPage(instance)
         // Do the initial parsing only once
         if (computedCategories.isEmpty()) {
             computedCategories = parseBestiaryData(profileInfo)
-            bestiaryLevel = calculateTotalBestiaryLevel(computedCategories)
+            bestiaryLevel = calculateTotalBestiaryTiers(computedCategories).toDouble()
         }
         val bestiarySize = computedCategories.size
         val bestiaryXSize = (350f / (bestiarySize - 1 + 0.0000001f)).toInt()
@@ -150,7 +150,7 @@ class BestiaryPage(instance: GuiProfileViewer?) : GuiProfileViewerPage(instance)
         val color = Color(128, 128, 128, 255)
         Utils.renderAlignedString(
             EnumChatFormatting.RED.toString() + "Milestone: ",
-            "${EnumChatFormatting.GRAY}${(bestiaryLevel / 10) - 1}",
+            "${EnumChatFormatting.GRAY}${(bestiaryLevel / 10)}",
             (guiLeft + 280).toFloat(),
             (guiTop + 50).toFloat(),
             110

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/level/task/SlayingTaskLevel.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/level/task/SlayingTaskLevel.java
@@ -161,10 +161,7 @@ public class SlayingTaskLevel extends GuiTaskLevel {
 			if (kuudraBossCollection >= 5000) bossCollectionXp += 30;
 		}
 
-		int sbXpBestiary = 0;
-		int bestiaryTiers = GuiProfileViewer.getSelectedProfile().getBestiaryLevel();
-		sbXpBestiary += bestiaryTiers;
-		sbXpBestiary = sbXpBestiary + (sbXpBestiary / 10) * 2;
+		int sbXpBestiary = GuiProfileViewer.getSelectedProfile().getBestiaryXp();
 
 		int mythologicalKillsXp = 0;
 		if (object.has("stats")) {
@@ -179,13 +176,7 @@ public class SlayingTaskLevel extends GuiTaskLevel {
 		int sbXpFromDragonKills = 0;
 		JsonObject slayDragonsXp = slayingTask.getAsJsonObject("slay_dragons_xp");
 		for (Map.Entry<String, JsonElement> stringJsonElementEntry : slayDragonsXp.entrySet()) {
-			String key = stringJsonElementEntry.getKey();
-			int value = stringJsonElementEntry.getValue().getAsInt();
-			// kills_superior_dragon_100
-			float element = Utils.getElementAsFloat(Utils.getElement(object, "bestiary.kills_" + key + "_100"), 0);
-			if (element > 0) {
-				sbXpFromDragonKills += value;
-			}
+			sbXpFromDragonKills += stringJsonElementEntry.getValue().getAsInt();
 		}
 
 		// slayer kills
@@ -215,21 +206,15 @@ public class SlayingTaskLevel extends GuiTaskLevel {
 		// arachne
 		JsonArray defeatArachneXp = slayingTask.get("defeat_arachne_xp").getAsJsonArray();
 		int sbXpGainedArachne = 0;
-
-		JsonElement tier1 = Utils.getElement(object, "bestiary.kills_arachne_300");
-		if (tier1 != null) {
-			sbXpGainedArachne += defeatArachneXp.get(0).getAsInt();
-		}
-
-		JsonElement tier2 = Utils.getElement(object, "bestiary.kills_arachne_500");
-		if (tier2 != null) {
-			sbXpGainedArachne += defeatArachneXp.get(1).getAsInt();
+		for (JsonElement jsonElement : defeatArachneXp) {
+			sbXpGainedArachne += jsonElement.getAsInt();
 		}
 
 		List<String> lore = new ArrayList<>();
 
 		int slayerLevelUpMax = slayingTask.get("slayer_level_up").getAsInt();
 		int bossCollectionsMax = slayingTask.get("boss_collections").getAsInt();
+		int bestiaryXpMax = slayingTask.get("bestiary_progress").getAsInt();
 		int slayDragonsMax = slayingTask.get("slay_dragons").getAsInt();
 		int defeatSlayersMax = slayingTask.get("defeat_slayers").getAsInt();
 		int defeatKuudraMax = slayingTask.get("defeat_kuudra").getAsInt();
@@ -237,7 +222,7 @@ public class SlayingTaskLevel extends GuiTaskLevel {
 
 		lore.add(levelPage.buildLore("Slayer Level Up", sbXpGainedSlayer, slayerLevelUpMax, false));
 		lore.add(levelPage.buildLore("Boss Collections", bossCollectionXp, bossCollectionsMax, false));
-		lore.add(levelPage.buildLore("Bestiary Progress", sbXpBestiary, 0, true));
+		lore.add(levelPage.buildLore("Bestiary Progress", sbXpBestiary, bestiaryXpMax, false));
 		lore.add(levelPage.buildLore("Mythological Kills", mythologicalKillsXp, mythologicalKillsMax, false));
 		lore.add(levelPage.buildLore("Slay Dragons", sbXpFromDragonKills, slayDragonsMax, false));
 		lore.add(levelPage.buildLore("Defeat Slayers", sbXpFromSlayerDefeat, defeatSlayersMax, false));
@@ -247,7 +232,7 @@ public class SlayingTaskLevel extends GuiTaskLevel {
 		int slayingTaskMax = levelPage.getConstant().getAsJsonObject("category_xp").get("slaying_task").getAsInt();
 
 		int totalXp = sbXpGainedSlayer + bossCollectionXp + mythologicalKillsXp +
-			sbXpFromDragonKills + sbXpFromSlayerDefeat + sbXpDefeatKuudra + sbXpGainedArachne;
+			sbXpFromDragonKills + sbXpFromSlayerDefeat + sbXpDefeatKuudra + sbXpGainedArachne + sbXpBestiary;
 		levelPage.renderLevelBar(
 			"Slaying Task",
 			new ItemStack(Items.golden_sword),


### PR DESCRIPTION
Requires this repo branch: jani270:bestiaryprogress
see: https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/pull/982

This fixes some bugs with the skyblock level xp calculation caused by Hypixel API updates

Also overhauls the skyblock xp level calculation for the bestiary, which was broken by the bestiary API overhaul