### PR TITLE
Hover Effect for Equipment- & Pet-Display, Vanilla Cooldowns, New DevCommands, Improved CustomSkulls

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/ItemTooltipListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/ItemTooltipListener.java
@@ -722,7 +722,7 @@ public class ItemTooltipListener {
 				}
 			}
 
-			copied = k || m || n || f;
+			copied = k || m || n || f || b;
 		}
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/ItemTooltipListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/ItemTooltipListener.java
@@ -673,6 +673,7 @@ public class ItemTooltipListener {
 			boolean m = Keyboard.isKeyDown(Keyboard.KEY_M);
 			boolean n = Keyboard.isKeyDown(Keyboard.KEY_N);
 			boolean f = Keyboard.isKeyDown(Keyboard.KEY_F);
+			boolean b = Keyboard.isKeyDown(Keyboard.KEY_B);
 
 			if (!copied && f && NotEnoughUpdates.INSTANCE.config.hidden.dev) {
 				MiscUtils.copyToClipboard(NotEnoughUpdates.INSTANCE.manager.getSkullValueForItem(event.itemStack));
@@ -687,6 +688,12 @@ public class ItemTooltipListener {
 
 			if (event.itemStack.getTagCompound() != null) {
 				NBTTagCompound tag = event.itemStack.getTagCompound();
+
+				event.toolTip.add(EnumChatFormatting.AQUA + "NBT: " + EnumChatFormatting.GRAY + "[...]" +
+					EnumChatFormatting.GOLD + " [B]");
+				if (!copied && b) {
+					MiscUtils.copyToClipboard(tag.toString());
+				}
 
 				if (tag.hasKey("SkullOwner", 10)) {
 					GameProfile gameprofile = NBTUtil.readGameProfileFromNBT(tag.getCompoundTag("SkullOwner"));

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomSkulls.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomSkulls.java
@@ -72,9 +72,9 @@ public class CustomSkulls implements IResourceManagerReloadListener {
 		return INSTANCE;
 	}
 
-	private final ResourceLocation atlas = new ResourceLocation("notenoughupdates:custom_skull_textures_atlas");
+	private final ResourceLocation atlas = new ResourceLocation("notenoughupdates", "custom_skull_textures_atlas");
 	private final ResourceLocation configuration = new ResourceLocation(
-		"notenoughupdates:custom_skull_textures/customskull.json");
+		"notenoughupdates", "custom_skull_textures/customskull.json");
 	protected final TextureMap textureMap = new TextureMap("custom_skull_textures");
 
 	public static ItemCameraTransforms.TransformType mostRecentTransformType = ItemCameraTransforms.TransformType.NONE;
@@ -116,7 +116,7 @@ public class CustomSkulls implements IResourceManagerReloadListener {
 					JsonObject obj = entry.getValue().getAsJsonObject();
 					if (obj.has("model")) {
 						String location = obj.get("model").getAsString();
-						ResourceLocation loc = new ResourceLocation("notenoughupdates:custom_skull_textures/" + location + ".json");
+						ResourceLocation loc = new ResourceLocation("notenoughupdates", "custom_skull_textures/" + location + ".json");
 
 						CustomSkull skull;
 						if ((skull = skullCache.get(location)) == null) {
@@ -133,7 +133,7 @@ public class CustomSkulls implements IResourceManagerReloadListener {
 						customSkulls.put(entry.getKey(), skull);
 					} else if (obj.has("texture")) {
 						String location = obj.get("texture").getAsString();
-						ResourceLocation loc = new ResourceLocation("notenoughupdates:custom_skull_textures/" + location + ".png");
+						ResourceLocation loc = new ResourceLocation("notenoughupdates", "custom_skull_textures/" + location + ".png");
 
 						CustomSkull skull = new CustomSkull();
 						skull.texture = loc;

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomSkulls.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomSkulls.java
@@ -109,6 +109,8 @@ public class CustomSkulls implements IResourceManagerReloadListener {
 
 			if (json == null) return;
 
+			final Map<String, CustomSkull> skullCache = new HashMap<>();
+
 			for (Map.Entry<String, JsonElement> entry : json.entrySet()) {
 				if (entry.getValue().isJsonObject()) {
 					JsonObject obj = entry.getValue().getAsJsonObject();
@@ -116,12 +118,17 @@ public class CustomSkulls implements IResourceManagerReloadListener {
 						String location = obj.get("model").getAsString();
 						ResourceLocation loc = new ResourceLocation("notenoughupdates:custom_skull_textures/" + location + ".json");
 
-						CustomSkull skull = new CustomSkull();
-						skull.model = ModelBlock.deserialize(new InputStreamReader(Minecraft
-							.getMinecraft()
-							.getResourceManager()
-							.getResource(loc)
-							.getInputStream()));
+						CustomSkull skull;
+						if ((skull = skullCache.get(location)) == null) {
+							skull = new CustomSkull();
+							skull.model = ModelBlock.deserialize(new InputStreamReader(Minecraft
+								.getMinecraft()
+								.getResourceManager()
+								.getResource(loc)
+								.getInputStream()));
+
+							skullCache.put(location, skull);
+						}
 
 						customSkulls.put(entry.getKey(), skull);
 					} else if (obj.has("texture")) {
@@ -140,15 +147,16 @@ public class CustomSkulls implements IResourceManagerReloadListener {
 
 			loadSprites();
 
-			for (CustomSkull skull : customSkulls.values()) {
-				if (skull.model != null) {
-					skull.modelBaked = bakeModel(skull.model, ModelRotation.X0_Y0, false);
+			customSkulls.values().stream().distinct().forEach(
+				(CustomSkull skull) -> {
+					if (skull.model != null) {
+						skull.modelBaked = bakeModel(skull.model, ModelRotation.X0_Y0, false);
+					}
 				}
-			}
+			);
 
 			Minecraft.getMinecraft().getTextureManager().loadTexture(atlas, textureMap);
-		} catch (Exception ignored) {
-		}
+		} catch (Exception ignored) {}
 	}
 
 	private void loadSprites() {

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomSkulls.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomSkulls.java
@@ -313,7 +313,7 @@ public class CustomSkulls implements IResourceManagerReloadListener {
 		if (NotEnoughUpdates.INSTANCE.config.misc.disableSkullRetexturing) {
 			return false;
 		}
-		if (placedDirection != EnumFacing.UP || skullType != 3) {
+		if (skullType != 3) {
 			return false;
 		}
 		if (skullOwner == null || skullOwner.getId() == null) {
@@ -331,16 +331,42 @@ public class CustomSkulls implements IResourceManagerReloadListener {
 			GlStateManager.disableCull();
 			GlStateManager.enableLighting();
 
-			GlStateManager.translate(xOffset + 0.5F, yOffset, zOffset + 0.5F);
+			final float rot;
+			switch (placedDirection) {
+				case NORTH: {
+					GlStateManager.translate(xOffset + 0.5f, yOffset + 0.25f, zOffset + 0.74f);
+					rot = 0f;
+					break;
+				}
+				case SOUTH: {
+					GlStateManager.translate(xOffset + 0.5f, yOffset + 0.25f, zOffset + 0.26f);
+					rot = 180.0f;
+					break;
+				}
+				case WEST: {
+					GlStateManager.translate(xOffset + 0.74f, yOffset + 0.25f, zOffset + 0.5f);
+					rot = 270.0f;
+					break;
+				}
+				case EAST: {
+					GlStateManager.translate(xOffset + 0.26f, yOffset + 0.25f, zOffset + 0.5f);
+					rot = 90.0f;
+					break;
+				}
+				default: {
+					GlStateManager.translate(xOffset + 0.5f, yOffset, zOffset + 0.5f);
+					rot = rotationDeg;
+				}
+			}
 
 			GlStateManager.enableRescaleNormal();
 			GlStateManager.enableAlpha();
 
-			GlStateManager.rotate(rotationDeg, 0, 1, 0);
+			GlStateManager.rotate(rot, 0, 1, 0);
 
 			GlStateManager.translate(0, 0.25f, 0);
 
-			if (xOffset == -0.5 && yOffset == 0 && zOffset == -0.5 && rotationDeg == 180) {
+			if (placedDirection == EnumFacing.UP && xOffset == -0.5 && yOffset == 0 && zOffset == -0.5 && rotationDeg == 180) {
 				skull.model.getAllTransforms().applyTransform(ItemCameraTransforms.TransformType.HEAD);
 			} else {
 				skull.model.getAllTransforms().applyTransform(mostRecentTransformType);

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/ItemCooldowns.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/ItemCooldowns.java
@@ -28,7 +28,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.network.play.server.S23PacketBlockChange;
 import net.minecraft.util.BlockPos;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
-import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
@@ -292,7 +291,6 @@ public class ItemCooldowns {
 				return durabilityOverride(pickaxeUseCooldownMillisRemaining, pickaxeCooldown, stack);
 			} else return -1;
 		}
-
 		// Treecapitator / Jungle Axe
 		if (internalname.equals("TREECAPITATOR_AXE") || internalname.equals("JUNGLE_AXE")) {
 			if (treecapitatorCooldownMillisRemaining < 0) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/ItemCooldowns.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/ItemCooldowns.java
@@ -28,6 +28,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.network.play.server.S23PacketBlockChange;
 import net.minecraft.util.BlockPos;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
@@ -291,6 +292,7 @@ public class ItemCooldowns {
 				return durabilityOverride(pickaxeUseCooldownMillisRemaining, pickaxeCooldown, stack);
 			} else return -1;
 		}
+
 		// Treecapitator / Jungle Axe
 		if (internalname.equals("TREECAPITATOR_AXE") || internalname.equals("JUNGLE_AXE")) {
 			if (treecapitatorCooldownMillisRemaining < 0) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -910,7 +910,7 @@ public class PetInfoOverlay extends TextOverlay {
 
 					float deltaXp = skillXp - skillXpLast;
 
-					float gain = getXpGain(currentPet, deltaXp, entry.getKey().toUpperCase());
+					float gain = getXpGain(currentPet, deltaXp, entry.getKey());
 					totalGain += gain;
 
 					skillInfoMapLast.put(entry.getKey(), skillXp);

--- a/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinRenderItem.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinRenderItem.java
@@ -22,10 +22,12 @@ package io.github.moulberry.notenoughupdates.mixins;
 import io.github.moulberry.notenoughupdates.NEUOverlay;
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.core.ChromaColour;
+import io.github.moulberry.notenoughupdates.core.util.render.RenderUtils;
 import io.github.moulberry.notenoughupdates.listener.RenderListener;
 import io.github.moulberry.notenoughupdates.miscfeatures.ItemCooldowns;
 import io.github.moulberry.notenoughupdates.miscfeatures.ItemCustomizeManager;
 import io.github.moulberry.notenoughupdates.profileviewer.GuiProfileViewer;
+import io.github.moulberry.notenoughupdates.util.Utils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.Gui;
@@ -39,6 +41,8 @@ import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.resources.model.IBakedModel;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.MathHelper;
+import net.minecraftforge.fml.client.config.GuiUtils;
 import org.lwjgl.opengl.GL11;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -47,6 +51,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+
 @Mixin({RenderItem.class})
 public abstract class MixinRenderItem {
 	private static void func_181565_a(
@@ -54,13 +59,13 @@ public abstract class MixinRenderItem {
 		int r, int g, int b, int a
 	) {
 		w.begin(7, DefaultVertexFormats.POSITION_COLOR);
-		w.pos((x + 0), (y + 0), 0.0D)
+		w.pos(x, y, 0.0D)
 		 .color(r, g, b, a).endVertex();
-		w.pos((x + 0), (y + height), 0.0D)
+		w.pos(x, y + height, 0.0D)
 		 .color(r, g, b, a).endVertex();
-		w.pos((x + width), (y + height), 0.0D)
+		w.pos(x + width, y + height, 0.0D)
 		 .color(r, g, b, a).endVertex();
-		w.pos((x + width), (y + 0), 0.0D)
+		w.pos(x + width, y, 0.0D)
 		 .color(r, g, b, a).endVertex();
 		Tessellator.getInstance().draw();
 	}
@@ -154,7 +159,7 @@ public abstract class MixinRenderItem {
 		if (NotEnoughUpdates.INSTANCE.overlay.searchMode && RenderListener.drawingGuiScreen && NotEnoughUpdates.INSTANCE.isOnSkyblock() && !(Minecraft.getMinecraft().currentScreen instanceof GuiProfileViewer)) {
 			boolean matches = false;
 
-			GuiTextField textField = NotEnoughUpdates.INSTANCE.overlay.getTextField();
+			GuiTextField textField = NEUOverlay.getTextField();
 
 			if (textField.getText().trim().isEmpty()) {
 				matches = true;
@@ -180,7 +185,7 @@ public abstract class MixinRenderItem {
 		if (NotEnoughUpdates.INSTANCE.overlay.searchMode && RenderListener.drawingGuiScreen && NotEnoughUpdates.INSTANCE.isOnSkyblock() && !(Minecraft.getMinecraft().currentScreen instanceof GuiProfileViewer)) {
 			boolean matches = false;
 
-			GuiTextField textField = NotEnoughUpdates.INSTANCE.overlay.getTextField();
+			GuiTextField textField = NEUOverlay.getTextField();
 
 			if (textField.getText().trim().isEmpty()) {
 				matches = true;
@@ -211,7 +216,7 @@ public abstract class MixinRenderItem {
 			if (NotEnoughUpdates.INSTANCE.overlay.searchMode && RenderListener.drawingGuiScreen && NotEnoughUpdates.INSTANCE.isOnSkyblock() && !(Minecraft.getMinecraft().currentScreen instanceof GuiProfileViewer)) {
 				boolean matches = false;
 
-				GuiTextField textField = NotEnoughUpdates.INSTANCE.overlay.getTextField();
+				GuiTextField textField = NEUOverlay.getTextField();
 
 				if (textField.getText().trim().isEmpty()) {
 					matches = true;
@@ -236,22 +241,12 @@ public abstract class MixinRenderItem {
 		float damageOverride = ItemCooldowns.getDurabilityOverride(stack);
 
 		if (damageOverride >= 0) {
-			float barX = 13.0f - damageOverride * 13.0f;
-			int col = (int) Math.round(255.0D - damageOverride * 255.0D);
 			GlStateManager.disableLighting();
 			GlStateManager.disableDepth();
-			GlStateManager.disableTexture2D();
-			GlStateManager.disableAlpha();
-			GlStateManager.disableBlend();
-
-			Tessellator tessellator = Tessellator.getInstance();
-			WorldRenderer worldrenderer = tessellator.getWorldRenderer();
-			func_181565_a(worldrenderer, xPosition + 2, yPosition + 13, 13, 2, 0, 0, 0, 255);
-			func_181565_a(worldrenderer, xPosition + 2, yPosition + 13, 12, 1, (255 - col) / 4, 64, 0, 255);
-			func_181565_a(worldrenderer, xPosition + 2, yPosition + 13, barX, 1, 255 - col, col, 0, 255);
-
 			GlStateManager.enableAlpha();
-			GlStateManager.enableTexture2D();
+
+			Utils.drawRect(xPosition, yPosition + 16.0f * (1.0f - damageOverride), xPosition + 16, yPosition + 16, Integer.MAX_VALUE);
+
 			GlStateManager.enableLighting();
 			GlStateManager.enableDepth();
 		}

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Mining.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Mining.java
@@ -123,7 +123,7 @@ public class Mining {
 		minStep = 10
 	)
 	@ConfigAccordionId(id = 1)
-	public int drillFuelBarWidth = 200;
+	public int drillFuelBarWidth = 182;
 
 	@Expose
 	public Position drillFuelBarPosition = new Position(0, -100, true, false);

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Mining.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Mining.java
@@ -119,14 +119,14 @@ public class Mining {
 	)
 	@ConfigEditorSlider(
 		minValue = 50,
-		maxValue = 400,
+		maxValue = 350,
 		minStep = 10
 	)
 	@ConfigAccordionId(id = 1)
-	public int drillFuelBarWidth = 182;
+	public int drillFuelBarWidth = 180;
 
 	@Expose
-	public Position drillFuelBarPosition = new Position(0, -100, true, false);
+	public Position drillFuelBarPosition = new Position(0, -91, true, false);
 
 	@ConfigOption(
 		name = "Dwarven Overlay",

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/EquipmentOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/EquipmentOverlay.java
@@ -206,10 +206,10 @@ public class EquipmentOverlay {
 		int mouseY = height - Mouse.getY() * height / Minecraft.getMinecraft().displayHeight - 1;
 
 		// Draw Backgrounds
-		GlStateManager.color(1, 1, 1, 1);
+		GL11.glColor4f(1F, 1F, 1F, 1F);
 		AccessorGuiContainer container = ((AccessorGuiContainer) inventory);
-		int overlayLeft = container.getGuiLeft() - ARMOR_OVERLAY_OVERHAND_WIDTH;
-		int overlayTop = container.getGuiTop();
+		final int overlayLeft = container.getGuiLeft() - ARMOR_OVERLAY_OVERHAND_WIDTH;
+		final int overlayTop = container.getGuiTop();
 		if (shouldRenderArmorHud) {
 			ResourceLocation equipmentTexture = getCustomEquipmentTexture(shouldRenderPets);
 			Minecraft.getMinecraft().getTextureManager().bindTexture(equipmentTexture);
@@ -220,10 +220,9 @@ public class EquipmentOverlay {
 		if (shouldRenderPets) {
 			ResourceLocation customPetTexture = getCustomPetTexture(shouldRenderArmorHud);
 			Minecraft.getMinecraft().getTextureManager().bindTexture(customPetTexture);
+			GlStateManager.color(1, 1, 1, 1);
 
-			overlayTop += PET_OVERLAY_OFFSET_Y;
-
-			Utils.drawTexturedRect(overlayLeft, overlayTop, PET_OVERLAY_WIDTH, PET_OVERLAY_HEIGHT, GL11.GL_NEAREST);
+			Utils.drawTexturedRect(overlayLeft, overlayTop + PET_OVERLAY_OFFSET_Y, PET_OVERLAY_WIDTH, PET_OVERLAY_HEIGHT, GL11.GL_NEAREST);
 		}
 		GlStateManager.bindTexture(0);
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/EquipmentOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/EquipmentOverlay.java
@@ -348,16 +348,11 @@ public class EquipmentOverlay {
 		);
 		ItemStack petInfo = petStack;
 
-		ResourceLocation customPetTexture = getCustomPetTexture(isRenderingArmorHud());
-		Minecraft.getMinecraft().getTextureManager().bindTexture(customPetTexture);
-		GlStateManager.color(1, 1, 1, 1);
-
 		AccessorGuiContainer container = ((AccessorGuiContainer) inventory);
 
 		int overlayLeft = container.getGuiLeft() - ARMOR_OVERLAY_OVERHAND_WIDTH;
 		int overlayTop = container.getGuiTop() + PET_OVERLAY_OFFSET_Y;
 
-		Utils.drawTexturedRect(overlayLeft, overlayTop, PET_OVERLAY_WIDTH, PET_OVERLAY_HEIGHT, GL11.GL_NEAREST);
 		GlStateManager.bindTexture(0);
 
 		Utils.drawItemStack(petInfo, overlayLeft + 8, overlayTop + 8, true);

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/EquipmentOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/EquipmentOverlay.java
@@ -303,8 +303,18 @@ public class EquipmentOverlay {
 
 	private void drawSlot(ItemStack stack, int x, int y, int mouseX, int mouseY, List<String> tooltip) {
 		if (stack == null) return;
+
 		Utils.drawItemStack(stack, x, y, true);
 		if (Utils.isWithinRect(mouseX, mouseY, x, y, 16, 16)) {
+			// draw the slot overlay
+			GlStateManager.disableLighting();
+			GlStateManager.disableDepth();
+			GlStateManager.colorMask(true, true, true, false);
+			Utils.drawGradientRect(x, y, x + 16, y + 16, -2130706433, -2130706433);
+			GlStateManager.colorMask(true, true, true, true);
+			GlStateManager.enableLighting();
+			GlStateManager.enableDepth();
+
 			List<String> tt = stack.getTooltip(Minecraft.getMinecraft().thePlayer, false);
 			if (shouldShowEquipmentTooltip(tt))
 				tooltip.addAll(tt);

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/EquipmentOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/EquipmentOverlay.java
@@ -205,7 +205,29 @@ public class EquipmentOverlay {
 		int mouseX = Mouse.getX() * width / Minecraft.getMinecraft().displayWidth;
 		int mouseY = height - Mouse.getY() * height / Minecraft.getMinecraft().displayHeight - 1;
 
-		GL11.glColor4f(1F, 1F, 1F, 1F);
+		// Draw Backgrounds
+		GlStateManager.color(1, 1, 1, 1);
+		AccessorGuiContainer container = ((AccessorGuiContainer) inventory);
+		int overlayLeft = container.getGuiLeft() - ARMOR_OVERLAY_OVERHAND_WIDTH;
+		int overlayTop = container.getGuiTop();
+		if (shouldRenderArmorHud) {
+			ResourceLocation equipmentTexture = getCustomEquipmentTexture(shouldRenderPets);
+			Minecraft.getMinecraft().getTextureManager().bindTexture(equipmentTexture);
+
+			Utils.drawTexturedRect(overlayLeft, overlayTop, ARMOR_OVERLAY_WIDTH, ARMOR_OVERLAY_HEIGHT, GL11.GL_NEAREST);
+		}
+
+		if (shouldRenderPets) {
+			ResourceLocation customPetTexture = getCustomPetTexture(shouldRenderArmorHud);
+			Minecraft.getMinecraft().getTextureManager().bindTexture(customPetTexture);
+
+			overlayTop += PET_OVERLAY_OFFSET_Y;
+
+			Utils.drawTexturedRect(overlayLeft, overlayTop, PET_OVERLAY_WIDTH, PET_OVERLAY_HEIGHT, GL11.GL_NEAREST);
+		}
+		GlStateManager.bindTexture(0);
+
+		// Draw foregrounds
 		if (shouldRenderArmorHud) {
 			renderEquipmentGui(inventory, mouseX, mouseY, width, height);
 		}
@@ -216,15 +238,10 @@ public class EquipmentOverlay {
 	}
 
 	public void renderEquipmentGui(GuiInventory guiScreen, int mouseX, int mouseY, int width, int height) {
-		AccessorGuiContainer container = ((AccessorGuiContainer) guiScreen);
+		AccessorGuiContainer container = (AccessorGuiContainer) guiScreen;
 
 		int overlayLeft = container.getGuiLeft() - ARMOR_OVERLAY_OVERHAND_WIDTH;
 		int overlayTop = container.getGuiTop();
-
-		ResourceLocation equipmentTexture = getCustomEquipmentTexture(shouldRenderPets);
-		Minecraft.getMinecraft().getTextureManager().bindTexture(equipmentTexture);
-
-		Utils.drawTexturedRect(overlayLeft, overlayTop, ARMOR_OVERLAY_WIDTH, ARMOR_OVERLAY_HEIGHT, GL11.GL_NEAREST);
 
 		List<String> tooltipToDisplay = new ArrayList<>();
 		drawSlot(slot1, overlayLeft + 8, overlayTop + EQUIPMENT_SLOT_OFFSET_Y, mouseX, mouseY, tooltipToDisplay);
@@ -353,6 +370,16 @@ public class EquipmentOverlay {
 				&& Mouse.getEventButtonState()) {
 				NotEnoughUpdates.INSTANCE.trySendCommand("/pets");
 			}
+
+			// draw the slot overlay
+			GlStateManager.disableLighting();
+			GlStateManager.disableDepth();
+			GlStateManager.colorMask(true, true, true, false);
+			Utils.drawGradientRect(overlayLeft + 8, overlayTop + 8, overlayLeft + 24, overlayTop + 24, -2130706433, -2130706433);
+			GlStateManager.colorMask(true, true, true, true);
+			GlStateManager.enableLighting();
+			GlStateManager.enableDepth();
+
 			tooltipToDisplay = petInfo.getTooltip(Minecraft.getMinecraft().thePlayer, false);
 			Utils.drawHoveringText(
 				tooltipToDisplay,

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/EquipmentOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/EquipmentOverlay.java
@@ -58,6 +58,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static io.github.moulberry.notenoughupdates.util.Utils.drawHoverOverlay;
+
 @NEUAutoSubscribe
 public class EquipmentOverlay {
 	public static EquipmentOverlay INSTANCE = new EquipmentOverlay();
@@ -205,7 +207,21 @@ public class EquipmentOverlay {
 		int mouseX = Mouse.getX() * width / Minecraft.getMinecraft().displayWidth;
 		int mouseY = height - Mouse.getY() * height / Minecraft.getMinecraft().displayHeight - 1;
 
-		// Draw Backgrounds
+		// Draw Backgrounds before anything, so hover overlay isn't occluded by the background
+		renderHudBackground(inventory);
+
+		// Draw foregrounds
+		if (shouldRenderArmorHud) {
+			renderEquipmentGui(inventory, mouseX, mouseY, width, height);
+		}
+
+		if (shouldRenderPets) {
+			renderPets(inventory, mouseX, mouseY, width, height);
+		}
+	}
+
+	// Draws Backgrounds
+	public void renderHudBackground(GuiScreen inventory) {
 		GL11.glColor4f(1F, 1F, 1F, 1F);
 		AccessorGuiContainer container = ((AccessorGuiContainer) inventory);
 		final int overlayLeft = container.getGuiLeft() - ARMOR_OVERLAY_OVERHAND_WIDTH;
@@ -225,15 +241,6 @@ public class EquipmentOverlay {
 			Utils.drawTexturedRect(overlayLeft, overlayTop + PET_OVERLAY_OFFSET_Y, PET_OVERLAY_WIDTH, PET_OVERLAY_HEIGHT, GL11.GL_NEAREST);
 		}
 		GlStateManager.bindTexture(0);
-
-		// Draw foregrounds
-		if (shouldRenderArmorHud) {
-			renderEquipmentGui(inventory, mouseX, mouseY, width, height);
-		}
-
-		if (shouldRenderPets) {
-			renderPets(inventory, mouseX, mouseY, width, height);
-		}
 	}
 
 	public void renderEquipmentGui(GuiInventory guiScreen, int mouseX, int mouseY, int width, int height) {
@@ -266,7 +273,7 @@ public class EquipmentOverlay {
 			}
 
 		}
-		if (tooltipToDisplay.size() > 0 &&
+		if (!tooltipToDisplay.isEmpty() &&
 			Utils.isWithinRect(
 				mouseX, mouseY,
 				overlayLeft, overlayTop,
@@ -323,13 +330,7 @@ public class EquipmentOverlay {
 		Utils.drawItemStack(stack, x, y, true);
 		if (Utils.isWithinRect(mouseX, mouseY, x, y, 16, 16)) {
 			// draw the slot overlay
-			GlStateManager.disableLighting();
-			GlStateManager.disableDepth();
-			GlStateManager.colorMask(true, true, true, false);
-			Utils.drawGradientRect(x, y, x + 16, y + 16, -2130706433, -2130706433);
-			GlStateManager.colorMask(true, true, true, true);
-			GlStateManager.enableLighting();
-			GlStateManager.enableDepth();
+			drawHoverOverlay(x, y);
 
 			List<String> tt = stack.getTooltip(Minecraft.getMinecraft().thePlayer, false);
 			if (shouldShowEquipmentTooltip(tt))
@@ -366,13 +367,7 @@ public class EquipmentOverlay {
 			}
 
 			// draw the slot overlay
-			GlStateManager.disableLighting();
-			GlStateManager.disableDepth();
-			GlStateManager.colorMask(true, true, true, false);
-			Utils.drawGradientRect(overlayLeft + 8, overlayTop + 8, overlayLeft + 24, overlayTop + 24, -2130706433, -2130706433);
-			GlStateManager.colorMask(true, true, true, true);
-			GlStateManager.enableLighting();
-			GlStateManager.enableDepth();
+			drawHoverOverlay(overlayLeft + 8, overlayTop + 8);
 
 			tooltipToDisplay = petInfo.getTooltip(Minecraft.getMinecraft().thePlayer, false);
 			Utils.drawHoveringText(

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/FarmingSkillOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/FarmingSkillOverlay.java
@@ -362,7 +362,7 @@ public class FarmingSkillOverlay extends TextOverlay {
 		} else if (cultivating < 100000000) {
 			cultivatingTier = 9;
 			cultivatingTierAmount = "100,000,000";
-		} else if (cultivating > 100000000) {
+		} else {
 			cultivatingTier = 10;
 			cultivatingTierAmount = "Maxed";
 		}

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/FishingSkillOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/FishingSkillOverlay.java
@@ -385,7 +385,7 @@ public class FishingSkillOverlay
             if(yaw > 180) yaw -= 360;
 
             lineMap.put(6, EnumChatFormatting.AQUA+"Yaw: "+EnumChatFormatting.YELLOW+
-                    String.format("%.2f", yaw)+EnumChatFormatting.BOLD+"\u1D52");*/
+                    String.format("%.2f", yaw)+EnumChatFormatting.BOLD+"\u00b0");*/
 			int key = NotEnoughUpdates.INSTANCE.config.skillOverlays.fishKey;
 
 			ISound sound = new PositionedSound(new ResourceLocation("random.orb")) {{

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/FuelBar.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/FuelBar.java
@@ -32,6 +32,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.fml.client.config.GuiUtils;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import org.lwjgl.opengl.GL11;
@@ -106,23 +107,21 @@ public class FuelBar {
 			ScaledResolution scaledResolution = Utils.pushGuiScale(NotEnoughUpdates.INSTANCE.config.locationedit.guiScale);
 
 			Position position = NotEnoughUpdates.INSTANCE.config.mining.drillFuelBarPosition;
-			int x = position.getAbsX(scaledResolution, NotEnoughUpdates.INSTANCE.config.mining.drillFuelBarWidth);
-			int y = position.getAbsY(scaledResolution, 10);
-			x -= NotEnoughUpdates.INSTANCE.config.mining.drillFuelBarWidth / 2;
-			renderBar(x, y + 4, NotEnoughUpdates.INSTANCE.config.mining.drillFuelBarWidth, fuelAmount);
+			int x = position.getAbsX(scaledResolution, NotEnoughUpdates.INSTANCE.config.mining.drillFuelBarWidth + 2);
+			int y = position.getAbsY(scaledResolution, 5);
+			x -= NotEnoughUpdates.INSTANCE.config.mining.drillFuelBarWidth / 2 - 1;
+			renderBar(x, y + 6, NotEnoughUpdates.INSTANCE.config.mining.drillFuelBarWidth + 2, fuelAmount);
 
 			String str = fuelString.replace("\u00A77", EnumChatFormatting.DARK_GREEN.toString()) +
 				EnumChatFormatting.GOLD + String.format(" (%d%%)", (int) (fuelAmount * 100));
 
 			GlStateManager.enableBlend();
-			GL14.glBlendFuncSeparate(
-				GL11.GL_SRC_ALPHA,
+			GL14.glBlendFuncSeparate(GL11.GL_SRC_ALPHA,
 				GL11.GL_ONE_MINUS_SRC_ALPHA,
 				GL11.GL_ONE,
 				GL11.GL_ONE_MINUS_SRC_ALPHA
 			);
-			GlStateManager.tryBlendFuncSeparate(
-				GL11.GL_SRC_ALPHA,
+			GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA,
 				GL11.GL_ONE_MINUS_SRC_ALPHA,
 				GL11.GL_ONE,
 				GL11.GL_ONE_MINUS_SRC_ALPHA
@@ -133,52 +132,18 @@ public class FuelBar {
 				for (int yO = -2; yO <= 2; yO++) {
 					if (Math.abs(xO) != Math.abs(yO)) {
 						Minecraft.getMinecraft().fontRendererObj.drawString(clean,
-							x + 2 + xO / 2f, y + yO / 2f,
-							new Color(0, 0, 0, 200 / Math.max(Math.abs(xO), Math.abs(yO))).getRGB(), false
+							x + 2 + xO / 2f,
+							y + yO / 2f,
+							new Color(0, 0, 0, 200 / Math.max(Math.abs(xO), Math.abs(yO))).getRGB(),
+							false
 						);
 					}
 				}
 			}
-			Minecraft.getMinecraft().fontRendererObj.drawString(str,
-				x + 2, y, 0xffffff, false
-			);
+			Minecraft.getMinecraft().fontRendererObj.drawString(str, x + 2, y, 0xffffff, false);
 			Utils.pushGuiScale(0);
 			GlStateManager.popMatrix();
 		}
-	}
-
-	private void renderBarCap(float x, float y, boolean left, float rCapSize, float completion) {
-		float size = left ? 10 : rCapSize;
-		int startTexX = left ? 0 : (170 + 11 - (int) Math.ceil(rCapSize));
-
-		if (completion < 1) {
-			Utils.drawTexturedRect(x, y, size, 5,
-				startTexX / 181f, 1, 0 / 10f, 5 / 10f, GL11.GL_NEAREST
-			);
-		}
-		if (completion > 0) {
-			Utils.drawTexturedRect(x, y, size * completion, 5,
-				startTexX / 181f, (startTexX + size * completion) / 181f, 5 / 10f, 10 / 10f, GL11.GL_NEAREST
-			);
-		}
-	}
-
-	private void renderBarNotch(float x, float y, int id, float completion) {
-		id = id % 16;
-
-		int startTexX = 10 + id * 10;
-
-		if (completion < 1) {
-			Utils.drawTexturedRect(x, y, 10, 5,
-				startTexX / 181f, (startTexX + 10) / 181f, 0 / 10f, 5 / 10f, GL11.GL_NEAREST
-			);
-		}
-		if (completion > 0) {
-			Utils.drawTexturedRect(x, y, 10 * completion, 5,
-				startTexX / 181f, (startTexX + 10 * completion) / 181f, 5 / 10f, 10 / 10f, GL11.GL_NEAREST
-			);
-		}
-
 	}
 
 	private void renderBar(float x, float y, float xSize, float completed) {
@@ -186,26 +151,21 @@ public class FuelBar {
 
 		GlStateManager.pushMatrix();
 		GlStateManager.translate(x, y, 0);
-		xSize = xSize / 1.5f;
-		GlStateManager.scale(1.5f, 1.5f, 1);
 
 		Color c = Color.getHSBColor(148 / 360f * completed - 20 / 360f, 0.9f, 1 - 0.5f * completed);
 		GlStateManager.color(c.getRed() / 255f, c.getGreen() / 255f, c.getBlue() / 255f, 1);
 
-		float offsetCompleteX = xSize * completed;
-		for (int xOffset = 0; xOffset < xSize; xOffset += 10) {
-			float notchCompl = 1;
-			if (xOffset > offsetCompleteX) {
-				notchCompl = 0;
-			} else if (xOffset + 10 > offsetCompleteX) {
-				notchCompl = (offsetCompleteX - xOffset) / 10f;
-			}
-			if (xOffset == 0) {
-				renderBarCap(0, 0, true, 0, notchCompl);
-			} else if (xOffset + 11 > xSize) {
-				renderBarCap(xOffset, 0, false, xSize - xOffset, notchCompl);
-			} else {
-				renderBarNotch(xOffset, 0, xOffset / 10, notchCompl);
+		Utils.pushGuiScale(NotEnoughUpdates.INSTANCE.config.locationedit.guiScale);
+
+		int w = (int) xSize;
+		int w_2 = w / 2;
+		int k = (int) Math.min(w, Math.ceil(completed * w));
+		Utils.drawTexturedRect(x, y, w_2, 5, 0, w_2 / 181f, 0, 0.5f, GL11.GL_NEAREST);
+		Utils.drawTexturedRect(x + w_2, y, w_2, 5, 1 - w_2 / 181f, 1f, 0, 0.5f, GL11.GL_NEAREST);
+		if (k > 0) {
+			Utils.drawTexturedRect(x, y, Math.min(w_2, k), 5, 0, Math.min(w_2, k) / 181f, 0.5f, 1, GL11.GL_NEAREST);
+			if (completed > 0.5f) {
+				Utils.drawTexturedRect(x + w_2, y, k - w_2, 5, 1 - w_2 / 181f, 1 + (k - w) / 181f, 0.5f, 1, GL11.GL_NEAREST);
 			}
 		}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/FuelBar.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/FuelBar.java
@@ -43,7 +43,7 @@ import static io.github.moulberry.notenoughupdates.NotEnoughUpdates.MODID;
 
 @NEUAutoSubscribe
 public class FuelBar {
-	public static final ResourceLocation FUEL_BAR = new ResourceLocation(MODID, "fuel_bar.png");
+	public static final ResourceLocation FUEL_BAR = new ResourceLocation("notenoughupdates:fuel_bar.png");
 
 	private float fuelAmount = -1;
 	private String fuelString = "";

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/FuelBar.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/FuelBar.java
@@ -39,9 +39,11 @@ import org.lwjgl.opengl.GL14;
 
 import java.awt.*;
 
+import static io.github.moulberry.notenoughupdates.NotEnoughUpdates.MODID;
+
 @NEUAutoSubscribe
 public class FuelBar {
-	public static final ResourceLocation FUEL_BAR = new ResourceLocation("notenoughupdates:fuel_bar.png");
+	public static final ResourceLocation FUEL_BAR = new ResourceLocation(MODID, "fuel_bar.png");
 
 	private float fuelAmount = -1;
 	private String fuelString = "";
@@ -107,7 +109,7 @@ public class FuelBar {
 
 			Position position = NotEnoughUpdates.INSTANCE.config.mining.drillFuelBarPosition;
 			int x = position.getAbsX(scaledResolution, NotEnoughUpdates.INSTANCE.config.mining.drillFuelBarWidth);
-			int y = position.getAbsY(scaledResolution, 12);
+			int y = position.getAbsY(scaledResolution, 10);
 			x -= NotEnoughUpdates.INSTANCE.config.mining.drillFuelBarWidth / 2;
 			renderBar(x, y + 4, NotEnoughUpdates.INSTANCE.config.mining.drillFuelBarWidth, fuelAmount);
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/FuelBar.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/FuelBar.java
@@ -39,8 +39,6 @@ import org.lwjgl.opengl.GL14;
 
 import java.awt.*;
 
-import static io.github.moulberry.notenoughupdates.NotEnoughUpdates.MODID;
-
 @NEUAutoSubscribe
 public class FuelBar {
 	public static final ResourceLocation FUEL_BAR = new ResourceLocation("notenoughupdates:fuel_bar.png");

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/FuelBarDummy.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/FuelBarDummy.java
@@ -49,6 +49,6 @@ public class FuelBarDummy extends TextOverlay {
 
 	@Override
 	public Vector2f getDummySize() {
-		return new Vector2f(NotEnoughUpdates.INSTANCE.config.mining.drillFuelBarWidth, 12);
+		return new Vector2f(NotEnoughUpdates.INSTANCE.config.mining.drillFuelBarWidth + 2, 12);
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/OverlayManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/OverlayManager.java
@@ -132,7 +132,7 @@ public class OverlayManager {
 			"\u00a7bCurrent XP: \u00a7e6,734",
 			"\u00a7bRemaining XP: \u00a7e3,265",
 			"\u00a7bXP/h: \u00a7e238,129",
-			"\u00a7bYaw: \u00a7e68.25\u00a7l\u1D52"
+			"\u00a7bYaw: \u00a7e68.25\u00a7l\u00b0"
 		);
 		farmingOverlay = new FarmingSkillOverlay(NotEnoughUpdates.INSTANCE.config.skillOverlays.farmingPosition, () -> {
 			List<String> strings = new ArrayList<>();
@@ -154,7 +154,7 @@ public class OverlayManager {
 			"\u00a7bCurrent XP: \u00a7e6,734",
 			"\u00a7bRemaining XP: \u00a7e3,265",
 			"\u00a7bXP/h: \u00a7e238,129",
-			"\u00a7bYaw: \u00a7e68.25\u00a7l\u1D52"
+			"\u00a7bYaw: \u00a7e68.25\u00a7l\u00b0"
 		);
 		miningSkillOverlay = new MiningSkillOverlay(NotEnoughUpdates.INSTANCE.config.skillOverlays.miningPosition, () -> {
 			List<String> strings = new ArrayList<>();
@@ -176,7 +176,7 @@ public class OverlayManager {
 			"\u00a7bCurrent XP: \u00a7e6,734",
 			"\u00a7bRemaining XP: \u00a7e3,265",
 			"\u00a7bXP/h: \u00a7e238,129"
-			//"\u00a7bYaw: \u00a7e68.25\u00a7l\u1D52"
+			//"\u00a7bYaw: \u00a7e68.25\u00a7l\u00b0"
 		);
 		fishingSkillOverlay =
 			new FishingSkillOverlay(NotEnoughUpdates.INSTANCE.config.skillOverlays.fishingPosition, () -> {

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
@@ -174,7 +174,7 @@ public class Utils {
 	}
 
 	public static ScaledResolution pushGuiScale(int scale) {
-		if (guiScales.size() == 0) {
+		if (guiScales.isEmpty()) {
 			if (Loader.isModLoaded("labymod")) {
 				GL11.glGetFloat(GL11.GL_PROJECTION_MATRIX, projectionMatrixOld);
 				GL11.glGetFloat(GL11.GL_MODELVIEW_MATRIX, modelviewMatrixOld);
@@ -182,7 +182,7 @@ public class Utils {
 		}
 
 		if (scale < 0) {
-			if (guiScales.size() > 0) {
+			if (!guiScales.isEmpty()) {
 				guiScales.pop();
 			}
 		} else {
@@ -193,7 +193,7 @@ public class Utils {
 			}
 		}
 
-		int newScale = guiScales.size() > 0
+		int newScale = !guiScales.isEmpty()
 			? Math.max(0, guiScales.peek())
 			: Minecraft.getMinecraft().gameSettings.guiScale;
 		if (newScale == 0) newScale = Minecraft.getMinecraft().gameSettings.guiScale;
@@ -203,7 +203,7 @@ public class Utils {
 		ScaledResolution scaledresolution = new ScaledResolution(Minecraft.getMinecraft());
 		Minecraft.getMinecraft().gameSettings.guiScale = oldScale;
 
-		if (guiScales.size() > 0) {
+		if (!guiScales.isEmpty()) {
 			GlStateManager.viewport(0, 0, Minecraft.getMinecraft().displayWidth, Minecraft.getMinecraft().displayHeight);
 			GlStateManager.matrixMode(GL11.GL_PROJECTION);
 			GlStateManager.loadIdentity();
@@ -496,9 +496,9 @@ public class Utils {
 		Minecraft.getMinecraft().getTextureManager().getTexture(TextureMap.locationBlocksTexture).setBlurMipmap(true, true);
 		GlStateManager.enableRescaleNormal();
 		GlStateManager.enableAlpha();
-		GlStateManager.alphaFunc(516, 0.1F);
+		GlStateManager.alphaFunc(GL11.GL_GREATER, 0.1F);
 		GlStateManager.enableBlend();
-		GlStateManager.blendFunc(770, 771);
+		GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		setupGuiTransform(x, y, ibakedmodel.isGui3d());
 		ibakedmodel = net.minecraftforge.client.ForgeHooksClient.handleCameraTransforms(
@@ -590,7 +590,7 @@ public class Utils {
 		GlStateManager.enableBlend();
 		GL14.glBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ONE_MINUS_SRC_ALPHA);
 		GlStateManager.enableAlpha();
-		GlStateManager.alphaFunc(516, 0.1F);
+		GlStateManager.alphaFunc(GL11.GL_GREATER, 0.1F);
 
 		int x = guiLeft - 28;
 		int y = guiTop + yIndex * 28;
@@ -631,7 +631,7 @@ public class Utils {
 		GlStateManager.enableBlend();
 		GL14.glBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ONE_MINUS_SRC_ALPHA);
 		GlStateManager.enableAlpha();
-		GlStateManager.alphaFunc(516, 0.1F);
+		GlStateManager.alphaFunc(GL11.GL_GREATER, 0.1F);
 
 		Minecraft.getMinecraft().getTextureManager().bindTexture(GuiProfileViewer.pv_elements);
 
@@ -870,7 +870,7 @@ public class Utils {
 
 		Tessellator tessellator = Tessellator.getInstance();
 		WorldRenderer worldrenderer = tessellator.getWorldRenderer();
-		worldrenderer.begin(7, DefaultVertexFormats.POSITION_TEX);
+		worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
 		worldrenderer
 			.pos(x, y + height, 0.0D)
 			.tex(uMin, vMax).endVertex();
@@ -909,7 +909,7 @@ public class Utils {
 
 		Tessellator tessellator = Tessellator.getInstance();
 		WorldRenderer worldrenderer = tessellator.getWorldRenderer();
-		worldrenderer.begin(7, DefaultVertexFormats.POSITION_TEX);
+		worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
 		worldrenderer
 			.pos(x, y + height, 0.0D)
 			.tex(uMin, vMax).endVertex();
@@ -1471,17 +1471,17 @@ public class Utils {
 		GlStateManager.disableTexture2D();
 		GlStateManager.enableBlend();
 		GlStateManager.disableAlpha();
-		GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
-		GlStateManager.shadeModel(7425);
+		GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
+		GlStateManager.shadeModel(GL11.GL_SMOOTH);
 		Tessellator tessellator = Tessellator.getInstance();
 		WorldRenderer worldrenderer = tessellator.getWorldRenderer();
-		worldrenderer.begin(7, DefaultVertexFormats.POSITION_COLOR);
+		worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_COLOR);
 		worldrenderer.pos(right, top, 0).color(f1, f2, f3, f).endVertex();
 		worldrenderer.pos(left, top, 0).color(f1, f2, f3, f).endVertex();
 		worldrenderer.pos(left, bottom, 0).color(f5, f6, f7, f4).endVertex();
 		worldrenderer.pos(right, bottom, 0).color(f5, f6, f7, f4).endVertex();
 		tessellator.draw();
-		GlStateManager.shadeModel(7424);
+		GlStateManager.shadeModel(GL11.GL_FLAT);
 		GlStateManager.disableBlend();
 		GlStateManager.enableAlpha();
 		GlStateManager.enableTexture2D();
@@ -1499,17 +1499,17 @@ public class Utils {
 		GlStateManager.disableTexture2D();
 		GlStateManager.enableBlend();
 		GlStateManager.disableAlpha();
-		GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
-		GlStateManager.shadeModel(7425);
+		GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
+		GlStateManager.shadeModel(GL11.GL_SMOOTH);
 		Tessellator tessellator = Tessellator.getInstance();
 		WorldRenderer worldrenderer = tessellator.getWorldRenderer();
-		worldrenderer.begin(7, DefaultVertexFormats.POSITION_COLOR);
+		worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_COLOR);
 		worldrenderer.pos(right, top, 0).color(f5, f6, f7, f4).endVertex();
 		worldrenderer.pos(left, top, 0).color(f1, f2, f3, f).endVertex();
 		worldrenderer.pos(left, bottom, 0).color(f1, f2, f3, f).endVertex();
 		worldrenderer.pos(right, bottom, 0).color(f5, f6, f7, f4).endVertex();
 		tessellator.draw();
-		GlStateManager.shadeModel(7424);
+		GlStateManager.shadeModel(GL11.GL_FLAT);
 		GlStateManager.disableBlend();
 		GlStateManager.enableAlpha();
 		GlStateManager.enableTexture2D();
@@ -1548,8 +1548,7 @@ public class Utils {
 					StandardCharsets.UTF_8
 				))
 			) {
-				T obj = gson.fromJson(reader, clazz);
-				return obj;
+				return gson.fromJson(reader, clazz);
 			} catch (Exception e) {
 				return null;
 			}
@@ -1690,7 +1689,7 @@ public class Utils {
 		if (!textLines.isEmpty()) {
 			int borderColorStart = 0x505000FF;
 			if (NotEnoughUpdates.INSTANCE.config.tooltipTweaks.tooltipBorderColours) {
-				if (textLines.size() > 0) {
+				if (!textLines.isEmpty()) {
 					String first = textLines.get(0);
 					borderColorStart = getPrimaryColour(first).getRGB() & 0x00FFFFFF |
 						((NotEnoughUpdates.INSTANCE.config.tooltipTweaks.tooltipBorderOpacity) << 24);
@@ -1931,19 +1930,19 @@ public class Utils {
 		GlStateManager.disableTexture2D();
 		GlStateManager.enableBlend();
 		GlStateManager.disableAlpha();
-		GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
-		GlStateManager.shadeModel(7425);
+		GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
+		GlStateManager.shadeModel(GL11.GL_SMOOTH);
 
 		Tessellator tessellator = Tessellator.getInstance();
 		WorldRenderer worldrenderer = tessellator.getWorldRenderer();
-		worldrenderer.begin(7, DefaultVertexFormats.POSITION_COLOR);
+		worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_COLOR);
 		worldrenderer.pos(right, top, zLevel).color(startRed, startGreen, startBlue, startAlpha).endVertex();
 		worldrenderer.pos(left, top, zLevel).color(startRed, startGreen, startBlue, startAlpha).endVertex();
 		worldrenderer.pos(left, bottom, zLevel).color(endRed, endGreen, endBlue, endAlpha).endVertex();
 		worldrenderer.pos(right, bottom, zLevel).color(endRed, endGreen, endBlue, endAlpha).endVertex();
 		tessellator.draw();
 
-		GlStateManager.shadeModel(7424);
+		GlStateManager.shadeModel(GL11.GL_FLAT);
 		GlStateManager.disableBlend();
 		GlStateManager.enableAlpha();
 		GlStateManager.enableTexture2D();
@@ -1970,7 +1969,7 @@ public class Utils {
 		WorldRenderer worldrenderer = tessellator.getWorldRenderer();
 		GlStateManager.disableTexture2D();
 		GlStateManager.color(f, f1, f2, f3);
-		worldrenderer.begin(7, DefaultVertexFormats.POSITION);
+		worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
 		worldrenderer.pos(left, bottom, 0.0D).endVertex();
 		worldrenderer.pos(right, bottom, 0.0D).endVertex();
 		worldrenderer.pos(right, top, 0.0D).endVertex();
@@ -2003,9 +2002,9 @@ public class Utils {
 		WorldRenderer worldRenderer = tessellator.getWorldRenderer();
 		GlStateManager.enableBlend();
 		GlStateManager.disableTexture2D();
-		GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
+		GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
 		GlStateManager.color(g, h, j, f);
-		worldRenderer.begin(7, DefaultVertexFormats.POSITION);
+		worldRenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
 		worldRenderer.pos(left, bottom, 0.0).endVertex();
 		worldRenderer.pos(right, bottom, 0.0).endVertex();
 		worldRenderer.pos(right, top, 0.0).endVertex();
@@ -2013,6 +2012,35 @@ public class Utils {
 		tessellator.draw();
 		GlStateManager.enableTexture2D();
 		GlStateManager.disableBlend();
+	}
+
+
+	/**
+	 * Draws a default-size 16 by 16 item-overlay at <i>x</i> and <i>y</i>.
+	 *
+	 * @param x position of the overlay
+	 * @param y position of the overlay
+	 */
+	public static void drawHoverOverlay(int x, int y) {
+		drawHoverOverlay(x, y, 16, 16);
+	}
+
+	/**
+	 * Draws an item-overlay of given <i>width</i> and <i>height</i> at <i>x</i> and <i>y</i>.
+	 *
+	 * @param x position of the overlay
+	 * @param y position of the overlay
+	 * @param width width of the overlay
+	 * @param height height of the overlay
+	 */
+	public static void drawHoverOverlay(int x, int y, int width, int height) {
+		GlStateManager.disableLighting();
+		GlStateManager.disableDepth();
+		GlStateManager.colorMask(true, true, true, false);
+		Utils.drawGradientRect(x, y, x + 16, y + 16, 0x80ffffff, 0x80ffffff);
+		GlStateManager.colorMask(true, true, true, true);
+		GlStateManager.enableLighting();
+		GlStateManager.enableDepth();
 	}
 
 	public static String prettyTime(Duration time) {
@@ -2054,7 +2082,7 @@ public class Utils {
 		GlStateManager.disableTexture2D();
 		GlStateManager.enableBlend();
 		GlStateManager.disableAlpha();
-		GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
+		GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
 		GlStateManager.color(f1, f2, f3, f);
 		GL11.glLineWidth(width);
 		GL11.glBegin(GL11.GL_LINES);
@@ -2095,7 +2123,7 @@ public class Utils {
 
 		Tessellator tessellator = Tessellator.getInstance();
 		WorldRenderer worldrenderer = tessellator.getWorldRenderer();
-		worldrenderer.begin(7, DefaultVertexFormats.POSITION_TEX);
+		worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
 		worldrenderer
 			.pos(x1, y1, 0.0D)
 			.tex(uMin, vMax).endVertex();

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/dev/PackDevCommand.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/dev/PackDevCommand.kt
@@ -39,6 +39,7 @@ import net.minecraft.item.ItemStack
 import net.minecraft.tileentity.TileEntitySkull
 import net.minecraft.util.EnumChatFormatting
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import java.util.*
 
 
 @NEUAutoSubscribe
@@ -169,7 +170,7 @@ class PackDevCommand {
                             it.append("Name: ")
                             it.appendLine(te.playerProfile.name)
                             it.append("Textures: ")
-                            it.appendLine(te.playerProfile.properties.get("textures")?.joinToString(", ", "[", "]") { p -> "${p.name}: ${p.value}" })
+                            it.appendLine(te.playerProfile.properties.get("textures")?.firstOrNull()?.value)
                         }
                     }.toString().trim()
 

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/dev/PackDevCommand.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/dev/PackDevCommand.kt
@@ -26,6 +26,7 @@ import io.github.moulberry.notenoughupdates.autosubscribe.NEUAutoSubscribe
 import io.github.moulberry.notenoughupdates.core.util.MiscUtils
 import io.github.moulberry.notenoughupdates.events.RegisterBrigadierCommandEvent
 import io.github.moulberry.notenoughupdates.util.brigadier.*
+import net.minecraft.block.state.IBlockState
 import net.minecraft.client.Minecraft
 import net.minecraft.client.entity.AbstractClientPlayer
 import net.minecraft.command.ICommandSender
@@ -35,8 +36,10 @@ import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
+import net.minecraft.tileentity.TileEntitySkull
 import net.minecraft.util.EnumChatFormatting
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
 
 @NEUAutoSubscribe
 class PackDevCommand {
@@ -152,6 +155,31 @@ class PackDevCommand {
             npcListCommand("armor stand", "getarmorstand", "getarmorstands", EntityArmorStand::class.java) {
                 Minecraft.getMinecraft().theWorld.loadedEntityList
             }
+            thenLiteralExecute("block") {
+                val pos = Minecraft.getMinecraft().thePlayer.rayTrace(4.0, 10f).blockPos
+
+                val block: IBlockState = Minecraft.getMinecraft().theWorld.getBlockState(pos)
+                if (block.block.hasTileEntity(block)) {
+                    val te = Minecraft.getMinecraft().theWorld.getTileEntity(pos)
+                    val s = StringBuilder().also {
+                        it.appendLine("NBT: ${te.tileData}")
+                        if (te is TileEntitySkull && te.playerProfile != null) {
+                            it.appendLine("PlayerProfile:\nId: ")
+                            it.appendLine(te.playerProfile.id)
+                            it.append("Name: ")
+                            it.appendLine(te.playerProfile.name)
+                            it.append("Textures: ")
+                            it.appendLine(te.playerProfile.properties.get("textures")?.joinToString(", ", "[", "]") { p -> "${p.name}: ${p.value}" })
+                        }
+                    }.toString().trim()
+
+                    MiscUtils.copyToClipboard(s)
+                    reply("Copied data to clipboard")
+                    return@thenLiteralExecute
+                }
+                reply("No tile entity found at your cursor")
+            }.withHelp("Find the tile entity you're looking at and copy data about it to your clipboard")
+
             thenExecute {
                 NotEnoughUpdates.INSTANCE.packDevEnabled = !NotEnoughUpdates.INSTANCE.packDevEnabled
                 if (NotEnoughUpdates.INSTANCE.packDevEnabled) {


### PR DESCRIPTION
here are some changes I had laying arround:

- the slots of the equipment- & pet-display in your inventory now have the hover effect (3454f345ef4fd02123e2c403988d977848bfbc98, aab2f10823742e39ae23057bc0c6c44ee8cdd665, c2baff3b2787a268c93e47df0ec160778530929f & ef85d3fe58cff42445c7f1dc05db609e286179f4)
- changed the tool-cooldown to the 1.9+ style of enderpearls and chorus-fruits (3a6a36eca978754e28285bf35ae19f039a4151a8)
- added `/neupackdev block` to copy data of the skulls/tile-entity you're looking at (fb6a74ba0667b46a9c98a4d0b237ad6bf0fe64ef)
- with _Packdev-Mode_ on, you may now copy the full NBT-Data of an item (ea7dd1005f7e7831eb873526577526822b2026e7)
- CustomSkulls now has a second config (`customskull2.json`) that allows replacement by skull texture, which is more robust than matching against UUID: (5f25c2f9a456b20b190e0b8ad69a6baf56a72069)
```json
{
	"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWUyYWFlODg4MmRhNTAxZmVmZDYxOTcwYjYxZDUzNjNjODNjYjhkNTJmOTdlNGFlYTc2ZjliMmQ2NjE2NWFiIn19fQ==": {
		"model": "lucky_block/red"
	},
	...
}
```
- CustomSkulls now also change hanging (wall) skulls (b57ab2b59214ee2d29b886f36916308c35ca8a2a)
- CustomSkulls will no longer load the same model twice (3e8c4d2913556c44b89776721b71fd15e3001059)
- changed the Degree-Character in the Preview to match the actual overlay (6f870d617b103acd18efd01e57b11ab8f15aeb2a)
- changed the default Drill-Fuel Bar width to match the xp-bar (e7aae8e91b2c64978a9c73e37f880005303f62cd)

im sorry for submitting so many changes at once :/