### PR TITLE
Actually fix the Concurrent Modification issue

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinTextureManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinTextureManager.java
@@ -35,6 +35,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @Mixin(TextureManager.class)
 public class MixinTextureManager {
@@ -58,6 +59,6 @@ public class MixinTextureManager {
 	 */
 	@Inject(method = "<init>", at = @At("RETURN"))
 	public void constructor(CallbackInfo ci) {
-		listTickables = Collections.synchronizedList(Lists.newArrayList());
+		listTickables = new CopyOnWriteArrayList<>();
 	}
 }


### PR DESCRIPTION
SynchronizedList did not fix the issue, as it needed to be wrapped in a synchronized block.
CopyOnWriteArrayList will create a copy of the list whenever its written and uses a custom iterator to prevent the issue.