### PR TITLE
BugFix for compatibility Skytils

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -148,7 +148,7 @@ dependencies {
 
 		shadowImplementation("com.mojang:brigadier:1.0.18")
 
-		shadowImplementation("org.spongepowered:mixin:0.7.11-SNAPSHOT") {
+		shadowImplementation("org.spongepowered:mixin:0.8.5") {
 				isTransitive = false // Dependencies of mixin are already bundled by minecraft
 		}
 		annotationProcessor("net.fabricmc:sponge-mixin:0.11.4+mixin.0.8.5")


### PR DESCRIPTION
If you have a unlucky mod loadup order the NEU mixin could be loaded causing multiple mods to fail because of the old version of mixin in the shadow jar.

![Skytils Error](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/12024658/8b14fded-8bdd-4bca-a37c-a3756ff2bf12)
