### PR TITLE
Fix crash when quitting with ch chest highlighted

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/world/CrystalHollowChestHighlighter.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/world/CrystalHollowChestHighlighter.java
@@ -90,6 +90,7 @@ public class CrystalHollowChestHighlighter extends GenericBlockHighlighter {
 		});
 
 		blockToRemove.forEach(highlightedBlocks::remove);
+		blockToRemove.forEach(markedBlocks::remove);
 	}
 
 	@SubscribeEvent

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/world/GenericBlockHighlighter.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/world/GenericBlockHighlighter.java
@@ -106,7 +106,7 @@ public abstract class GenericBlockHighlighter {
 	}
 
 	@SubscribeEvent
-	public void onWorldChange(WorldEvent.Load event) {
+	public void onWorldChange(WorldEvent.Unload event) {
 		highlightedBlocks.clear();
 	}
 


### PR DESCRIPTION
Resolves #927. Clears `highlightedBlocks` on world unload rather than load in case `Minecraft.getMinecraft().theWorld` is accessed in a loop with `highlightedBlocks`.