### PR TITLE
migrate pronoundb integration to new api version

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/BasicPage.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/BasicPage.java
@@ -197,9 +197,7 @@ public class BasicPage extends GuiProfileViewerPage {
 					.flatMap(it -> it); // Flatten: First optional is whether it loaded, second optional is whether it was successful
 			if (pronounChoice.isPresent()) {
 				PronounDB.PronounChoice pronouns = pronounChoice.get();
-				if (pronouns.isConsciousChoice()) {
-					getInstance().tooltipToDisplay = pronouns.render();
-				}
+				getInstance().tooltipToDisplay = pronouns.render();
 			}
 		}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/BasicPage.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/BasicPage.java
@@ -62,6 +62,7 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -197,7 +198,7 @@ public class BasicPage extends GuiProfileViewerPage {
 					.flatMap(it -> it); // Flatten: First optional is whether it loaded, second optional is whether it was successful
 			if (pronounChoice.isPresent()) {
 				PronounDB.PronounChoice pronouns = pronounChoice.get();
-				getInstance().tooltipToDisplay = pronouns.render();
+				getInstance().tooltipToDisplay = Collections.singletonList(pronouns.render());
 			}
 		}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/PronounDB.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/PronounDB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2023 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -19,148 +19,126 @@
 
 package io.github.moulberry.notenoughupdates.util;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
+import lombok.Getter;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class PronounDB {
-
-	private static boolean isDisabled() {
-		JsonObject disabled = Constants.DISABLE;
-		return disabled != null && disabled.has("pronoundb");
-	}
-
 	/**
 	 * Returns an Optional, since JVMs can be *very* funky with KeyStore loading
 	 */
 	public static CompletableFuture<Optional<JsonObject>> performPronouning(String platform, String id) {
 		if (isDisabled()) return CompletableFuture.completedFuture(Optional.empty());
 		return NotEnoughUpdates.INSTANCE.manager.apiUtils
-			.request()
-			.url("https://pronoundb.org/api/v1/lookup")
-			.queryArgument("platform", platform)
-			.queryArgument("id", id)
+			.request().url("https://pronoundb.org/api/v2/lookup")
+			.queryArgument("platform", platform).queryArgument("ids", id)
 			.requestJson()
 			.handle((result, ex) -> Optional.ofNullable(result));
 	}
 
-	public enum Pronoun {
-		HE("he", "him", "his"),
-		IT("it", "it", "its"),
-		SHE("she", "her", "hers"),
-		THEY("they", "them", "theirs");
-
-		private final String subject;
-		private final String object;
-		private final String possessive;
-
-		Pronoun(String subject, String object, String possessive) {
-			this.subject = subject;
-			this.object = object;
-			this.possessive = possessive;
-		}
-
-		public String getSubject() {
-			return subject;
-		}
-
-		public String getObject() {
-			return object;
-		}
-
-		public String getPossessive() {
-			return possessive;
-		}
+	private static boolean isDisabled() {
+		JsonObject disabled = Constants.DISABLE;
+		return disabled != null && disabled.has("pronoundb");
 	}
 
-	public enum PronounChoice {
-		UNSPECIFIED("unspecified", "Unspecified"),
-		HE("hh", Pronoun.HE),
-		HEIT("hi", Pronoun.HE, Pronoun.IT),
-		HESHE("hs", Pronoun.HE, Pronoun.SHE),
-		HETHEY("ht", Pronoun.HE, Pronoun.THEY),
-		ITHE("ih", Pronoun.IT, Pronoun.HE),
-		IT("ii", Pronoun.IT),
-		ITSHE("is", Pronoun.IT, Pronoun.SHE),
-		ITTHEY("it", Pronoun.IT, Pronoun.THEY),
-		SHEHE("shh", Pronoun.SHE, Pronoun.HE),
-		SHE("sh", Pronoun.SHE),
-		SHEIT("si", Pronoun.SHE, Pronoun.IT),
-		SHETHEY("st", Pronoun.SHE, Pronoun.THEY),
-		THEYHE("th", Pronoun.THEY, Pronoun.HE),
-		THEYIT("ti", Pronoun.THEY, Pronoun.IT),
-		THEYSHE("ts", Pronoun.THEY, Pronoun.SHE),
-		THEY("tt", Pronoun.THEY),
-		ANY("any", "Any pronouns"),
-		OTHER("other", "Other pronouns"),
-		ASK("ask", "Ask me my pronouns"),
-		AVOID("avoid", "Avoid pronouns, use my name");
-		private final String id;
-		private List<Pronoun> pronouns = null;
-		private String override = null;
+	public static CompletableFuture<Optional<PronounChoice>> getPronounsFor(String platform, String name) {
+		return performPronouning(platform, name).thenApply(it -> it.flatMap(jsonObject -> parsePronouns(jsonObject, name)));
+	}
 
-		PronounChoice(String id, String override) {
-			this.override = override;
-			this.id = id;
-		}
+	public static Optional<PronounChoice> parsePronouns(JsonObject pronounObject, String name) {
+		if (pronounObject.has(name)) {
 
-		PronounChoice(String id, Pronoun... pronouns) {
-			this.id = id;
-			this.pronouns = Arrays.asList(pronouns);
-		}
+			List<String> set = JsonUtils
+				.transformJsonArrayToList(Utils
+					.getElementOrDefault(pronounObject, name + ".sets.en", new JsonArray())
+					.getAsJsonArray(), JsonElement::getAsString);
 
-		public static Optional<PronounChoice> findPronounsForId(String id) {
-			for (PronounChoice value : values()) {
-				if (value.id.equals(id)) return Optional.of(value);
-			}
-			return Optional.empty();
-		}
-
-		public String getOverride() {
-			return override;
-		}
-
-		public List<Pronoun> getPronounsInPreferredOrder() {
-			return pronouns;
-		}
-
-		public String getId() {
-			return id;
-		}
-
-		public List<String> render() {
-			if (override != null)
-				return Arrays.asList(override);
-			return pronouns
+			List<Pronoun> pronouns = set
 				.stream()
-				.map(pronoun -> pronoun.getSubject() + "/" + pronoun.getObject())
+				.map(pronounId -> Arrays
+					.stream(Pronoun.values())
+					.filter(pronoun -> pronoun.id.equals(pronounId))
+					.findFirst()
+					.orElse(null))
+				.filter(Objects::nonNull)
 				.collect(Collectors.toList());
-		}
 
-		public boolean isConsciousChoice() {
-			return this != UNSPECIFIED;
-		}
+			if (pronouns.isEmpty()) {
+				return Optional.empty();
+			}
 
-	}
+			if (pronouns.size() >= 2) {
+				return Optional.of(new PronounChoice(pronouns.get(0), pronouns.get(1)));
+			} else {
+				return Optional.of(new PronounChoice(pronouns.get(0), null));
 
-	public static Optional<PronounChoice> parsePronouns(JsonObject pronounObject) {
-		if (pronounObject.has("pronouns")) {
-			JsonElement pronouns = pronounObject.get("pronouns");
-			if (pronouns.isJsonPrimitive() && pronouns.getAsJsonPrimitive().isString())
-				return PronounChoice.findPronounsForId(pronouns.getAsString());
+			}
 		}
 		return Optional.empty();
 	}
 
-	public static CompletableFuture<Optional<PronounChoice>> getPronounsFor(String platform, String name) {
-		return performPronouning(platform, name).thenApply(it -> it.flatMap(PronounDB::parsePronouns));
+	@Getter
+	public enum Pronoun {
+		HE("he", "him", "his"),
+		IT("it", "it", "its"),
+		SHE("she", "her", "hers"),
+		THEY("they", "them", "theirs"),
+		ANY("any", "Any pronouns"),
+		OTHER("other", "Other pronouns"),
+		ASK("ask", "Ask me my pronouns"),
+		AVOID("avoid", "Avoid pronouns, use my name");
+
+		private final String id;
+		private final String object;
+		private final String possessive;
+		private final String override;
+
+		Pronoun(String id, String object, String possessive) {
+			this.id = id;
+			this.object = object;
+			this.possessive = possessive;
+			this.override = null;
+		}
+
+		Pronoun(String id, String override) {
+			this.id = id;
+			this.override = override;
+			this.object = null;
+			this.possessive = null;
+		}
+	}
+
+	@Getter
+	public static class PronounChoice {
+		private final Pronoun firstPronoun;
+		private final Pronoun secondPronoun;
+
+		PronounChoice(Pronoun firstPronoun, Pronoun secondPronoun) {
+			this.firstPronoun = firstPronoun;
+			this.secondPronoun = secondPronoun;
+		}
+
+		public List<String> render() {
+			if (firstPronoun.override != null)
+				return Collections.singletonList(firstPronoun.override);
+
+			if (secondPronoun == null) {
+				return Collections.singletonList(firstPronoun.id + "/" + firstPronoun.object);
+			} else {
+				return Collections.singletonList(firstPronoun.id + "/" + secondPronoun.id);
+			}
+		}
 	}
 
 	public static CompletableFuture<Optional<PronounChoice>> getPronounsFor(UUID minecraftPlayer) {

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/dev/DevTestCommand.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/dev/DevTestCommand.kt
@@ -225,7 +225,7 @@ class DevTestCommand {
                 reply(AQUA.toString() + "I would never search")
             }.withHelp("Reset your search data to redisplay the search tutorial")
             thenLiteralExecute("bluehair") {
-                PronounDB.test()
+                PronounDB.test(MC.thePlayer.uniqueID)
             }.withHelp("Test the pronoundb integration")
             thenLiteral("opengui") {
                 thenArgumentExecute("class", StringArgumentType.string()) { className ->


### PR DESCRIPTION
Closes #955

Since the new API version has a completely new format, I revamped the `PronounChoice` enum into a class. This doesn't really change the calls to `PronounDB.getPronounsFor`

Supports up to two "normal" pronouns or one override (i.e. "any pronouns", "ask me" etc.)