### PR TITLE
Fix outline color of custom tooltips with formatting

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
@@ -1668,13 +1668,15 @@ public class Utils {
 	public static char getPrimaryColourCode(String displayName) {
 		int lastColourCode = -99;
 		int currentColour = 0;
+		int colourIndex = 0;
 		int[] mostCommon = new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 		for (int i = 0; i < displayName.length(); i++) {
 			char c = displayName.charAt(i);
 			if (c == '\u00A7') {
 				lastColourCode = i;
 			} else if (lastColourCode == i - 1) {
-				currentColour = Math.max(0, "0123456789abcdef".indexOf(c));
+				colourIndex = "0123456789abcdef".indexOf(c);
+				if (colourIndex != -1) currentColour = colourIndex;
 			} else if ("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".indexOf(c) >= 0) {
 				if (currentColour > 0) {
 					mostCommon[currentColour]++;


### PR DESCRIPTION
This PR fixes a small bug that has caused the outline of items in item list that have formatting in the first line (eg. bold, italics) to be black
![a very descriptive alt](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/70163122/8a4ecd80-6407-4003-9f9b-e5083100c8e3)

