### PR TITLE
Fix double v in version number

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
@@ -166,7 +166,7 @@ public class NEUConfig extends Config {
 
 	@Override
 	public String getTitle() {
-		return "§7NotEnoughUpdates v" + NotEnoughUpdates.VERSION + " by §5Moulberry";
+		return "§7NotEnoughUpdates " + NotEnoughUpdates.VERSION + " by §5Moulberry";
 	}
 
 	@Override


### PR DESCRIPTION

![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/77941535/0e1bc7c1-be9d-49c8-92ba-0e4efa2f8be1)

title
