### PR TITLE
Add Platinum and Diamond brackets to the inJacobsContest check

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/FarmingSkillOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/FarmingSkillOverlay.java
@@ -140,7 +140,7 @@ public class FarmingSkillOverlay extends TextOverlay {
 			int cropsFarmed = -1;
 			for (String line : SidebarUtil.readSidebarLines()) {
 				if (line.contains("Collected") || line.contains("BRONZE") || line.contains("SILVER") ||
-					line.contains("GOLD")) {
+					line.contains("GOLD") || line.contains("PLATINUM") || line.contains("DIAMOND")) {
 					inJacobContest = true;
 					String l = line.replaceAll("[^A-Za-z0-9() ]", "");
 					cropsFarmed = Integer.parseInt(l.substring(l.lastIndexOf(" ") + 1).replace(",", ""));


### PR DESCRIPTION
Currently the contest estimation is gone whenever you enter the PLATINUM and DIAMOND brackets.
Instead of me complaining about it and saying "fix it", I thought I could attempt to fix it myself.