### PR TITLE
Fix drop chance in mob loot

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/recipes/MobLootRecipe.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/recipes/MobLootRecipe.java
@@ -27,7 +27,6 @@ import io.github.moulberry.notenoughupdates.NEUManager;
 import io.github.moulberry.notenoughupdates.core.util.StringUtils;
 import io.github.moulberry.notenoughupdates.miscfeatures.entityviewer.EntityViewer;
 import io.github.moulberry.notenoughupdates.miscgui.GuiItemRecipe;
-import io.github.moulberry.notenoughupdates.profileviewer.GuiProfileViewer;
 import io.github.moulberry.notenoughupdates.profileviewer.Panorama;
 import io.github.moulberry.notenoughupdates.util.ItemUtils;
 import io.github.moulberry.notenoughupdates.util.JsonUtils;
@@ -81,9 +80,9 @@ public class MobLootRecipe implements NeuRecipe {
 			}
 
 			String chanceText = chance.substring(0, chance.length() - 1);
-			int chanceIn;
+			double chanceIn;
 			try {
-				chanceIn = (int) (100.0 / Double.parseDouble(chanceText));
+				chanceIn = (100.0 / Double.parseDouble(chanceText));
 			} catch (NumberFormatException e) {
 				return chance;
 			}


### PR DESCRIPTION
Removes the cast to int, therefore adding back the decimal point to chances that require it (e.g. 40%)