### PR TITLE
Add separate locked slots for rift and overworld.

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/SlotLocking.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/SlotLocking.java
@@ -92,7 +92,6 @@ public class SlotLocking {
 	}
 
 	public static class SlotLockProfile {
-		int currentProfile = 0;
 
 		public SlotLockData[] slotLockData = new SlotLockData[1];
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/SlotLocking.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/SlotLocking.java
@@ -72,6 +72,7 @@ public class SlotLocking {
 	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
 	private static final LockedSlot DEFAULT_LOCKED_SLOT = new LockedSlot();
+
 	private final ResourceLocation LOCK = new ResourceLocation("notenoughupdates:slotlocking/lock.png");
 	private final ResourceLocation BOUND = new ResourceLocation("notenoughupdates:slotlocking/bound.png");
 
@@ -82,16 +83,18 @@ public class SlotLocking {
 	public static class LockedSlot {
 		public boolean locked = false;
 		public int boundTo = -1;
+
 	}
 
 	public static class SlotLockData {
 		public LockedSlot[] lockedSlots = new LockedSlot[40];
+		public LockedSlot[] riftLockedSlots = new LockedSlot[40];
 	}
 
 	public static class SlotLockProfile {
 		int currentProfile = 0;
 
-		public SlotLockData[] slotLockData = new SlotLockData[9];
+		public SlotLockData[] slotLockData = new SlotLockData[1];
 	}
 
 	public static class SlotLockingConfig {
@@ -196,13 +199,19 @@ public class SlotLocking {
 			profile.slotLockData[profile.currentProfile] = new SlotLockData();
 		}
 
-		return profile.slotLockData[profile.currentProfile].lockedSlots;
+
+		if (!"rift".equals(SBInfo.getInstance().getLocation())) {
+			return profile.slotLockData[profile.currentProfile].lockedSlots;
+		} else {
+			return profile.slotLockData[profile.currentProfile].riftLockedSlots;
+		}
 	}
 
 	private LockedSlot getLockedSlot(LockedSlot[] lockedSlots, int index) {
 		if (lockedSlots == null) {
 			return DEFAULT_LOCKED_SLOT;
 		}
+
 
 		LockedSlot slot = lockedSlots[index];
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/SlotLocking.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/SlotLocking.java
@@ -191,18 +191,16 @@ public class SlotLocking {
 			k -> new SlotLockProfile()
 		);
 
-		if (profile.currentProfile < 0) profile.currentProfile = 0;
-		if (profile.currentProfile >= 9) profile.currentProfile = 8;
 
-		if (profile.slotLockData[profile.currentProfile] == null) {
-			profile.slotLockData[profile.currentProfile] = new SlotLockData();
+		if (profile.slotLockData[0] == null) {
+			profile.slotLockData[0] = new SlotLockData();
 		}
 
 
 		if (!"rift".equals(SBInfo.getInstance().getLocation())) {
-			return profile.slotLockData[profile.currentProfile].lockedSlots;
+			return profile.slotLockData[0].lockedSlots;
 		} else {
-			return profile.slotLockData[profile.currentProfile].riftLockedSlots;
+			return profile.slotLockData[0].riftLockedSlots;
 		}
 	}
 


### PR DESCRIPTION
also removed unnecessary nulls 
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/73615108/2b1efcfd-b9d0-491b-a67e-f7e68f63fdb9)
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/73615108/9cb4beb5-4b42-4587-82ed-44c28087ef3c)
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/73615108/924ce39b-3177-4791-9d3e-c201dbca6c47)
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/73615108/a9776a4c-42a3-4ed6-bbf1-ebaab61e8738)
