### PR TITLE
Fix nucleus runs completed

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/MiningPage.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/MiningPage.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 public class MiningPage extends GuiProfileViewerPage {
 
@@ -97,22 +98,10 @@ public class MiningPage extends GuiProfileViewerPage {
 			"powder_spent_gemstone"
 		), 0);
 
-		float amberCrystalsPlaced =
-			Utils.getElementAsFloat(Utils.getElement(miningCore, "crystals.amber_crystal.total_placed"), 0);
-		float amethystCrystalsPlaced =
-			Utils.getElementAsFloat(Utils.getElement(miningCore, "crystals.amethyst_crystal.total_placed"), 0);
-		float jadeCrystalsPlaced =
-			Utils.getElementAsFloat(Utils.getElement(miningCore, "crystals.jade_crystal.total_placed"), 0);
-		float sapphireCrystalsPlaced =
-			Utils.getElementAsFloat(Utils.getElement(miningCore, "crystals.sapphire_crystal.total_placed"), 0);
-		float topazCrystalsPlaced =
-			Utils.getElementAsFloat(Utils.getElement(miningCore, "crystals.topaz_crystal.total_placed"), 0);
-
-		float[] crystalsPlaced = {
-			amberCrystalsPlaced, amethystCrystalsPlaced, jadeCrystalsPlaced, sapphireCrystalsPlaced, topazCrystalsPlaced
-		};
-		Arrays.sort(crystalsPlaced);
-		float nucleusRunsCompleted = crystalsPlaced[0];
+		double nucleusRunsCompleted = Stream.of("amber_crystal", "amethyst_crystal", "jade_crystal", "sapphire_crystal", "topaz_crystal")
+			.mapToDouble(crystal -> Utils.getElementAsFloat(Utils.getElement(miningCore, "crystals." + crystal + ".total_placed"), 0))
+			.min()
+			.orElse(0);
 
 		int miningFortune = Utils.getElementAsInt(Utils.getElement(nodes, "mining_fortune"), 0);
 		int miningFortuneStat = miningFortune * 5;

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/MiningPage.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/MiningPage.java
@@ -97,8 +97,22 @@ public class MiningPage extends GuiProfileViewerPage {
 			"powder_spent_gemstone"
 		), 0);
 
-		float crystalPlacedAmount =
+		float amberCrystalsPlaced =
+			Utils.getElementAsFloat(Utils.getElement(miningCore, "crystals.amber_crystal.total_placed"), 0);
+		float amethystCrystalsPlaced =
+			Utils.getElementAsFloat(Utils.getElement(miningCore, "crystals.amethyst_crystal.total_placed"), 0);
+		float jadeCrystalsPlaced =
 			Utils.getElementAsFloat(Utils.getElement(miningCore, "crystals.jade_crystal.total_placed"), 0);
+		float sapphireCrystalsPlaced =
+			Utils.getElementAsFloat(Utils.getElement(miningCore, "crystals.sapphire_crystal.total_placed"), 0);
+		float topazCrystalsPlaced =
+			Utils.getElementAsFloat(Utils.getElement(miningCore, "crystals.topaz_crystal.total_placed"), 0);
+
+		float[] crystalsPlaced = {
+			amberCrystalsPlaced, amethystCrystalsPlaced, jadeCrystalsPlaced, sapphireCrystalsPlaced, topazCrystalsPlaced
+		};
+		Arrays.sort(crystalsPlaced);
+		float nucleusRunsCompleted = crystalsPlaced[0];
 
 		int miningFortune = Utils.getElementAsInt(Utils.getElement(nodes, "mining_fortune"), 0);
 		int miningFortuneStat = miningFortune * 5;
@@ -211,8 +225,8 @@ public class MiningPage extends GuiProfileViewerPage {
 		}
 
 		Utils.renderAlignedString(
-			EnumChatFormatting.BLUE + "Total Placed Crystals:",
-			EnumChatFormatting.WHITE + StringUtils.shortNumberFormat(crystalPlacedAmount),
+			EnumChatFormatting.BLUE + "Nucleus Runs Completed:",
+			EnumChatFormatting.WHITE + StringUtils.shortNumberFormat(nucleusRunsCompleted),
 			guiLeft + xStart,
 			guiTop + yStartTop + 149,
 			110

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/MiningPage.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/MiningPage.java
@@ -98,8 +98,8 @@ public class MiningPage extends GuiProfileViewerPage {
 			"powder_spent_gemstone"
 		), 0);
 
-		double nucleusRunsCompleted = Stream.of("amber_crystal", "amethyst_crystal", "jade_crystal", "sapphire_crystal", "topaz_crystal")
-			.mapToDouble(crystal -> Utils.getElementAsFloat(Utils.getElement(miningCore, "crystals." + crystal + ".total_placed"), 0))
+		double nucleusRunsCompleted = Stream.of("amber", "amethyst", "jade", "sapphire", "topaz")
+			.mapToDouble(crystal -> Utils.getElementAsFloat(Utils.getElement(miningCore, "crystals." + crystal + "_crystal.total_placed"), 0))
 			.min()
 			.orElse(0);
 


### PR DESCRIPTION
- Use the minimum of all crystals placed, rather than just checking the amount of jade crystals placed, which may be wrong if you have an incomplete nucleus run with a jade crystal placed.
- Made it say "nucleus runs completed" rather than "crystals placed". Technically, the number of crystals placed would be actually five times the nucleus runs completed, but runs completed is the only important number.