### PR TITLE
fix: abiphone favorites showing in /show

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/AbiphoneFavourites.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/AbiphoneFavourites.java
@@ -50,6 +50,7 @@ public class AbiphoneFavourites {
 
 	private static final AbiphoneFavourites INSTANCE = new AbiphoneFavourites();
 	private long lastClick = 0L;
+	private ItemStack checkShowSlot = null;
 
 	public static AbiphoneFavourites getInstance() {
 		return INSTANCE;
@@ -204,9 +205,14 @@ public class AbiphoneFavourites {
 
 	@SubscribeEvent
 	public void onDrawBackground(GuiContainerBackgroundDrawnEvent event) {
-		if (isWrongInventory()) return;
+		if (!NotEnoughUpdates.INSTANCE.hasSkyblockScoreboard()
+			|| !NotEnoughUpdates.INSTANCE.config.misc.abiphoneFavourites
+			|| Utils.getOpenChestName().equals("Abiphone Shop")
+			|| !Utils.getOpenChestName().startsWith("Abiphone ")) return;
 
 		GuiContainer container = event.getContainer();
+
+		checkShowSlot = container.inventorySlots.getSlot(13).getStack();
 
 		for (Slot slot : container.inventorySlots.inventorySlots) {
 			if (slot == null) continue;
@@ -230,7 +236,8 @@ public class AbiphoneFavourites {
 		return !NotEnoughUpdates.INSTANCE.hasSkyblockScoreboard()
 			|| !NotEnoughUpdates.INSTANCE.config.misc.abiphoneFavourites
 			|| Utils.getOpenChestName().equals("Abiphone Shop")
-			|| !Utils.getOpenChestName().startsWith("Abiphone ");
+			|| !Utils.getOpenChestName().startsWith("Abiphone ")
+			|| checkShowSlot != null && checkShowSlot.getDisplayName().contains("Abiphone ");
 	}
 
 	private boolean isContact(ItemStack stack) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/AbiphoneFavourites.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/AbiphoneFavourites.java
@@ -50,7 +50,7 @@ public class AbiphoneFavourites {
 
 	private static final AbiphoneFavourites INSTANCE = new AbiphoneFavourites();
 	private long lastClick = 0L;
-	private ItemStack checkShowSlot = null;
+	private boolean isInShowMenu = false;
 
 	public static AbiphoneFavourites getInstance() {
 		return INSTANCE;
@@ -212,7 +212,8 @@ public class AbiphoneFavourites {
 
 		GuiContainer container = event.getContainer();
 
-		checkShowSlot = container.inventorySlots.getSlot(13).getStack();
+		ItemStack checkForShowMenu = container.inventorySlots.getSlot(1*9 + 4).getStack();
+		isInShowMenu = checkForShowMenu != null && checkForShowMenu.getDisplayName().contains("Abiphone ");
 
 		for (Slot slot : container.inventorySlots.inventorySlots) {
 			if (slot == null) continue;
@@ -237,7 +238,7 @@ public class AbiphoneFavourites {
 			|| !NotEnoughUpdates.INSTANCE.config.misc.abiphoneFavourites
 			|| Utils.getOpenChestName().equals("Abiphone Shop")
 			|| !Utils.getOpenChestName().startsWith("Abiphone ")
-			|| checkShowSlot != null && checkShowSlot.getDisplayName().contains("Abiphone ");
+			|| isInShowMenu;
 	}
 
 	private boolean isContact(ItemStack stack) {


### PR DESCRIPTION
Uses item slot in show menu and sets wrong inventory if it is an abiphone

closes #930

![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/52770460/213b007f-19d4-460d-af4c-4e61155b1d18)

![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/52770460/6280e123-57bd-41df-b247-7b0cd6aa673c)
