### PR TITLE
Catch gson exception

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
@@ -21,6 +21,7 @@ package io.github.moulberry.notenoughupdates.util;
 
 import com.google.common.reflect.TypeToken;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.autosubscribe.NEUAutoSubscribe;
 import io.github.moulberry.notenoughupdates.miscfeatures.CookieWarning;
@@ -226,6 +227,8 @@ public class SBInfo {
 			);
 			areGamemodesLoaded = true;
 		} catch (IOException e) {
+			e.printStackTrace();
+		} catch (JsonSyntaxException e) {
 			e.printStackTrace();
 		}
 	}


### PR DESCRIPTION
Bandaid attempt to fix #834 

The crash indicates that the profiles.json file started with a `"` rather than a `{`, which should be impossible unless the file was modified are did not properly save, as it saves as the HashMap. This just makes the thrown exception not crash the game, as it's not a critical error, but it doesn't explain why the profiles.json would not have a `{` at the beginning.