### PR TITLE
Fix crash in EquipmentOverlay

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/EquipmentOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/EquipmentOverlay.java
@@ -391,6 +391,8 @@ public class EquipmentOverlay {
 		ItemStack heldItem = Minecraft.getMinecraft().thePlayer.getHeldItem();
 		List<String> heldItemLore = ItemUtils.getLore(heldItem);
 
+		if (heldItemLore.isEmpty()) return;
+
 		String itemType = Objects.requireNonNull(StringUtils.substringAfterLast(heldItemLore.get(heldItemLore.size() - 1), " "), "null");
 		if (!Arrays.asList("NECKLACE", "CLOAK", "BELT", "GLOVES", "BRACELET").contains(itemType)) return;
 


### PR DESCRIPTION
This can happen when you right click with an item with no lore in your hand. For example, a Magical Water Bucket that temporarily turns into a vanilla Bucket upon use, until the server turns it back into a Magical Water Bucket.

<!--

Thank you for choosing to contribute to NEU!

Please make sure to give your PR a descriptive title.

Your PR title will be used in our changelog and should look like one of those:

Add fleebleblub menu
Fix crash in the gorp overlay
meta: Remove outdated documentation in CONTRIBUTING.md

Use the meta prefix for things that don't affect users and use Add, Fix, or Remove for the rest of your PR.

Do not end your PR title with a .

If your PR bundles two features, consider opening two PRs, one for each instead.

-->
