### PR TITLE
Fix enchanted books not working with bz keybind

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -1213,7 +1213,13 @@ public class NEUOverlay extends Gui {
 							return true;
 						} else if (keyPressed == NotEnoughUpdates.INSTANCE.config.misc.openAHKeybind) {
 							String cleanName = Utils.cleanColour(item.get("displayname").getAsString()).replace("[Lvl {LVL}]", "").trim();
-							if (NotEnoughUpdates.INSTANCE.manager.auctionManager.getBazaarInfo(internalname.get()) == null) {
+
+							if (item.get("itemid").getAsString().equals("minecraft:enchanted_book")) {
+								String loreName = Utils.cleanColour(item.getAsJsonArray("lore").get(0).getAsString());
+								int lastWhiteSpace = loreName.lastIndexOf(' ');
+								String bookName = loreName.substring(0, lastWhiteSpace);
+								NotEnoughUpdates.INSTANCE.trySendCommand("/bz " + bookName);
+							} else if (NotEnoughUpdates.INSTANCE.manager.auctionManager.getBazaarInfo(internalname.get()) == null) {
 								NotEnoughUpdates.INSTANCE.trySendCommand("/ahs " + cleanName);
 							} else {
 								NotEnoughUpdates.INSTANCE.trySendCommand("/bz " + cleanName);

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -1212,12 +1212,14 @@ public class NEUOverlay extends Gui {
 							NotEnoughUpdates.INSTANCE.openGui = new GuiPriceGraph(internalname.get());
 							return true;
 						} else if (keyPressed == NotEnoughUpdates.INSTANCE.config.misc.openAHKeybind) {
-							String cleanName = Utils.cleanColour(item.get("displayname").getAsString()).replace("[Lvl {LVL}]", "").trim();
+							String displayname = item.get("displayname").getAsString();
 
-							if (item.get("itemid").getAsString().equals("minecraft:enchanted_book")) {
+							String cleanName = Utils.cleanColour(displayname).replace("[Lvl {LVL}]", "").trim();
+
+							if (displayname.equals("§fEnchanted Book")) {
 								String loreName = Utils.cleanColour(item.getAsJsonArray("lore").get(0).getAsString());
-								int lastWhiteSpace = loreName.lastIndexOf(' ');
-								String bookName = loreName.substring(0, lastWhiteSpace);
+
+								String bookName = loreName.substring(0, loreName.lastIndexOf(' '));
 								NotEnoughUpdates.INSTANCE.trySendCommand("/bz " + bookName);
 							} else if (NotEnoughUpdates.INSTANCE.manager.auctionManager.getBazaarInfo(internalname.get()) == null) {
 								NotEnoughUpdates.INSTANCE.trySendCommand("/ahs " + cleanName);


### PR DESCRIPTION
closes #885

Extracts the book name from the lore of the item.
Then searches directly with /bz since enchanted books can't be in the auction house