### PR TITLE
Fix gemstone sound paths for custom sounds feature

### DIFF
--- a/src/main/resources/assets/notenoughupdates/sounds.json
+++ b/src/main/resources/assets/notenoughupdates/sounds.json
@@ -12,7 +12,7 @@
     "category": "block",
     "sounds": [
       {
-        "name": "gemstonebreaktopaz",
+        "name": "gemstonetopazbreak",
         "stream": false
       }
     ]
@@ -21,7 +21,7 @@
     "category": "block",
     "sounds": [
       {
-        "name": "gemstonebreakruby",
+        "name": "gemstonerubybreak",
         "stream": false
       }
     ]
@@ -30,7 +30,7 @@
     "category": "block",
     "sounds": [
       {
-        "name": "gemstonebreakamber",
+        "name": "gemstoneamberbreak",
         "stream": false
       }
     ]


### PR DESCRIPTION
Ruby, topaz and amber gemstones had the wrong path so no sound was playing for the resource pack feature.