### PR TITLE
Fix Fairy Soul Waypoints not showing found message when no waypoints present

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/FairySouls.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/FairySouls.java
@@ -198,7 +198,7 @@ public class FairySouls {
 	}
 
 	public void markClosestSoulFound() {
-		if (!trackSouls) return;
+		if (!trackSouls || allSoulsInCurrentLocation == null || allSoulsInCurrentLocation.isEmpty()) return;
 		int closestIndex = -1;
 		double closestDistSq = 10 * 10;
 		for (int i = 0; i < allSoulsInCurrentLocation.size(); i++) {
@@ -211,7 +211,7 @@ public class FairySouls {
 				closestIndex = i;
 			}
 		}
-		if (closestIndex != -1) {
+		if (closestIndex != -1 && foundSoulsInLocation != null) {
 			foundSoulsInLocation.add(closestIndex);
 			refreshMissingSoulInfo(true);
 		}


### PR DESCRIPTION
<!--

Thank you for choosing to contribute to NEU!

Please make sure to give your PR a descriptive title.

Your PR title will be used in our changelog and should look like one of those:

Add fleebleblub menu
Fix crash in the gorp overlay
meta: Remove outdated documentation in CONTRIBUTING.md

Use the meta prefix for things that don't affect users and use Add, Fix, or Remove for the rest of your PR.

Do not end your PR title with a .

If your PR bundles two features, consider opening two PRs, one for each instead.

-->
This bugfix can be tested in the rift or on a private island  /visit timedeo, then click on the soul