### PR TITLE
meta: Fix discord links not working anymore

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -3,18 +3,18 @@
 ## What is this feature?
 
 ### Equipment Overlay
-![Equipment Overlay](https://cdn.discordapp.com/attachments/756532125443817594/1006792213432389752/unknown.png)
+![Equipment Overlay](https://i.imgur.com/wshoYns.png)
 
 This overlay shows the current equipment of the player
 #### It doesn't fit in with my texture pack !!!!!
-[If you go to /neu equipment you can change the style of the overlay](https://cdn.discordapp.com/attachments/756532125443817594/1006796222415245413/unknown.png)
+[If you go to /neu equipment you can change the style of the overlay](https://i.imgur.com/6MmROv3.png)
 This also applies to the pet inventory overlay
 
 
 ## What does this mean?
 
 ### Missing Repo Data
-![Missing Repo Data](https://cdn.discordapp.com/attachments/756532125443817594/1006805696639143987/unknown.png)
+![Missing Repo Data](https://i.imgur.com/EsnFJ4I.png)
 
 If you get this popup you need to update your repo data.
 As the popup says, you can try `/neuresetrepo` but if that doesn't resolve the issue go to [#neu-support](https://discord.gg/moulberry) and ask for help
@@ -22,13 +22,13 @@ As the popup says, you can try `/neuresetrepo` but if that doesn't resolve the i
 ## How do I?
 
 ### Turn on fairy soul waypoints
-You can either [run `/neusouls`](https://cdn.discordapp.com/attachments/756532125443817594/1006808649471103046/unknown.png) for the help menu or [turn on the option in the first page of `/neu`](https://cdn.discordapp.com/attachments/756532125443817594/1006808594743840778/unknown.png)
+You can either [run `/neusouls`](https://i.imgur.com/2vfXxDB.png) for the help menu or [turn on the option in the first page of `/neu`](https://i.imgur.com/OtmxAlT.png)
 
 ### Help I accidentally turned off the custom storage gui
-![enable storage gui](https://cdn.discordapp.com/attachments/756532125443817594/1006810880794710046/unknown.png)
+![enable storage gui](https://i.imgur.com/JCJil2p.png)
 
 Simply go to `/neu storage` and turn on the first option
 
 ### Move a GUI element 
-![Edit gui](https://cdn.discordapp.com/attachments/756532125443817594/1006811543356317797/unknown.png)
+![Edit gui](https://i.imgur.com/yL0J63B.png)
 Go to the second tab of `/neu` and here you will have all the gui elements you can move

--- a/Update Notes/2.1.md
+++ b/Update Notes/2.1.md
@@ -7,25 +7,25 @@
 - Added combat skill overlay - nopo
 - Added slayer overlay - nopo
 - Added blocking clicks back to the enchanting minigames (because apparently, it's not bannable?)
-  - [Donpireso replied to a sba dev's email about some of sba features, and it seems to imply that blocking clicks in guis aren't bannable](https://cdn.discordapp.com/attachments/823769568933576764/906101631861526559/unknown.png)
+  - [Donpireso replied to a sba dev's email about some of sba features, and it seems to imply that blocking clicks in guis aren't bannable](https://i.imgur.com/VTmGSVP.png)
   - Made it if you hold shift in the enchant solvers it overrides prevent missclicks - nopo
 - Fixed pet overlay not updating when going into /pets - nopo
 - Fixed pet overlay randomly going to level 100 - nopo
-- [Added an armor overlay for the new armor slots](https://cdn.discordapp.com/attachments/832652653292027904/922399046528794634/unknown.png)
+- [Added an armor overlay for the new armor slots](https://i.imgur.com/XzHELVq.png)
 - Added a pet overlay that shows your active pet in your inventory - nopo
-- [Price graph for items on /ah and /bz](https://cdn.discordapp.com/attachments/896407218151366687/926968296929107999/unknown.png) - DeDiamondPro
+- [Price graph for items on /ah and /bz](https://i.imgur.com/UkoyUH3.png) - DeDiamondPro
 - Added wishing compass solver that shows target coordinates, structure, and integrates with Skytils waypoints - CraftyOldMiner
 - Improved metal detector logic to solve using a single position in most cases using known locations based on Keeper coordinates - CraftyOldMiner
 - Added support for official Hypixel wiki, can be toggled in /neu misc - DeDiamondPro
 - Added a calculator (/neucalc help), that also works in the auction house / bazaar - nea89
 - Added an enchant table style gui for /hex - nopo
 - Added and fixed various things in the profile viewer:
-  - [Added hotm tab](https://media.discordapp.net/attachments/659613194066722833/991115131507441724/unknown.png) - nopo
+  - [Added hotm tab](https://i.imgur.com/WneMM4c.png) - nopo
     - Big thanks to kwev1n for some math and jani for the texture
-  - [Added bingo tab](https://media.discordapp.net/attachments/659613194066722833/991115625772625980/unknown.png) - Lulonaut
-  - [Added bingo and stranded profile icons](https://cdn.discordapp.com/attachments/832652653292027904/915844465372065842/unknown.png) - nopo
-  - [Added trophy fishing tab](https://media.discordapp.net/attachments/659613194066722833/991114639150698567/unknown.png) - efefury
-  - [Added bestiary tab](https://cdn.discordapp.com/attachments/832652653292027904/991927854776459324/unknown.png) - nopo
+  - [Added bingo tab](https://i.imgur.com/CcNoY2V.png) - Lulonaut
+  - [Added bingo and stranded profile icons](https://i.imgur.com/ap2qZZ0.png) - nopo
+  - [Added trophy fishing tab](https://i.imgur.com/1y5gpDt.png) - efefury
+  - [Added bestiary tab](https://i.imgur.com/Ci6g3ik.png) - nopo
   - Added equipment - nopo
   - Added blaze slayer level and kills - nopo
   - Added social level - nopo
@@ -105,9 +105,9 @@
 - Added Heavy Pearls to todo overlay - Cobble8
 - Added Booster Cookie Warning - 2stinkysocks
 - Added an option to only search for Level 100 pets in the auction house search overlay - Lulonaut
-- [Added an error if you have new tab list off](https://cdn.discordapp.com/attachments/896407218151366687/913681097605398528/unknown.png) - nopo
+- [Added an error if you have new tab list off](https://i.imgur.com/P8HLmGd.png) - nopo
 - Added Fishing Timer over bobber - nea89
-- Added [Auction Profit Viewer Overlay](https://cdn.discordapp.com/attachments/848901833119629332/993191851400101918/176946124-28ddf336-1ec7-460b-b22a-5fe2733b46a3.png) - efefury
+- Added [Auction Profit Viewer Overlay](https://i.imgur.com/1xA0Gtw.png) - efefury
 - Added Trophy Reward Overlay - hannibal2
 - Add Auto-Updater (linux only) - nea89
 - Added power stone feature - hannibal2

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/Enchanting.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/Enchanting.java
@@ -110,7 +110,7 @@ public class Enchanting {
 	@ConfigAccordionId(id = 0)
 	public boolean enableEnchantingSolvers = true;
 	//In an email from Donpireso (admin) he says not sending a packet at all isn't bannable
-	//https://cdn.discordapp.com/attachments/823769568933576764/906101631861526559/unknown.png
+	//https://i.imgur.com/VTmGSVP.png
 	@Expose
 	@ConfigOption(
 		name = "Prevent Misclicks",


### PR DESCRIPTION
Discord CDN links now have a signature and expiry date, so the old links no longer work.