### PR TITLE
Remove checking for SBA before adding Z to Color parsing list. 

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/item/enchants/EnchantMatcher.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/item/enchants/EnchantMatcher.java
@@ -41,7 +41,7 @@ public class EnchantMatcher {
 	private final static String romanNumerals =
 		"(I|II|III|IV|V|VI|VII|VIII|IX|X|XI|XII|XIII|XIV|XV|XVI|XVII|XVIII|XIX|XX)";
 	private final static Supplier<String> validColors = Suppliers.memoize(() ->
-		"0123456789abcdefz" + ( Loader.isModLoaded("skyhanni") ? "Z" : ""));
+		"0123456789abcdefzZ");
 
 	public static LRUCache<String, Optional<EnchantMatcher>> fromSaveFormatMemoized =
 		LRUCache.memoize(

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/item/enchants/EnchantMatcher.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/item/enchants/EnchantMatcher.java
@@ -41,7 +41,7 @@ public class EnchantMatcher {
 	private final static String romanNumerals =
 		"(I|II|III|IV|V|VI|VII|VIII|IX|X|XI|XII|XIII|XIV|XV|XVI|XVII|XVIII|XIX|XX)";
 	private final static Supplier<String> validColors = Suppliers.memoize(() ->
-		"0123456789abcdefz" + (Loader.isModLoaded("skyblockaddons") ? "Z" : ""));
+		"0123456789abcdefz" + ( Loader.isModLoaded("skyhanni") ? "Z" : ""));
 
 	public static LRUCache<String, Optional<EnchantMatcher>> fromSaveFormatMemoized =
 		LRUCache.memoize(


### PR DESCRIPTION
SBA is relatively outdated and not receiving updates, and as a result SkyHanni might be adding SBA Chroma in. The reason for completely removing the check instead of adding SkyHanni as an additional check is threefold.

1. If another mod adds SBA Chroma I see no reason why NEU shouldn't be able to just use it out of the box.
2. If Skyhanni [doesn't merge this](https://github.com/hannibal002/SkyHanni/pull/487) there really isn't a reason to a check relating to it in the code-base there. 
3. If nothing to provide SBA Chroma is installed, the text is merely white. This is also shown in the preview. Nothing bad happens when nothing is providing SBA Chroma Coloring and it gets parsed. 

From my testing this has no negative effects on anything. 