### PR TITLE
Added Recipe Search Overlay

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,21 +1,21 @@
-	/*
- * Copyright (C) 2022 NotEnoughUpdates contributors
- *
- * This file is part of NotEnoughUpdates.
- *
- * NotEnoughUpdates is free software: you can redistribute it
- * and/or modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation, either
- * version 3 of the License, or (at your option) any later version.
- *
- * NotEnoughUpdates is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
- */
+/*
+* Copyright (C) 2022 NotEnoughUpdates contributors
+*
+* This file is part of NotEnoughUpdates.
+*
+* NotEnoughUpdates is free software: you can redistribute it
+* and/or modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation, either
+* version 3 of the License, or (at your option) any later version.
+*
+* NotEnoughUpdates is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
+*/
 
 
 import neubs.NEUBuildFlags

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-/*
+	/*
  * Copyright (C) 2022 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.

--- a/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
@@ -56,6 +56,7 @@ import io.github.moulberry.notenoughupdates.miscfeatures.Navigation;
 import io.github.moulberry.notenoughupdates.miscfeatures.NullzeeSphere;
 import io.github.moulberry.notenoughupdates.miscfeatures.PetInfoOverlay;
 import io.github.moulberry.notenoughupdates.miscfeatures.PowerStoneStatsDisplay;
+import io.github.moulberry.notenoughupdates.miscfeatures.RecipeSearch;
 import io.github.moulberry.notenoughupdates.miscfeatures.SlotLocking;
 import io.github.moulberry.notenoughupdates.miscfeatures.StorageManager;
 import io.github.moulberry.notenoughupdates.miscfeatures.SunTzu;
@@ -315,6 +316,7 @@ public class NotEnoughUpdates {
 		MinecraftForge.EVENT_BUS.register(AbiphoneWarning.getInstance());
 		MinecraftForge.EVENT_BUS.register(new BetterContainers());
 		MinecraftForge.EVENT_BUS.register(AuctionBINWarning.getInstance());
+		MinecraftForge.EVENT_BUS.register(RecipeSearch.getInstance());
 		MinecraftForge.EVENT_BUS.register(navigation);
 
 		if (Minecraft.getMinecraft().getResourceManager() instanceof IReloadableResourceManager) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
@@ -465,7 +465,6 @@ public class RenderListener {
 			return;
 		}
 
-
 		boolean tradeWindowActive = TradeWindow.tradeWindowActive(containerName);
 		boolean storageOverlayActive = StorageManager.getInstance().shouldRenderStorageOverlay(containerName);
 		boolean customAhActive =
@@ -807,7 +806,7 @@ public class RenderListener {
 							if (bazaarPrice < 5000000 && internal.equals("RECOMBOBULATOR_3000")) bazaarPrice = 5000000;
 
 							double worth = -1;
- 							boolean isOnBz = false;
+							boolean isOnBz = false;
 							if (bazaarPrice >= 0) {
 								worth = bazaarPrice;
 								isOnBz = true;
@@ -1085,7 +1084,6 @@ public class RenderListener {
 			event.setCanceled(true);
 			return;
 		}
-
 
 		boolean tradeWindowActive = TradeWindow.tradeWindowActive(containerName);
 		boolean storageOverlayActive = StorageManager.getInstance().shouldRenderStorageOverlay(containerName);
@@ -1566,7 +1564,6 @@ public class RenderListener {
 			event.setCanceled(true);
 			return;
 		}
-
 
 		boolean tradeWindowActive = TradeWindow.tradeWindowActive(containerName);
 		boolean storageOverlayActive = StorageManager.getInstance().shouldRenderStorageOverlay(containerName);

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
@@ -58,6 +58,7 @@ import io.github.moulberry.notenoughupdates.overlays.BazaarSearchOverlay;
 import io.github.moulberry.notenoughupdates.overlays.EquipmentOverlay;
 import io.github.moulberry.notenoughupdates.overlays.OverlayManager;
 import io.github.moulberry.notenoughupdates.overlays.RancherBootOverlay;
+import io.github.moulberry.notenoughupdates.overlays.RecipeSearchOverlay;
 import io.github.moulberry.notenoughupdates.overlays.TextOverlay;
 import io.github.moulberry.notenoughupdates.profileviewer.GuiProfileViewer;
 import io.github.moulberry.notenoughupdates.util.ItemUtils;
@@ -430,6 +431,11 @@ public class RenderListener {
 		}
 		if (BazaarSearchOverlay.shouldReplace()) {
 			BazaarSearchOverlay.render();
+			event.setCanceled(true);
+			return;
+		}
+		if (RecipeSearchOverlay.shouldReplace()) {
+			RecipeSearchOverlay.render();
 			event.setCanceled(true);
 			return;
 		}
@@ -1032,6 +1038,11 @@ public class RenderListener {
 			event.setCanceled(true);
 			return;
 		}
+		if (RecipeSearchOverlay.shouldReplace()) {
+			RecipeSearchOverlay.mouseEvent();
+			event.setCanceled(true);
+			return;
+		}
 		if (RancherBootOverlay.shouldReplace()) {
 			RancherBootOverlay.mouseEvent();
 			event.setCanceled(true);
@@ -1520,6 +1531,11 @@ public class RenderListener {
 		}
 		if (BazaarSearchOverlay.shouldReplace()) {
 			BazaarSearchOverlay.keyEvent();
+			event.setCanceled(true);
+			return;
+		}
+		if (RecipeSearchOverlay.shouldReplace()) {
+			RecipeSearchOverlay.keyEvent();
 			event.setCanceled(true);
 			return;
 		}

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/BetterContainers.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/BetterContainers.java
@@ -74,6 +74,7 @@ public class BetterContainers {
 	public static HashMap<Integer, ItemStack> itemCache = new HashMap<>();
 
 	public static int profileViewerStackIndex = -1;
+	public static int recipeSearchStackIndex = -1;
 
 	public static void clickSlot(int slot) {
 		clickedSlotMillis = System.currentTimeMillis();
@@ -144,6 +145,10 @@ public class BetterContainers {
 			return false;
 		}
 
+		if (index != -1 && index == recipeSearchStackIndex) {
+			return false;
+		}
+
 		return stack != null && stack.getItem() == Item.getItemFromBlock(Blocks.stained_glass_pane) &&
 			stack.getItemDamage() == 15 &&
 			stack.getDisplayName() != null && stack.getDisplayName().trim().isEmpty();
@@ -155,6 +160,10 @@ public class BetterContainers {
 
 	public static boolean isButtonStack(int index, ItemStack stack) {
 		if (index == profileViewerStackIndex) {
+			return true;
+		}
+
+		if (index == recipeSearchStackIndex) {
 			return true;
 		}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/RecipeSearch.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/RecipeSearch.java
@@ -44,14 +44,10 @@ public class RecipeSearch {
 	@SubscribeEvent
 	public void onGuiOpen(SlotClickEvent event) {
 		ContainerChest chest = (ContainerChest) event.guiContainer.inventorySlots;
-//		Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(
-//			"Gui opened! " + chest.getLowerChestInventory().getName()));
 		String guiName = chest.getLowerChestInventory().getName();
 		if (!Objects.equals(guiName, "Craft Item")) return;
 		if (event.slot.slotNumber != 32) return;
-//		RecipeSearchOverlay.render();
 		Minecraft.getMinecraft().displayGuiScreen(new GuiEditSign(new TileEntitySign()));
-//		AuctionSearchOverlay.render();
 		event.setCanceled(true);
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/RecipeSearch.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/RecipeSearch.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 NotEnoughUpdates contributors
+ *
+ * This file is part of NotEnoughUpdates.
+ *
+ * NotEnoughUpdates is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * NotEnoughUpdates is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.moulberry.notenoughupdates.miscfeatures;
+
+import io.github.moulberry.notenoughupdates.events.SlotClickEvent;
+import io.github.moulberry.notenoughupdates.overlays.AuctionSearchOverlay;
+import io.github.moulberry.notenoughupdates.overlays.RecipeSearchOverlay;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.inventory.GuiChest;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.gui.inventory.GuiEditSign;
+import net.minecraft.inventory.ContainerChest;
+import net.minecraft.tileentity.TileEntitySign;
+import net.minecraft.util.ChatComponentText;
+import net.minecraftforge.client.event.GuiOpenEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.util.Objects;
+
+public class RecipeSearch {
+	private static final RecipeSearch INSTANCE = new RecipeSearch();
+
+	public static RecipeSearch getInstance() {
+		return INSTANCE;
+	}
+
+	@SubscribeEvent
+	public void onGuiOpen(SlotClickEvent event) {
+		ContainerChest chest = (ContainerChest) event.guiContainer.inventorySlots;
+//		Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(
+//			"Gui opened! " + chest.getLowerChestInventory().getName()));
+		String guiName = chest.getLowerChestInventory().getName();
+		if (!Objects.equals(guiName, "Craft Item")) return;
+		if (event.slot.slotNumber != 32) return;
+//		RecipeSearchOverlay.render();
+		Minecraft.getMinecraft().displayGuiScreen(new GuiEditSign(new TileEntitySign()));
+//		AuctionSearchOverlay.render();
+		event.setCanceled(true);
+	}
+}

--- a/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinGuiContainer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinGuiContainer.java
@@ -129,8 +129,7 @@ public abstract class MixinGuiContainer extends GuiScreen {
 					}
 				}
 			}
-		}
-		else if (!hasRecipeSearchStack && $this instanceof GuiChest && slot.getSlotIndex() == 32 &&
+		} else if (!hasRecipeSearchStack && $this instanceof GuiChest && slot.getSlotIndex() == 32 &&
 			BetterContainers.isBlankStack(-1, slot.getStack())) {
 			BetterContainers.recipeSearchStackIndex = -1;
 			hasRecipeSearchStack = true;
@@ -138,7 +137,7 @@ public abstract class MixinGuiContainer extends GuiScreen {
 			GuiChest eventGui = (GuiChest) $this;
 			ContainerChest cc = (ContainerChest) eventGui.inventorySlots;
 			String containerName = cc.getLowerChestInventory().getDisplayName().getUnformattedText();
-			if(containerName.equals("Craft Item") && cc.inventorySlots.size() >= 54) {
+			if (containerName.equals("Craft Item") && cc.inventorySlots.size() >= 54) {
 				ci.cancel();
 
 				this.zLevel = 100.0F;
@@ -157,14 +156,13 @@ public abstract class MixinGuiContainer extends GuiScreen {
 				this.itemRender.zLevel = 0.0F;
 				this.zLevel = 0.0F;
 				BetterContainers.recipeSearchStackIndex = slot.getSlotIndex();
-			}else {
+			} else {
 				BetterContainers.recipeSearchStackIndex = -1;
 			}
 		} else if (slot.getSlotIndex() == 0) {
 			hasProfileViewerStack = false;
 			hasRecipeSearchStack = false;
-		}
-		else if (!($this instanceof GuiChest)) {
+		} else if (!($this instanceof GuiChest)) {
 			BetterContainers.recipeSearchStackIndex = -1;
 			BetterContainers.profileViewerStackIndex = -1;
 		}

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
@@ -56,6 +56,7 @@ import io.github.moulberry.notenoughupdates.options.seperateSections.NeuAuctionH
 import io.github.moulberry.notenoughupdates.options.seperateSections.Notifications;
 import io.github.moulberry.notenoughupdates.options.seperateSections.PetOverlay;
 import io.github.moulberry.notenoughupdates.options.seperateSections.ProfileViewer;
+import io.github.moulberry.notenoughupdates.options.seperateSections.RecipeTweaks;
 import io.github.moulberry.notenoughupdates.options.seperateSections.SkillOverlays;
 import io.github.moulberry.notenoughupdates.options.seperateSections.SlayerOverlay;
 import io.github.moulberry.notenoughupdates.options.seperateSections.SlotLocking;
@@ -382,7 +383,7 @@ public class NEUConfig extends Config {
 		name = "Recipe Tweaks",
 		desc = "Tweaks for the Recipe Search"
 	)
-	public BazaarTweaks recipeTweaks = new BazaarTweaks();
+	public RecipeTweaks recipeTweaks = new RecipeTweaks();
 
 	@Expose
 	@Category(

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
@@ -379,6 +379,13 @@ public class NEUConfig extends Config {
 
 	@Expose
 	@Category(
+		name = "Recipe Tweaks",
+		desc = "Tweaks for the Recipe Search"
+	)
+	public BazaarTweaks recipeTweaks = new BazaarTweaks();
+
+	@Expose
+	@Category(
 		name = "AH/BZ Graph",
 		desc = "Graph of auction and bazaar prices"
 	)
@@ -454,6 +461,8 @@ public class NEUConfig extends Config {
 		public ArrayList<String> previousAuctionSearches = new ArrayList<>();
 		@Expose
 		public ArrayList<String> previousBazaarSearches = new ArrayList<>();
+		@Expose
+		public ArrayList<String> previousRecipeSearches = new ArrayList<>();
 		@Expose
 		public ArrayList<String> eventFavourites = new ArrayList<>();
 		@Expose

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/RecipeTweaks.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/RecipeTweaks.java
@@ -64,7 +64,7 @@ public class RecipeTweaks {
 	@Expose
 	@ConfigOption(
 		name = "ESC to Full Close",
-		desc = "Make pressing ESCAPE close the search GUI without opening up the Bazaar again\n" +
+		desc = "Make pressing ESCAPE close the search GUI without opening up the Craft menu again\n" +
 			"ENTER can still be used to search"
 	)
 	@ConfigEditorBoolean

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/RecipeTweaks.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/RecipeTweaks.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 NotEnoughUpdates contributors
+ *
+ * This file is part of NotEnoughUpdates.
+ *
+ * NotEnoughUpdates is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * NotEnoughUpdates is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.moulberry.notenoughupdates.options.seperateSections;
+
+import com.google.gson.annotations.Expose;
+import io.github.moulberry.notenoughupdates.core.config.annotations.ConfigAccordionId;
+import io.github.moulberry.notenoughupdates.core.config.annotations.ConfigEditorAccordion;
+import io.github.moulberry.notenoughupdates.core.config.annotations.ConfigEditorBoolean;
+import io.github.moulberry.notenoughupdates.core.config.annotations.ConfigOption;
+
+public class RecipeTweaks {
+
+	@ConfigOption(
+		name = "Search GUI",
+		desc = ""
+	)
+	@ConfigEditorAccordion(id = 0)
+	public boolean searchAccordion = false;
+
+	@Expose
+	@ConfigOption(
+		name = "Enable Search GUI",
+		desc = "Use the advanced search GUI with autocomplete and history instead of the normal sign GUI"
+	)
+	@ConfigEditorBoolean
+	@ConfigAccordionId(id = 0)
+	public boolean enableSearchOverlay = true;
+
+	@Expose
+	@ConfigOption(
+		name = "Keep Previous Search",
+		desc = "Don't clear the search bar after closing the GUI"
+	)
+	@ConfigEditorBoolean
+	@ConfigAccordionId(id = 0)
+	public boolean keepPreviousSearch = false;
+
+	@Expose
+	@ConfigOption(
+		name = "Past Searches",
+		desc = "Show past searches below the autocomplete box"
+	)
+	@ConfigEditorBoolean
+	@ConfigAccordionId(id = 0)
+	public boolean showPastSearches = true;
+
+	@Expose
+	@ConfigOption(
+		name = "ESC to Full Close",
+		desc = "Make pressing ESCAPE close the search GUI without opening up the Bazaar again\n" +
+			"ENTER can still be used to search"
+	)
+	@ConfigEditorBoolean
+	@ConfigAccordionId(id = 0)
+	public boolean escFullClose = true;
+}
+

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/RecipeSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/RecipeSearchOverlay.java
@@ -77,8 +77,7 @@ public class RecipeSearchOverlay {
 		}
 
 		String lastContainer = Utils.getLastOpenChestName();
-		if(lastContainer.equals("Craft Item") || lastContainer.contains("Recipes (")) return true;
-		else return false;
+		return lastContainer.equals("Craft Item") || lastContainer.contains("Recipes (");
 	}
 
 	public static void render() {
@@ -124,8 +123,7 @@ public class RecipeSearchOverlay {
 					if (i == tabCompletionIndex) {
 						Minecraft.getMinecraft().getTextureManager().bindTexture(SEARCH_OVERLAY_TEXTURE_TAB_COMPLETED);
 						GlStateManager.color(1, 1, 1, 1);
-						Utils.drawTexturedRect(
-							width / 2 - 96 + 1,
+						Utils.drawTexturedRect(width / 2 - 96 + 1,
 							topY + 30 + num * 22 + 1,
 							193,
 							21,
@@ -138,8 +136,7 @@ public class RecipeSearchOverlay {
 					} else {
 						Minecraft.getMinecraft().getTextureManager().bindTexture(SEARCH_OVERLAY_TEXTURE);
 						GlStateManager.color(1, 1, 1, 1);
-						Utils.drawTexturedRect(
-							width / 2 - 96 + 1,
+						Utils.drawTexturedRect(width / 2 - 96 + 1,
 							topY + 30 + num * 22 + 1,
 							193,
 							21,
@@ -157,12 +154,9 @@ public class RecipeSearchOverlay {
 						itemName = lore[0].trim();
 					}
 
-					Minecraft.getMinecraft().fontRendererObj.drawString(Minecraft.getMinecraft().fontRendererObj.trimStringToWidth(
-							itemName,
-							165
-						),
-						width / 2 - 74, topY + 35 + num * 22 + 1, 0xdddddd, true
-					);
+					Minecraft.getMinecraft().fontRendererObj.drawString(Minecraft.getMinecraft().fontRendererObj.trimStringToWidth(itemName,
+						165
+					), width / 2 - 74, topY + 35 + num * 22 + 1, 0xdddddd, true);
 
 					GlStateManager.enableDepth();
 					Utils.drawItemStack(stack, width / 2 - 94 + 2, topY + 32 + num * 22 + 1);
@@ -178,8 +172,7 @@ public class RecipeSearchOverlay {
 		}
 
 		if (NotEnoughUpdates.INSTANCE.config.recipeTweaks.showPastSearches) {
-			Minecraft.getMinecraft().fontRendererObj.drawString(
-				"Past Searches:",
+			Minecraft.getMinecraft().fontRendererObj.drawString("Past Searches:",
 				width / 2 - 100,
 				topY + 25 + AUTOCOMPLETE_HEIGHT + 5,
 				0xdddddd,
@@ -190,8 +183,7 @@ public class RecipeSearchOverlay {
 				if (i >= NotEnoughUpdates.INSTANCE.config.hidden.previousRecipeSearches.size()) break;
 
 				String s = NotEnoughUpdates.INSTANCE.config.hidden.previousRecipeSearches.get(i);
-				Minecraft.getMinecraft().fontRendererObj.drawString(
-					s,
+				Minecraft.getMinecraft().fontRendererObj.drawString(s,
 					width / 2 - 95 + 1,
 					topY + 45 + AUTOCOMPLETE_HEIGHT + i * 10 + 2,
 					0xdddddd,
@@ -200,8 +192,7 @@ public class RecipeSearchOverlay {
 			}
 
 			if (tooltipToDisplay != null) {
-				Utils.drawHoveringText(
-					tooltipToDisplay,
+				Utils.drawHoveringText(tooltipToDisplay,
 					mouseX,
 					mouseY,
 					width,
@@ -253,10 +244,9 @@ public class RecipeSearchOverlay {
 
 		String search = stringBuilder.toString();
 
-		if(search.isEmpty()) return;
+		if (search.isEmpty()) return;
 
 		Minecraft.getMinecraft().thePlayer.sendChatMessage("/recipe " + search);
-
 
 		if (!searchString.trim().isEmpty()) {
 			List<String> previousRecipeSearches = NotEnoughUpdates.INSTANCE.config.hidden.previousRecipeSearches;
@@ -346,7 +336,6 @@ public class RecipeSearchOverlay {
 
 			title.retainAll(bazaarItems);
 			desc.retainAll(bazaarItems);
-
 
 			if (thisSearchId != searchId.get()) return;
 
@@ -452,8 +441,8 @@ public class RecipeSearchOverlay {
 						searchStringExtra = "";
 						close();
 						Minecraft.getMinecraft().thePlayer.sendQueue.addToSendQueue(new C0DPacketCloseWindow(Minecraft.getMinecraft().thePlayer.openContainer.windowId));
-						NotEnoughUpdates.INSTANCE.openGui = new GuiScreenElementWrapper(new NEUConfigEditor(
-							NotEnoughUpdates.INSTANCE.config, "Bazaar Tweaks"));
+						NotEnoughUpdates.INSTANCE.openGui =
+							new GuiScreenElementWrapper(new NEUConfigEditor(NotEnoughUpdates.INSTANCE.config, "Bazaar Tweaks"));
 					}
 				}
 			} else if (Mouse.getEventButton() == 0) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/RecipeSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/RecipeSearchOverlay.java
@@ -26,6 +26,7 @@ import io.github.moulberry.notenoughupdates.core.GuiElementTextField;
 import io.github.moulberry.notenoughupdates.core.GuiScreenElementWrapper;
 import io.github.moulberry.notenoughupdates.mixins.AccessorGuiEditSign;
 import io.github.moulberry.notenoughupdates.options.NEUConfigEditor;
+import io.github.moulberry.notenoughupdates.util.ItemResolutionQuery;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
@@ -331,6 +332,8 @@ public class RecipeSearchOverlay {
 			if (thisSearchId != searchId.get()) return;
 
 			Set<String> bazaarItems = NotEnoughUpdates.INSTANCE.manager.auctionManager.getBazaarKeySet();
+//			ItemResolutionQuery query = new ItemResolutionQuery().resolveToItemListJson();
+//			NotEnoughUpdates.INSTANCE.manager
 			// Amalgamated Crimsonite (Old) // TODO remove from repo
 			bazaarItems.remove("AMALGAMATED_CRIMSONITE");
 
@@ -442,7 +445,7 @@ public class RecipeSearchOverlay {
 						close();
 						Minecraft.getMinecraft().thePlayer.sendQueue.addToSendQueue(new C0DPacketCloseWindow(Minecraft.getMinecraft().thePlayer.openContainer.windowId));
 						NotEnoughUpdates.INSTANCE.openGui =
-							new GuiScreenElementWrapper(new NEUConfigEditor(NotEnoughUpdates.INSTANCE.config, "Bazaar Tweaks"));
+							new GuiScreenElementWrapper(new NEUConfigEditor(NotEnoughUpdates.INSTANCE.config, "Recipe Tweaks"));
 					}
 				}
 			} else if (Mouse.getEventButton() == 0) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/RecipeSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/RecipeSearchOverlay.java
@@ -1,0 +1,505 @@
+/*
+ * Copyright (C) 2022 NotEnoughUpdates contributors
+ *
+ * This file is part of NotEnoughUpdates.
+ *
+ * NotEnoughUpdates is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * NotEnoughUpdates is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.moulberry.notenoughupdates.overlays;
+
+import com.google.common.base.Splitter;
+import com.google.gson.JsonObject;
+import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
+import io.github.moulberry.notenoughupdates.core.GuiElementTextField;
+import io.github.moulberry.notenoughupdates.core.GuiScreenElementWrapper;
+import io.github.moulberry.notenoughupdates.mixins.AccessorGuiEditSign;
+import io.github.moulberry.notenoughupdates.options.NEUConfigEditor;
+import io.github.moulberry.notenoughupdates.util.Utils;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.gui.inventory.GuiEditSign;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.play.client.C0DPacketCloseWindow;
+import net.minecraft.tileentity.TileEntitySign;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ResourceLocation;
+import org.lwjgl.input.Keyboard;
+import org.lwjgl.input.Mouse;
+import org.lwjgl.opengl.GL11;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RecipeSearchOverlay {
+	private static final ResourceLocation SEARCH_OVERLAY_TEXTURE = new ResourceLocation(
+		"notenoughupdates:auc_search/ah_search_overlay.png");
+	private static final ResourceLocation SEARCH_OVERLAY_TEXTURE_TAB_COMPLETED = new ResourceLocation(
+		"notenoughupdates:auc_search/ah_search_overlay_tab_completed.png");
+
+	private static final GuiElementTextField textField = new GuiElementTextField("", 200, 20, 0);
+	private static boolean searchFieldClicked = false;
+	private static String searchString = "";
+	private static String searchStringExtra = "";
+	private static final Splitter SPACE_SPLITTER = Splitter.on(" ").omitEmptyStrings().trimResults();
+	private static boolean tabCompleted = false;
+	private static int tabCompletionIndex = -1;
+
+	private static final int AUTOCOMPLETE_HEIGHT = 118;
+
+	private static final Set<String> autocompletedItems = new LinkedHashSet<>();
+
+	public static boolean shouldReplace() {
+		if (!NotEnoughUpdates.INSTANCE.hasSkyblockScoreboard()) return false;
+		if (!NotEnoughUpdates.INSTANCE.config.recipeTweaks.enableSearchOverlay) return false;
+
+		if (!(Minecraft.getMinecraft().currentScreen instanceof GuiEditSign)) {
+			if (!NotEnoughUpdates.INSTANCE.config.recipeTweaks.keepPreviousSearch) searchString = "";
+			return false;
+		}
+
+		String lastContainer = Utils.getLastOpenChestName();
+		if(lastContainer.equals("Craft Item") || lastContainer.contains("Recipes (")) return true;
+		else return false;
+	}
+
+	public static void render() {
+		ScaledResolution scaledResolution = new ScaledResolution(Minecraft.getMinecraft());
+		int width = scaledResolution.getScaledWidth();
+		int height = scaledResolution.getScaledHeight();
+		int mouseX = Mouse.getX() * width / Minecraft.getMinecraft().displayWidth;
+		int mouseY = height - Mouse.getY() * height / Minecraft.getMinecraft().displayHeight - 1;
+
+		Utils.drawGradientRect(0, 0, width, height, -1072689136, -804253680);
+
+		int h = NotEnoughUpdates.INSTANCE.config.recipeTweaks.showPastSearches ? 219 : 145;
+
+		int topY = height / 4;
+		if (scaledResolution.getScaleFactor() >= 4) {
+			topY = height / 2 - h / 2 + 5;
+		}
+
+		Minecraft.getMinecraft().getTextureManager().bindTexture(SEARCH_OVERLAY_TEXTURE);
+		GlStateManager.color(1, 1, 1, 1);
+		Utils.drawTexturedRect(width / 2 - 100, topY - 1, 203, h, 0, 203 / 512f, 0, h / 256f, GL11.GL_NEAREST);
+
+		Minecraft.getMinecraft().fontRendererObj.drawString("Enter Query:", width / 2 - 100, topY - 10, 0xdddddd, true);
+
+		textField.setFocus(true);
+		textField.setText(searchString);
+		textField.setSize(149, 20);
+		textField.setCustomBorderColour(0xffffff);
+		textField.render(width / 2 - 100 + 1, topY + 1);
+
+		if (textField.getText().trim().isEmpty()) autocompletedItems.clear();
+
+		List<String> tooltipToDisplay = null;
+
+		int num = 0;
+		synchronized (autocompletedItems) {
+			String[] autoCompletedItemsArray = autocompletedItems.toArray(new String[0]);
+			for (int i = 0; i < autoCompletedItemsArray.length; i++) {
+				String str = autoCompletedItemsArray[i];
+				JsonObject obj = NotEnoughUpdates.INSTANCE.manager.getItemInformation().get(str);
+				if (obj != null) {
+					ItemStack stack = NotEnoughUpdates.INSTANCE.manager.jsonToStack(obj);
+					if (i == tabCompletionIndex) {
+						Minecraft.getMinecraft().getTextureManager().bindTexture(SEARCH_OVERLAY_TEXTURE_TAB_COMPLETED);
+						GlStateManager.color(1, 1, 1, 1);
+						Utils.drawTexturedRect(
+							width / 2 - 96 + 1,
+							topY + 30 + num * 22 + 1,
+							193,
+							21,
+							0 / 512f,
+							193 / 512f,
+							0,
+							21 / 256f,
+							GL11.GL_NEAREST
+						);
+					} else {
+						Minecraft.getMinecraft().getTextureManager().bindTexture(SEARCH_OVERLAY_TEXTURE);
+						GlStateManager.color(1, 1, 1, 1);
+						Utils.drawTexturedRect(
+							width / 2 - 96 + 1,
+							topY + 30 + num * 22 + 1,
+							193,
+							21,
+							214 / 512f,
+							407 / 512f,
+							0,
+							21 / 256f,
+							GL11.GL_NEAREST
+						);
+
+					}
+					String itemName = Utils.trimIgnoreColour(stack.getDisplayName().replaceAll("\\[.+]", ""));
+					if (itemName.contains("Enchanted Book") && str.contains(";")) {
+						String[] lore = NotEnoughUpdates.INSTANCE.manager.getLoreFromNBT(stack.getTagCompound());
+						itemName = lore[0].trim();
+					}
+
+					Minecraft.getMinecraft().fontRendererObj.drawString(Minecraft.getMinecraft().fontRendererObj.trimStringToWidth(
+							itemName,
+							165
+						),
+						width / 2 - 74, topY + 35 + num * 22 + 1, 0xdddddd, true
+					);
+
+					GlStateManager.enableDepth();
+					Utils.drawItemStack(stack, width / 2 - 94 + 2, topY + 32 + num * 22 + 1);
+
+					if (mouseX > width / 2 - 96 && mouseX < width / 2 + 96 && mouseY > topY + 30 + num * 22 &&
+						mouseY < topY + 30 + num * 22 + 20) {
+						tooltipToDisplay = stack.getTooltip(Minecraft.getMinecraft().thePlayer, false);
+					}
+
+					if (++num >= 5) break;
+				}
+			}
+		}
+
+		if (NotEnoughUpdates.INSTANCE.config.recipeTweaks.showPastSearches) {
+			Minecraft.getMinecraft().fontRendererObj.drawString(
+				"Past Searches:",
+				width / 2 - 100,
+				topY + 25 + AUTOCOMPLETE_HEIGHT + 5,
+				0xdddddd,
+				true
+			);
+
+			for (int i = 0; i < 5; i++) {
+				if (i >= NotEnoughUpdates.INSTANCE.config.hidden.previousRecipeSearches.size()) break;
+
+				String s = NotEnoughUpdates.INSTANCE.config.hidden.previousRecipeSearches.get(i);
+				Minecraft.getMinecraft().fontRendererObj.drawString(
+					s,
+					width / 2 - 95 + 1,
+					topY + 45 + AUTOCOMPLETE_HEIGHT + i * 10 + 2,
+					0xdddddd,
+					true
+				);
+			}
+
+			if (tooltipToDisplay != null) {
+				Utils.drawHoveringText(
+					tooltipToDisplay,
+					mouseX,
+					mouseY,
+					width,
+					height,
+					-1,
+					Minecraft.getMinecraft().fontRendererObj
+				);
+			}
+		}
+
+	}
+
+	private static final ExecutorService searchES = Executors.newSingleThreadExecutor();
+	private static final AtomicInteger searchId = new AtomicInteger(0);
+
+	private static String getItemIdAtIndex(int i) {
+		if (!autocompletedItems.isEmpty()) {
+			if ((i > autocompletedItems.size() - 1) || i < 0 || i > 4) {
+				return "";
+			}
+			String searchString = autocompletedItems.toArray()[i].toString();
+			JsonObject repoObject = NotEnoughUpdates.INSTANCE.manager.getItemInformation().get(searchString);
+			if (repoObject != null) {
+				ItemStack stack = NotEnoughUpdates.INSTANCE.manager.jsonToStack(repoObject);
+				return Utils.cleanColour(stack.getDisplayName().replaceAll("\\[.+]", ""));
+			}
+
+		}
+		return null;
+	}
+
+	public static void close() {
+		if (tabCompleted) {
+			tabCompletionIndex = -1;
+			tabCompleted = false;
+		}
+		if (NotEnoughUpdates.INSTANCE.config.recipeTweaks.keepPreviousSearch) {
+			search();
+		} else {
+			synchronized (autocompletedItems) {
+				autocompletedItems.clear();
+			}
+		}
+
+		StringBuilder stringBuilder = new StringBuilder(searchString.trim());
+		if (!searchStringExtra.isEmpty()) {
+			stringBuilder.append(searchStringExtra);
+		}
+
+		String search = stringBuilder.toString();
+
+		if(search.isEmpty()) return;
+
+		Minecraft.getMinecraft().thePlayer.sendChatMessage("/recipe " + search);
+
+
+		if (!searchString.trim().isEmpty()) {
+			List<String> previousRecipeSearches = NotEnoughUpdates.INSTANCE.config.hidden.previousRecipeSearches;
+			previousRecipeSearches.remove(searchString);
+			previousRecipeSearches.remove(searchString);
+			previousRecipeSearches.add(0, searchString);
+			while (previousRecipeSearches.size() > 5) {
+				previousRecipeSearches.remove(previousRecipeSearches.size() - 1);
+			}
+		}
+
+		Minecraft.getMinecraft().displayGuiScreen(null);
+
+		if (Minecraft.getMinecraft().currentScreen == null) {
+			Minecraft.getMinecraft().setIngameFocus();
+		}
+	}
+
+	private static boolean updateTabCompletedSearch(int key) {
+		String id;
+		if (key == Keyboard.KEY_DOWN || key == Keyboard.KEY_TAB) {
+			id = getItemIdAtIndex(tabCompletionIndex + 1);
+			if (id == null) {
+				textField.setFocus(true);
+				textField.setText(searchString);
+				tabCompleted = false;
+				tabCompletionIndex = -1;
+				return true;
+			} else if (id.equals("")) {
+				tabCompletionIndex = 0;
+				return true;
+			} else {
+				searchString = id;
+				tabCompletionIndex += 1;
+				return true;
+			}
+		} else if (key == Keyboard.KEY_UP) {
+			id = getItemIdAtIndex(tabCompletionIndex - 1);
+			if (id == null) {
+				textField.setFocus(true);
+				textField.setText(searchString);
+				tabCompleted = false;
+				tabCompletionIndex = -1;
+				return true;
+			} else if (id.equals("")) {
+				if (autocompletedItems.size() > 4) tabCompletionIndex = 4;
+				else tabCompletionIndex = autocompletedItems.size() - 1;
+				tabCompletionIndex = autocompletedItems.size() - 1;
+				return true;
+			} else {
+				searchString = id;
+				tabCompletionIndex -= 1;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public static void search() {
+		final int thisSearchId = searchId.incrementAndGet();
+
+		searchES.submit(() -> {
+			if (thisSearchId != searchId.get()) return;
+
+			List<String> title = new ArrayList<>(NotEnoughUpdates.INSTANCE.manager.search("title:" + searchString.trim()));
+
+			if (thisSearchId != searchId.get()) return;
+
+			if (!searchString.trim().contains(" ")) {
+				StringBuilder sb = new StringBuilder();
+				for (char c : searchString.toCharArray()) {
+					sb.append(c).append(" ");
+				}
+				title.addAll(NotEnoughUpdates.INSTANCE.manager.search("title:" + sb.toString().trim()));
+			}
+
+			if (thisSearchId != searchId.get()) return;
+
+			List<String> desc = new ArrayList<>(NotEnoughUpdates.INSTANCE.manager.search("desc:" + searchString.trim()));
+			desc.removeAll(title);
+
+			if (thisSearchId != searchId.get()) return;
+
+			Set<String> bazaarItems = NotEnoughUpdates.INSTANCE.manager.auctionManager.getBazaarKeySet();
+			// Amalgamated Crimsonite (Old) // TODO remove from repo
+			bazaarItems.remove("AMALGAMATED_CRIMSONITE");
+
+			title.retainAll(bazaarItems);
+			desc.retainAll(bazaarItems);
+
+
+			if (thisSearchId != searchId.get()) return;
+
+			synchronized (autocompletedItems) {
+				autocompletedItems.clear();
+				autocompletedItems.addAll(title);
+				autocompletedItems.addAll(desc);
+			}
+		});
+	}
+
+	public static void keyEvent() {
+		boolean ignoreKey = false;
+
+		if (Keyboard.getEventKey() == Keyboard.KEY_ESCAPE) {
+			searchStringExtra = "";
+			close();
+			if (NotEnoughUpdates.INSTANCE.config.recipeTweaks.escFullClose) {
+				Minecraft.getMinecraft().thePlayer.sendQueue.addToSendQueue(new C0DPacketCloseWindow(Minecraft.getMinecraft().thePlayer.openContainer.windowId));
+			}
+			return;
+		} else if (Keyboard.getEventKey() == Keyboard.KEY_RETURN) {
+			searchStringExtra = "";
+			close();
+			return;
+		} else if (Keyboard.getEventKey() == Keyboard.KEY_TAB) {
+			//autocomplete to first item in the list
+			if (!tabCompleted) {
+				tabCompleted = true;
+				ignoreKey = true;
+				String id = getItemIdAtIndex(0);
+				if (id == null) {
+					tabCompleted = false;
+					textField.setFocus(true);
+					textField.setText(searchString);
+				} else {
+					tabCompletionIndex = 0;
+					searchString = id;
+				}
+			}
+		}
+
+		if (Keyboard.getEventKeyState()) {
+			if (tabCompleted) {
+				if (!ignoreKey) {
+					boolean success = updateTabCompletedSearch(Keyboard.getEventKey());
+					if (success) return;
+					textField.setFocus(true);
+					textField.setText(searchString);
+					tabCompleted = false;
+					tabCompletionIndex = -1;
+				} else return;
+
+			}
+			textField.setFocus(true);
+			textField.setText(searchString);
+			textField.keyTyped(Keyboard.getEventCharacter(), Keyboard.getEventKey());
+			searchString = textField.getText();
+
+			search();
+		}
+	}
+
+	public static void mouseEvent() {
+		ScaledResolution scaledResolution = new ScaledResolution(Minecraft.getMinecraft());
+		int width = scaledResolution.getScaledWidth();
+		int height = scaledResolution.getScaledHeight();
+		int mouseX = Mouse.getX() * width / Minecraft.getMinecraft().displayWidth;
+		int mouseY = height - Mouse.getY() * height / Minecraft.getMinecraft().displayHeight - 1;
+
+		int h = NotEnoughUpdates.INSTANCE.config.recipeTweaks.showPastSearches ? 219 : 145;
+
+		int topY = height / 4;
+		if (scaledResolution.getScaleFactor() >= 4) {
+			topY = height / 2 - h / 2 + 5;
+		}
+
+		if (!Mouse.getEventButtonState() && Mouse.getEventButton() == -1 && searchFieldClicked) {
+			textField.mouseClickMove(mouseX - 2, topY + 10, 0, 0);
+		}
+
+		if (Mouse.getEventButton() != -1) {
+			searchFieldClicked = false;
+		}
+
+		if (Mouse.getEventButtonState()) {
+			if (mouseY > topY && mouseY < topY + 20) {
+				if (mouseX > width / 2 - 100) {
+					if (mouseX < width / 2 + 49) {
+						searchFieldClicked = true;
+						textField.mouseClicked(mouseX - 2, mouseY, Mouse.getEventButton());
+
+						if (Mouse.getEventButton() == 1) {
+							searchString = "";
+							synchronized (autocompletedItems) {
+								autocompletedItems.clear();
+							}
+						}
+					} else if (mouseX < width / 2 + 75) {
+						searchStringExtra = "";
+						close();
+					} else if (mouseX < width / 2 + 100) {
+						searchStringExtra = "";
+						close();
+						Minecraft.getMinecraft().thePlayer.sendQueue.addToSendQueue(new C0DPacketCloseWindow(Minecraft.getMinecraft().thePlayer.openContainer.windowId));
+						NotEnoughUpdates.INSTANCE.openGui = new GuiScreenElementWrapper(new NEUConfigEditor(
+							NotEnoughUpdates.INSTANCE.config, "Bazaar Tweaks"));
+					}
+				}
+			} else if (Mouse.getEventButton() == 0) {
+				int num = 0;
+				synchronized (autocompletedItems) {
+					for (String str : autocompletedItems) {
+						JsonObject obj = NotEnoughUpdates.INSTANCE.manager.getItemInformation().get(str);
+						if (obj != null) {
+							ItemStack stack = NotEnoughUpdates.INSTANCE.manager.jsonToStack(obj);
+							if (mouseX >= width / 2 - 96 && mouseX <= width / 2 + 96 && mouseY >= topY + 30 + num * 22 &&
+								mouseY <= topY + 30 + num * 22 + 20) {
+								searchString = Utils.cleanColour(stack.getDisplayName().replaceAll("\\[.+]", "")).trim();
+								if (searchString.contains("Enchanted Book") && str.contains(";")) {
+									String[] lore = NotEnoughUpdates.INSTANCE.manager.getLoreFromNBT(stack.getTagCompound());
+									if (lore != null) {
+										searchString = Utils.cleanColour(lore[0]);
+									}
+								}
+
+								searchStringExtra = " ";
+
+								close();
+								return;
+							}
+
+							if (++num >= 5) break;
+						}
+					}
+				}
+
+				if (NotEnoughUpdates.INSTANCE.config.recipeTweaks.showPastSearches) {
+					for (int i = 0; i < 5; i++) {
+						if (i >= NotEnoughUpdates.INSTANCE.config.hidden.previousRecipeSearches.size()) break;
+
+						String s = NotEnoughUpdates.INSTANCE.config.hidden.previousRecipeSearches.get(i);
+						if (mouseX >= width / 2 - 95 && mouseX <= width / 2 + 95 &&
+							mouseY >= topY + 45 + AUTOCOMPLETE_HEIGHT + i * 10 &&
+							mouseY <= topY + 45 + AUTOCOMPLETE_HEIGHT + i * 10 + 10) {
+							searchString = s;
+							searchStringExtra = "";
+							close();
+							return;
+						}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added recipe search overlay which uses the same way ah and bz search overlays are made.

Known bugs that I couldn't fix:
- [ ] Ghost shadow appearing in different pages other than crafting menu without the pickaxe.
- [ ] Shift clicking an item crashes the game

(Third time's the charm)