### PR TITLE
Fix profilePrefix constant

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
@@ -307,7 +307,7 @@ public class SBInfo {
 		return lastLocation;
 	}
 
-	private static final String profilePrefix = "\u00a7r\u00a7e\u00a7lProfile: \u00a7r\u00a7a";
+	private static final String profilePrefix = "\u00a7r\u00a7l\u00a7r\u00a7e\u00a7lProfile: \u00a7r\u00a7a";
 	private static final String skillsPrefix = "\u00a7r\u00a7e\u00a7lSkills: \u00a7r\u00a7a";
 	private static final String completedFactionQuests =
 		"\u00a7r \u00a7r\u00a7a(?!(Paul|Finnegan|Aatrox|Cole|Diana|Diaz|Foxy|Marina)).*";


### PR DESCRIPTION
I noticed that the storage menu stopped working,
after some research I found that NEU tries to find the user's current profile by looking for a username that starts with "§r§e§lProfile: §r§a" in the scoreboard.
after checking in Skyblock, looks like they changed the username to "\u00a7r\u00a7l\u00a7r\u00a7e\u00a7lProfile: \u00a7r\u00a7a",
So I changed the constant.