### PR TITLE
Fix insta buy warning not working with long item names

### DIFF
--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/BazaarPriceWarning.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/BazaarPriceWarning.kt
@@ -27,6 +27,7 @@ import io.github.moulberry.notenoughupdates.util.ItemUtils
 import io.github.moulberry.notenoughupdates.util.Utils
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiChest
+import net.minecraft.init.Items
 import net.minecraft.inventory.Slot
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
@@ -44,8 +45,15 @@ class BazaarPriceWarning : WarningPopUp() {
     val limit get() = NotEnoughUpdates.INSTANCE.config.bazaarTweaks.bazaarOverpayWarning
     @SubscribeEvent
     fun onClick(event: SlotClickEvent) {
-        if (!Utils.getOpenChestName().contains("Instant Buy"))
-            return
+        val openSlots = Minecraft.getMinecraft().thePlayer?.openContainer?.inventorySlots ?: return
+        //both insta buy and buy order screens have this sign
+        //we check the name of the buy order page and return if its that
+        //however the custom amount insta buy page doesnt have a sign so we also have to check its title
+        val signStack = openSlots[16]?.stack ?: return
+        if ((signStack.item != Items.sign ||
+                    signStack.displayName != "§aCustom Amount" ||
+                    Utils.getOpenChestName().contains("How many do you want?")) &&
+            !Utils.getOpenChestName().contains("Confirm Instant Buy")) return
         if (shouldShow()) return
         val stack = event.slot.stack ?: return
         val lore = ItemUtils.getLore(stack)

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/BazaarPriceWarning.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/BazaarPriceWarning.kt
@@ -46,12 +46,13 @@ class BazaarPriceWarning : WarningPopUp() {
     @SubscribeEvent
     fun onClick(event: SlotClickEvent) {
         val openSlots = Minecraft.getMinecraft().thePlayer?.openContainer?.inventorySlots ?: return
+        if (openSlots.size < 17) return
         //both insta buy and buy order screens have this sign
         //we check the name of the buy order page and return if its that
         //however the custom amount insta buy page doesnt have a sign so we also have to check its title
         val signStack = openSlots[16]?.stack ?: return
         if ((signStack.item != Items.sign ||
-                    signStack.displayName != "§aCustom Amount" ||
+                    ItemUtils.getDisplayName(signStack) != "§aCustom Amount" ||
                     Utils.getOpenChestName().contains("How many do you want?")) &&
             !Utils.getOpenChestName().contains("Confirm Instant Buy")) return
         if (shouldShow()) return


### PR DESCRIPTION
Closes #1130

![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/40329022/9298145d-4ea9-4765-9c37-21d7dc6c2266)
