### PR TITLE
meta: Fix log spam when optifine isnt loaded

### DIFF
--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscgui/DynamicLightItemsEditor.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscgui/DynamicLightItemsEditor.kt
@@ -230,8 +230,7 @@ class DynamicLightItemsEditor() : GuiScreen() {
             try {
                 Class.forName("net.optifine.DynamicLights")
                 println("Loaded dynamic lights successfully.")
-            } catch (e: Exception) {
-                e.printStackTrace()
+            } catch (_: Exception) {
             }
             hasAttemptedToLoadOptifine = true
             if (!didApplyMixin) {


### PR DESCRIPTION
Mixin gives an (much smaller) error anyway `Error loading class: net/optifine/DynamicLights (java.lang.ClassNotFoundException: The specified class 'net.optifine.DynamicLights' was not found)` so I think its fine to not log anything