### PR TITLE
Fix grammatical error in Profile Viewer crash text

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/CrashRecoveryPage.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/CrashRecoveryPage.java
@@ -77,7 +77,7 @@ public class CrashRecoveryPage extends GuiProfileViewerPage {
 
 		drawTitle();
 
-		drawString("§cLooked like your profile viewer crashed.");
+		drawString("§cLooks like your profile viewer crashed.");
 		drawString("§cPlease immediately send a screenshot of this screen into #neu-support.");
 		drawString("§cJoin our support server at §adiscord.gg/moulberry§c.");
 


### PR DESCRIPTION
The Profile Viewer crash text said "Looked like your profile viewer crashed", I changed it to "Looks like your profile viewer crashed" which is more correct for the situation the text is being shown in.