### PR TITLE
"fix": taming level crash

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/SkyblockProfiles.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/SkyblockProfiles.java
@@ -1267,7 +1267,7 @@ public class SkyblockProfiles {
 			if (!getUuid().equals(Minecraft.getMinecraft().thePlayer.getUniqueID().toString().replace("-", ""))) return;
 			if (!getLatestProfile().skillsApiEnabled()) return;
 
-			if (getLevelingInfo().get("taming") != null) { //idfk what else could cause an NPE here
+			if (getLevelingInfo() != null && getLevelingInfo().get("taming") != null) { //idfk what else could cause an NPE here
 				PetInfoOverlay.getConfig().tamingLevel = (int) getLevelingInfo().get("taming").level;
 			}
 		}


### PR DESCRIPTION
it now says skill api off and shows missing repo file instead of going to the crash screen