### PR TITLE
Farming kicks

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/ItemCooldowns.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/ItemCooldowns.java
@@ -33,7 +33,9 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -170,8 +172,16 @@ public class ItemCooldowns {
 	public static void checkForBlockChange(BlockPos pos, IBlockState blockState) {
 		BlockData oldBlockData = null;
 
-		for (BlockData value : blocksClicked.values()) {
-			if (value.blockPos.equals(pos)) oldBlockData = value;
+		// Create a copy of the key set of 'blocksClicked'
+		Set<Long> keysCopy = new HashSet<>(blocksClicked.keySet());
+
+		for (Long key : keysCopy) {
+			BlockData value = blocksClicked.get(key);
+
+			if (value.blockPos.equals(pos)) {
+				oldBlockData = value;
+				blocksClicked.remove(key); // Modify the original map safely
+			}
 		}
 
 		if (oldBlockData != null) {


### PR DESCRIPTION
Did something with the `blocksClicked` field in the `checkForBlockChange` method to fix this disconnect while farming:
```
Netty Client IO #4@21376" daemon prio=5 tid=0xda nid=NA runnable
  java.lang.Thread.State: RUNNABLE
      at java.util.ConcurrentModificationException.<init>(Unknown Source:-1)
      at java.util.TreeMap$PrivateEntryIterator.nextEntry(Unknown Source:-1)
      at java.util.TreeMap$ValueIterator.next(Unknown Source:-1)
      at io.github.moulberry.notenoughupdates.miscfeatures.ItemCooldowns.checkForBlockChange(ItemCooldowns.java:173)
      at io.github.moulberry.notenoughupdates.miscfeatures.ItemCooldowns.processBlockChangePacket(ItemCooldowns.java:167)
      at net.minecraft.client.network.NetHandlerPlayClient.handler$bjb000$handleBlockChange(MixinNetHandlerPlayClient.java:123)
      at net.minecraft.client.network.NetHandlerPlayClient.func_147234_a(NetHandlerPlayClient.java:688)
      at net.minecraft.network.play.server.S23PacketBlockChange.func_148833_a(SourceFile:40)
      at net.minecraft.network.play.server.S23PacketBlockChange.func_148833_a(SourceFile:13)
      at net.minecraft.network.NetworkManager.channelRead0(NetworkManager.java:151)
      at net.minecraft.network.NetworkManager.channelRead0(NetworkManager.java:54)
      ```
I've tested it, this fixes it for me.