### PR TITLE
Fix commission todo timer

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
@@ -316,7 +316,7 @@ public class TimersOverlay extends TextTabOverlay {
 						break;
 					}
 					if (hidden.commissionsCompleted == 0) {
-						hidden.commissionsCompleted = currentTime + TimeEnums.DAY.time;
+						hidden.commissionsCompleted = currentTime;
 					}
 					for (int i = 9; i < 18; i++) {
 						stack = lower.getStackInSlot(i);


### PR DESCRIPTION
For some reason, it was marking it as completed tomorrow when you completed it.