### PR TITLE
Fix Mojang API errors when opening PV

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
@@ -52,6 +52,7 @@ import io.github.moulberry.notenoughupdates.oneconfig.IOneConfigCompat;
 import io.github.moulberry.notenoughupdates.options.NEUConfig;
 import io.github.moulberry.notenoughupdates.overlays.OverlayManager;
 import io.github.moulberry.notenoughupdates.profileviewer.ProfileViewer;
+import io.github.moulberry.notenoughupdates.profileviewer.persistent.RecentPVSearches;
 import io.github.moulberry.notenoughupdates.recipes.RecipeGenerator;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import io.github.moulberry.notenoughupdates.util.brigadier.BrigadierRoot;
@@ -319,6 +320,7 @@ public class NotEnoughUpdates {
 		overlay = new NEUOverlay(manager);
 		profileViewer = new ProfileViewer(manager);
 		HypixelItemAPI.INSTANCE.loadItemData();
+		RecentPVSearches.INSTANCE.loadRecentSearches();
 
 		for (KeyBinding kb : manager.keybinds) {
 			ClientRegistry.registerKeyBinding(kb);

--- a/src/main/java/io/github/moulberry/notenoughupdates/core/config/ConfigUtil.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/core/config/ConfigUtil.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -41,6 +42,22 @@ public class ConfigUtil {
 
 	public static <T> @Nullable T loadConfig(Class<T> configClass, File file, Gson gson, boolean useGzip) {
 		return loadConfig(configClass, file, gson, useGzip, true);
+	}
+
+	public static <T> @Nullable T loadConfigWithTypeToken(Type type, File file, Gson gson) {
+		BufferedReader reader = null;
+		try {
+			reader = new BufferedReader(new InputStreamReader(
+				Files.newInputStream(file.toPath()),
+				StandardCharsets.UTF_8
+			));
+		} catch (IOException e) {
+			System.out.println("Failed to load config file: " + file.getAbsolutePath());
+		}
+		if (reader == null) {
+			return null;
+		}
+		return gson.fromJson(reader, type);
 	}
 
 	public static <T> @Nullable T loadConfig(

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
@@ -551,8 +551,6 @@ public class NEUConfig extends Config {
 		@Expose
 		public ArrayList<String> previousBazaarSearches = new ArrayList<>();
 		@Expose
-		public ArrayList<String> previousProfileSearches = new ArrayList<>();
-		@Expose
 		public ArrayList<String> eventFavourites = new ArrayList<>();
 		@Expose
 		public ArrayList<String> quickCommands = createDefaultQuickCommands();

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
@@ -522,7 +522,7 @@ public class ProfileViewer {
 
 		manager.apiUtils
 			.request()
-			.url("https://api.mojang.com/users/profiles/minecraft/" + nameLower)
+			.url("https://mowojang.matdoes.dev/users/profiles/minecraft/" + nameLower)
 			.requestJson()
 			.thenAccept(jsonObject -> {
 				if (jsonObject.has("id") && jsonObject.get("id").isJsonPrimitive() &&

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
@@ -522,7 +522,7 @@ public class ProfileViewer {
 
 		manager.apiUtils
 			.request()
-			.url("https://mowojang.matdoes.dev/users/profiles/minecraft/" + nameLower)
+			.url("https://api.mojang.com/users/profiles/minecraft/" + nameLower)
 			.requestJson()
 			.thenAccept(jsonObject -> {
 				if (jsonObject.has("id") && jsonObject.get("id").isJsonPrimitive() &&

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewerUtils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewerUtils.java
@@ -240,13 +240,13 @@ public class ProfileViewerUtils {
 			}
 		}
 
+		while (previousSearches.size() > (alreadySearched ? 6 : 5)) {
+			previousSearches.remove(0);
+		}
+
 		if (!alreadySearched) {
 			// The player head will be saved later when rendering, since it will the fallback to start
 			previousSearches.add(new RecentPVSearches.RecentSearch(nameLower, null));
-		}
-
-		while (previousSearches.size() > 6) {
-			previousSearches.remove(previousSearches.size() - 1);
 		}
 	}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewerUtils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewerUtils.java
@@ -25,6 +25,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import io.github.moulberry.notenoughupdates.NEUManager;
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
+import io.github.moulberry.notenoughupdates.profileviewer.persistent.RecentPVSearches;
 import io.github.moulberry.notenoughupdates.util.Constants;
 import io.github.moulberry.notenoughupdates.util.JsonUtils;
 import io.github.moulberry.notenoughupdates.util.Utils;
@@ -227,15 +228,29 @@ public class ProfileViewerUtils {
 		if (username == null) return;
 		String nameLower = username.toLowerCase(Locale.ROOT);
 		if (nameLower.equals(Minecraft.getMinecraft().thePlayer.getName().toLowerCase(Locale.ROOT))) return;
-		List<String> previousProfileSearches = NotEnoughUpdates.INSTANCE.config.hidden.previousProfileSearches;
-		previousProfileSearches.remove(nameLower);
-		previousProfileSearches.add(0, nameLower);
-		while (previousProfileSearches.size() > 6) {
-			previousProfileSearches.remove(previousProfileSearches.size() - 1);
+		List<RecentPVSearches.RecentSearch> previousSearches = RecentPVSearches.INSTANCE.getRecentSearches();
+
+		boolean alreadySearched = false;
+		for (RecentPVSearches.RecentSearch recentSearch : previousSearches) {
+			if (nameLower.equals(recentSearch.getPlayername())) {
+				previousSearches.remove(recentSearch);
+				previousSearches.add(recentSearch);
+				alreadySearched = true;
+				break;
+			}
+		}
+
+		if (!alreadySearched) {
+			// The player head will be saved later when rendering, since it will the fallback to start
+			previousSearches.add(new RecentPVSearches.RecentSearch(nameLower, null));
+		}
+
+		while (previousSearches.size() > 6) {
+			previousSearches.remove(previousSearches.size() - 1);
 		}
 	}
 
-	private static ItemStack fallBackSkull() {
+	public static ItemStack fallBackSkull() {
 		return Utils.createSkull(
 			"Simon",
 			"f3c4dfb91c7b40ac81fd462538538523",

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/persistent/RecentPVSearches.kt
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/persistent/RecentPVSearches.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2024 NotEnoughUpdates contributors
+ *
+ * This file is part of NotEnoughUpdates.
+ *
+ * NotEnoughUpdates is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * NotEnoughUpdates is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.github.moulberry.notenoughupdates.profileviewer.persistent
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.google.gson.reflect.TypeToken
+import io.github.moulberry.notenoughupdates.NotEnoughUpdates
+import io.github.moulberry.notenoughupdates.autosubscribe.NEUAutoSubscribe
+import io.github.moulberry.notenoughupdates.core.config.ConfigUtil
+import io.github.moulberry.notenoughupdates.events.RegisterBrigadierCommandEvent
+import io.github.moulberry.notenoughupdates.util.brigadier.thenExecute
+import io.github.moulberry.notenoughupdates.util.kotlin.set
+import net.minecraft.item.ItemStack
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import java.io.File
+
+@NEUAutoSubscribe
+object RecentPVSearches {
+    var recentSearches: ArrayList<RecentSearch> = ArrayList()
+
+    private fun getFile() = File(NotEnoughUpdates.INSTANCE.neuDir, "recent_pv_searches.json")
+
+    fun loadRecentSearches() {
+        if (!getFile().exists()) {
+            return
+        }
+        val listType = object : TypeToken<ArrayList<JsonObject>?>() {}.type
+
+        val rawSearches: ArrayList<JsonObject> =
+            ConfigUtil.loadConfigWithTypeToken(listType, getFile(), Gson()) ?: return
+
+        recentSearches.clear()
+        for (recentSearch in rawSearches) {
+            val name = recentSearch["playername"].asString ?: continue
+            val stackObject = recentSearch["itemstack"].asJsonObject ?: continue
+            val stack = NotEnoughUpdates.INSTANCE.manager.jsonToStack(stackObject, false, false)
+            recentSearches.add(RecentSearch(name, stack))
+        }
+    }
+
+    fun saveRecentSearches() {
+        val rawSearches: ArrayList<JsonObject> = ArrayList()
+        for (recentSearch in recentSearches) {
+            // If the actual skull was never resolved, don't store it
+            if (recentSearch.playerHead == null) {
+                continue
+            }
+            val jsonObject = JsonObject()
+            jsonObject["playername"] = recentSearch.playername
+            val stackObject = NotEnoughUpdates.INSTANCE.manager.getJsonForItem(recentSearch.playerHead)
+            stackObject["internalname"] = "SKULL_ITEM"
+            jsonObject["itemstack"] = stackObject
+            rawSearches.add(jsonObject)
+        }
+
+        ConfigUtil.saveConfig(rawSearches, getFile(), Gson())
+    }
+
+    @SubscribeEvent
+    fun onCommands(event: RegisterBrigadierCommandEvent) {
+        event.command("neutestrecentsearchsaving") {
+            thenExecute {
+                saveRecentSearches()
+            }
+        }
+
+        event.command("neutestrecentsearchreading") {
+            thenExecute {
+                loadRecentSearches()
+            }
+        }
+    }
+
+    data class RecentSearch(val playername: String, val playerHead: ItemStack?)
+}


### PR DESCRIPTION
(Mostly) caused by requesting info about all recently searched players from Mojang.

This pr stores the recently searched itemnames and their associated itemskulls on disk to remove the need for mojang API requests.
<!--

Thank you for choosing to contribute to NEU!

Please make sure to give your PR a descriptive title.

Your PR title will be used in our changelog and should look like one of those:

Add fleebleblub menu
Fix crash in the gorp overlay
meta: Remove outdated documentation in CONTRIBUTING.md

Use the meta prefix for things that don't affect users and use Add, Fix, or Remove for the rest of your PR.

Do not end your PR title with a .

If your PR bundles two features, consider opening two PRs, one for each instead.

-->
