### PR TITLE
Add discount parsing in Enchant Table and Hex GUIs 

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/GuiCustomEnchant.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/GuiCustomEnchant.java
@@ -79,6 +79,7 @@ public class GuiCustomEnchant extends Gui {
 	private static final ModelBook MODEL_BOOK = new ModelBook();
 
 	private static final Pattern XP_COST_PATTERN = Pattern.compile("\\u00a73(\\d+) Exp Levels");
+	private static final Pattern DISCOUNT_COST_PATTERN = Pattern.compile("\\u00a78\\u00a7m(\\d+)\\u00a73 (\\d+) Exp Levels");
 	private static final Pattern ENCHANT_LEVEL_PATTERN = Pattern.compile("(.*)_(.*)");
 	private static final Pattern ENCHANT_NAME_PATTERN = Pattern.compile("([^IVX]*) ([IVX]*)");
 
@@ -160,6 +161,15 @@ public class GuiCustomEnchant extends Gui {
 					}
 
 				}
+			}
+			for (String line : this.displayLore) {
+					Matcher matcher = XP_COST_PATTERN.matcher(line);
+					Matcher discount_matcher = DISCOUNT_COST_PATTERN.matcher(line);
+					if (matcher.find()) {
+						this.xpCost = Integer.parseInt(matcher.group(1));
+					} else if (discount_matcher.find()) {
+							this.xpCost = Integer.parseInt(discount_matcher.group(2));
+					}
 			}
 		}
 	}
@@ -432,8 +442,11 @@ public class GuiCustomEnchant extends Gui {
 				if (enchanterCurrentEnch != null && removingEnchantPlayerLevel >= 0) {
 					for (String line : enchanterCurrentEnch.displayLore) {
 						Matcher matcher = XP_COST_PATTERN.matcher(line);
+						Matcher discount_matcher = DISCOUNT_COST_PATTERN.matcher(line);
 						if (matcher.find()) {
 							enchanterCurrentEnch.xpCost = Integer.parseInt(matcher.group(1));
+						} else if (discount_matcher.find()) {
+							enchanterCurrentEnch.xpCost = Integer.parseInt(discount_matcher.group(2));
 						}
 					}
 				}

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/hex/GuiCustomHex.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/hex/GuiCustomHex.java
@@ -86,6 +86,7 @@ public class GuiCustomHex extends Gui {
 	private static final ModelBook MODEL_BOOK = new ModelBook();
 
 	private static final Pattern XP_COST_PATTERN = Pattern.compile("\\u00a73(\\d+) Exp Levels");
+	private static final Pattern DISCOUNT_COST_PATTERN = Pattern.compile("\\u00a78\\u00a7m(\\d+)\\u00a73 (\\d+) Exp Levels");
 	private static final Pattern ENCHANT_LEVEL_PATTERN = Pattern.compile("(.*)_(.*)");
 	private static final Pattern ENCHANT_NAME_PATTERN = Pattern.compile("([^IVX]*) ([IVX]*)");
 
@@ -172,6 +173,15 @@ public class GuiCustomHex extends Gui {
 						}
 					}
 
+				}
+			}
+			for (String line : this.displayLore) {
+				Matcher matcher = XP_COST_PATTERN.matcher(line);
+				Matcher discount_matcher = DISCOUNT_COST_PATTERN.matcher(line);
+				if (matcher.find()) {
+					this.xpCost = Integer.parseInt(matcher.group(1));
+				} else if (discount_matcher.find()) {
+						this.xpCost = Integer.parseInt(discount_matcher.group(2));
 				}
 			}
 		}
@@ -562,8 +572,11 @@ public class GuiCustomHex extends Gui {
 				if (enchanterCurrentEnch != null && removingEnchantPlayerLevel >= 0) {
 					for (String line : enchanterCurrentEnch.displayLore) {
 						Matcher matcher = XP_COST_PATTERN.matcher(line);
+						Matcher discount_matcher = DISCOUNT_COST_PATTERN.matcher(line);
 						if (matcher.find()) {
 							enchanterCurrentEnch.xpCost = Integer.parseInt(matcher.group(1));
+						} else if (discount_matcher.find()) {
+								enchanterCurrentEnch.xpCost = Integer.parseInt(discount_matcher.group(2));
 						}
 					}
 				}


### PR DESCRIPTION
Hypixel added XP discounts for enchanting and adding books [in Febuary](https://hypixel.net/threads/skyblock-patch-notes-0-19-11-stackable-god-potions-and-other-improvements.5592331/) and the Enchant/Hex GUIs have been slightly broken ever since, since they don't have the code to parse discounts. I could not fix the xp costs in the list being incorrect, since the information about discounts is not available to us before the user clicks on an enchant (theoretically possible with API but that's a problem for another day).

I made it so every time an Enchantment class is instantiated, there is now a check to see if a discount exists and if so, the cost information is overridden with the discount info. This makes it so the cost information displayed on the enchant specific page is accurate, and fixes the problem of a greyed out "Apply" button when the player is able to apply the enchant.