### PR TITLE
Add tuning stats to /pv

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/InventoriesPage.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/InventoriesPage.java
@@ -43,6 +43,7 @@ import org.lwjgl.opengl.GL11;
 
 import java.awt.*;
 import java.io.IOException;
+import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -109,6 +110,27 @@ public class InventoriesPage extends GuiProfileViewerPage {
 	private int greenCandyCount = -1;
 	private int purpleCandyCount = -1;
 
+	public static final HashMap<String, String> apiStatNames = new HashMap<String, String>() {{
+			put("health","§c❤ Health");
+			put("defense","§a❈ Defense");
+			put("walk_speed","§f✦ Speed");
+			put("strength","§c❁ Strength");
+			put("critical_damage","§9☠ Crit Damage");
+			put("critical_chance","§9☣ Crit Chance");
+			put("attack_speed","§e⚔ Bonus Attack Speed");
+			put("intelligence","§b✎ Intelligence");
+	}};
+	public static final HashMap<String, Float> tuningCoefficients = new HashMap<String, Float>() {{
+		put("health",5f);
+		put("defense",1f);
+		put("walk_speed",1.5f);
+		put("strength",1f);
+		put("critical_damage",1f);
+		put("critical_chance",0.2f);
+		put("attack_speed",0.3f);
+		put("intelligence",2f);
+	}};
+
 	public InventoriesPage(GuiProfileViewer instance) {
 		super(instance);
 	}
@@ -172,6 +194,21 @@ public class InventoriesPage extends GuiProfileViewerPage {
 									? selectedPowerString.append(EnumChatFormatting.RED).append("None!").toString()
 									: selectedPowerString.append(EnumChatFormatting.GREEN).append(selectedPower).toString()
 							);
+
+						LinkedHashMap<String, Integer> tuningInfo = getSelectedProfile().getTuningInfo();
+						if(tuningInfo != null && tuningInfo.size() > 0) {
+							getInstance().tooltipToDisplay.add("");
+							getInstance().tooltipToDisplay.add(EnumChatFormatting.GRAY + "Tuning:");
+							tuningInfo.forEach((statName, statPoints) -> {
+								if(statPoints != 0) {
+									getInstance().tooltipToDisplay.add(
+										"  " + apiStatNames.get(statName) + ": +" +
+											new DecimalFormat("#.#").format(statPoints * tuningCoefficients.get(statName)) +
+											EnumChatFormatting.DARK_GRAY + " (" + EnumChatFormatting.YELLOW + statPoints +
+											EnumChatFormatting.DARK_GRAY + " points)");
+								}
+							});
+						}
 					}
 				}
 			}

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/InventoriesPage.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/InventoriesPage.java
@@ -203,7 +203,7 @@ public class InventoriesPage extends GuiProfileViewerPage {
 								if(statPoints != 0) {
 									getInstance().tooltipToDisplay.add(
 										"  " + apiStatNames.get(statName) + ": +" +
-											new DecimalFormat("#.#").format(statPoints * tuningCoefficients.get(statName)) +
+											new DecimalFormat("#.#").format(statPoints * tuningCoefficients.getOrDefault(statName, 1.0f)) +
 											EnumChatFormatting.DARK_GRAY + " (" + EnumChatFormatting.YELLOW + statPoints +
 											EnumChatFormatting.DARK_GRAY + " points)");
 								}

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/SkyblockProfiles.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/SkyblockProfiles.java
@@ -87,6 +87,17 @@ public class SkyblockProfiles {
 		"runecrafting",
 		"social"
 	);
+
+	private static final List<String> tuningStats = Arrays.asList(
+		"health",
+		"defense",
+		"walk_speed",
+		"strength",
+		"critical_damage",
+		"critical_chance",
+		"attack_speed",
+		"intelligence"
+	);
 	private final ProfileViewer profileViewer;
 	// TODO: replace with UUID type
 	private final String uuid;
@@ -488,6 +499,7 @@ public class SkyblockProfiles {
 		private final JsonObject outerProfileJson;
 		private final String gamemode;
 		private Integer magicPower = null;
+		private LinkedHashMap<String, Integer> tuningInfo = null;
 		private Double skyblockLevel = null;
 		private EnumChatFormatting skyBlockExperienceColour = null;
 		private Map<String, JsonArray> inventoryNameToInfo = null;
@@ -706,6 +718,24 @@ public class SkyblockProfiles {
 			}
 
 			return magicPower = ProfileViewerUtils.getMagicalPower(inventoryInfo.get("talisman_bag"), getProfileJson());
+		}
+
+		public LinkedHashMap<String, Integer> getTuningInfo() {
+			if (tuningInfo != null) {
+				return tuningInfo;
+			}
+
+			JsonObject profileJson = getProfileJson();
+			if (Utils.getElement(profileJson, "accessory_bag_storage.tuning") == null) return null;
+			JsonObject tuningData = Utils.getElement(profileJson, "accessory_bag_storage.tuning.slot_0").getAsJsonObject();
+			tuningInfo = new LinkedHashMap<>();
+
+			for (String stat : tuningStats) {
+				int statData = tuningData.get(stat).getAsInt();
+				tuningInfo.put(stat, statData);
+			}
+
+			return tuningInfo;
 		}
 
 		public Map<String, JsonArray> getInventoryInfo() {


### PR DESCRIPTION
Added tuning stats the tooltip of accessory bag in inventories /pv page. Does not show stats with no points applied. Tested with people that didnt play after tuning update & with no points assigned at all.