### PR TITLE
Fewer Ingredients

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/NEUEventListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/NEUEventListener.java
@@ -104,7 +104,6 @@ public class NEUEventListener {
 			return;
 		}
 
-		// TODO remove
 		if (neu.hasSkyblockScoreboard()) {
 			if (!preloadedItems) {
 				preloadedItems = true;

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/NEUEventListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/NEUEventListener.java
@@ -104,6 +104,7 @@ public class NEUEventListener {
 			return;
 		}
 
+		// TODO remove
 		if (neu.hasSkyblockScoreboard()) {
 			if (!preloadedItems) {
 				preloadedItems = true;

--- a/src/main/java/io/github/moulberry/notenoughupdates/recipes/CraftingRecipe.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/recipes/CraftingRecipe.java
@@ -149,7 +149,7 @@ public class CraftingRecipe implements NeuRecipe {
 			if (!recipe.has(name)) continue;
 			String item = recipe.get(name).getAsString();
 			if (item == null || item.isEmpty()) continue;
-			craftMatrix[i] = new Ingredient(manager, item);
+			craftMatrix[i] = Ingredient.ingredient(item);
 		}
 		int resultCount = 1;
 		if (recipe.has("count"))
@@ -162,6 +162,6 @@ public class CraftingRecipe implements NeuRecipe {
 		String outputItemId = outputItem.get("internalname").getAsString();
 		if (recipe.has("overrideOutputId"))
 			outputItemId = recipe.get("overrideOutputId").getAsString();
-		return new CraftingRecipe(manager, craftMatrix, new Ingredient(manager, outputItemId, resultCount), extra);
+		return new CraftingRecipe(manager, craftMatrix, Ingredient.ingredient(outputItemId, resultCount), extra);
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/recipes/EssenceUpgrades.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/recipes/EssenceUpgrades.java
@@ -138,7 +138,7 @@ public class EssenceUpgrades implements NeuRecipe {
 		JsonObject jsonObject = entry.getValue().getAsJsonObject();
 		Gson gson = new Gson();
 
-		Ingredient output = new Ingredient(manager, internalName);
+		Ingredient output = Ingredient.ingredient(internalName);
 
 		if (!jsonObject.has("type")) {
 			System.err.println("Invalid essence entry for: " + internalName);
@@ -278,10 +278,7 @@ public class EssenceUpgrades implements NeuRecipe {
 			for (Map.Entry<String, Integer> requiredItem : tierUpgrade.getItemsRequired().entrySet()) {
 				ItemStack itemStack;
 				if (requiredItem.getKey().equals("SKYBLOCK_COIN")) {
-					Ingredient ingredient = Ingredient.coinIngredient(
-						manager,
-						requiredItem.getValue()
-					);
+					Ingredient ingredient = Ingredient.coinIngredient(requiredItem.getValue());
 					itemStack = ingredient.getItemStack();
 				} else {
 					itemStack = manager.createItemResolutionQuery().withKnownInternalName(

--- a/src/main/java/io/github/moulberry/notenoughupdates/recipes/ForgeRecipe.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/recipes/ForgeRecipe.java
@@ -206,7 +206,7 @@ public class ForgeRecipe implements NeuRecipe {
 		List<Ingredient> ingredients = new ArrayList<>();
 		for (JsonElement element : recipe.getAsJsonArray("inputs")) {
 			String ingredientString = element.getAsString();
-			ingredients.add(new Ingredient(manager, ingredientString));
+			ingredients.add(Ingredient.ingredient(ingredientString));
 		}
 		String internalItemId = output.get("internalname").getAsString();
 		if (recipe.has("overrideOutputId"))
@@ -226,7 +226,7 @@ public class ForgeRecipe implements NeuRecipe {
 		return new ForgeRecipe(
 			manager,
 			ingredients,
-			new Ingredient(manager, internalItemId, resultCount),
+			Ingredient.ingredient(internalItemId, resultCount),
 			duration,
 			hotmLevel
 		);

--- a/src/main/java/io/github/moulberry/notenoughupdates/recipes/ItemShopRecipe.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/recipes/ItemShopRecipe.java
@@ -196,12 +196,12 @@ public class ItemShopRecipe implements NeuRecipe {
 
 	public static NeuRecipe parseItemRecipe(NEUManager neuManager, JsonObject recipe, JsonObject outputItemJson) {
 		return new ItemShopRecipe(
-			new Ingredient(neuManager, outputItemJson.get("internalname").getAsString()),
+			Ingredient.ingredient(outputItemJson.get("internalname").getAsString()),
 			JsonUtils.transformJsonArrayToList(
 				recipe.getAsJsonArray("cost"),
-				it -> new Ingredient(neuManager, it.getAsString())
+				it -> Ingredient.ingredient(it.getAsString())
 			),
-			new Ingredient(neuManager, recipe.get("result").getAsString()),
+			Ingredient.ingredient(recipe.get("result").getAsString()),
 			outputItemJson
 		);
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/recipes/MobLootRecipe.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/recipes/MobLootRecipe.java
@@ -329,7 +329,7 @@ public class MobLootRecipe implements NeuRecipe {
 	private static MobDrop parseMobDrop(NEUManager manager, JsonElement jsonElement) {
 		if (jsonElement.isJsonPrimitive()) {
 			return (new MobDrop(
-				new Ingredient(manager, jsonElement.getAsString()),
+				Ingredient.ingredient(jsonElement.getAsString()),
 				null,
 				Collections.emptyList(),
 				Collections.emptyList()
@@ -338,7 +338,7 @@ public class MobLootRecipe implements NeuRecipe {
 			JsonObject jsonObject = jsonElement.getAsJsonObject();
 			return (
 				new MobDrop(
-					new Ingredient(manager, jsonObject.get("id").getAsString()),
+					Ingredient.ingredient(jsonObject.get("id").getAsString()),
 					jsonObject.has("chance") ? jsonObject.get("chance").getAsString() : null,
 					JsonUtils.getJsonArrayOrEmpty(jsonObject, "extra", JsonElement::getAsString),
 					JsonUtils.getJsonArrayOrEmpty(jsonObject, "alternatives", element -> parseMobDrop(manager, element))
@@ -349,7 +349,7 @@ public class MobLootRecipe implements NeuRecipe {
 	public static MobLootRecipe parseRecipe(NEUManager manager, JsonObject recipe, JsonObject outputItemJson) {
 
 		return new MobLootRecipe(
-			new Ingredient(manager, outputItemJson.get("internalname").getAsString(), 1),
+			Ingredient.ingredient(outputItemJson.get("internalname").getAsString(), 1),
 			JsonUtils.getJsonArrayOrEmpty(recipe, "drops", element -> parseMobDrop(manager, element)),
 			recipe.has("level") ? recipe.get("level").getAsInt() : 0,
 			recipe.has("coins") ? recipe.get("coins").getAsInt() : 0,

--- a/src/main/java/io/github/moulberry/notenoughupdates/recipes/RecipeGenerator.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/recipes/RecipeGenerator.java
@@ -185,7 +185,7 @@ public class RecipeGenerator {
 						Utils.addChatMessage("[WARNING] Could not parse drop, ambiguous or missing item information: " + loreLine);
 						continue;
 					}
-					Ingredient item = new Ingredient(neu.manager, possibleItems.get(0).get("internalname").getAsString());
+					Ingredient item = Ingredient.ingredient(possibleItems.get(0).get("internalname").getAsString());
 					String chance = loreMatcher.group("dropChances") != null
 						? loreMatcher.group("dropChances")
 						: loreMatcher.group("dropCount");
@@ -196,7 +196,7 @@ public class RecipeGenerator {
 				}
 			}
 			recipes.add(new MobLootRecipe(
-				new Ingredient(neu.manager, internalMobName, 1),
+				Ingredient.ingredient(internalMobName, 1),
 				drops,
 				level,
 				coins,
@@ -277,9 +277,9 @@ public class RecipeGenerator {
 				int coinCost = Integer.parseInt(
 					name.substring(0, name.length() - COINS_SUFFIX.length())
 							.replace(",", ""));
-				ingredient = Ingredient.coinIngredient(neu.manager, coinCost);
+				ingredient = Ingredient.coinIngredient(coinCost);
 			} else if (internalId != null) {
-				ingredient = new Ingredient(neu.manager, internalId, itemStack.stackSize);
+				ingredient = Ingredient.ingredient(internalId, itemStack.stackSize);
 			}
 			if (ingredient == null) continue;
 			if (col < 4) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/recipes/VillagerTradeRecipe.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/recipes/VillagerTradeRecipe.java
@@ -172,8 +172,8 @@ public class VillagerTradeRecipe implements NeuRecipe {
 
 	public static VillagerTradeRecipe parseStaticRecipe(NEUManager manager, JsonObject recipe, JsonObject result) {
 		return new VillagerTradeRecipe(
-			new Ingredient(manager, recipe.get("result").getAsString()),
-			new Ingredient(manager, recipe.get("cost").getAsString()),
+			Ingredient.ingredient(recipe.get("result").getAsString()),
+			Ingredient.ingredient(recipe.get("cost").getAsString()),
 			recipe.has("min") ? recipe.get("min").getAsInt() : -1,
 			recipe.has("max") ? recipe.get("max").getAsInt() : -1
 		);

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/ItemUtils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/ItemUtils.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -54,6 +55,7 @@ import java.util.function.BiFunction;
 
 public class ItemUtils {
 	private static final Gson smallPrintingGson = new Gson();
+	private static final Map<Double, ItemStack> itemCache = new HashMap<>();
 
 	public static ItemStack createSkullItemStack(String displayName, String uuid, String skinAbsoluteUrl) {
 		JsonObject object = new JsonObject();
@@ -71,6 +73,10 @@ public class ItemUtils {
 	}
 
 	public static ItemStack getCoinItemStack(double coinAmount) {
+		return Utils.getOrPut(itemCache, coinAmount, () -> createCoinItemStack(coinAmount));
+	}
+
+	public static ItemStack createCoinItemStack(double coinAmount) {
 		String uuid = "2070f6cb-f5db-367a-acd0-64d39a7e5d1b";
 		String texture =
 			"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTM4MDcxNzIxY2M1YjRjZDQwNmNlNDMxYTEzZjg2MDgzYTg5NzNlMTA2NGQyZjg4OTc4Njk5MzBlZTZlNTIzNyJ9fX0=";
@@ -412,8 +418,11 @@ public class ItemUtils {
 					int maxLvl = 100;
 					if (Constants.PETS != null && Constants.PETS.has("custom_pet_leveling") &&
 						Constants.PETS.getAsJsonObject("custom_pet_leveling").has(pet.petType.toUpperCase(Locale.ROOT)) &&
-						Constants.PETS.getAsJsonObject("custom_pet_leveling").getAsJsonObject(pet.petType.toUpperCase(Locale.ROOT)).has(
-							"max_level")) {
+						Constants.PETS
+							.getAsJsonObject("custom_pet_leveling")
+							.getAsJsonObject(pet.petType.toUpperCase(Locale.ROOT))
+							.has(
+								"max_level")) {
 						maxLvl =
 							Constants.PETS
 								.getAsJsonObject("custom_pet_leveling")

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/ItemUtils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/ItemUtils.java
@@ -421,14 +421,12 @@ public class ItemUtils {
 						Constants.PETS
 							.getAsJsonObject("custom_pet_leveling")
 							.getAsJsonObject(pet.petType.toUpperCase(Locale.ROOT))
-							.has(
-								"max_level")) {
-						maxLvl =
-							Constants.PETS
-								.getAsJsonObject("custom_pet_leveling")
-								.getAsJsonObject(pet.petType.toUpperCase(Locale.ROOT))
-								.get("max_level")
-								.getAsInt();
+							.has("max_level")) {
+						maxLvl = Constants.PETS
+							.getAsJsonObject("custom_pet_leveling")
+							.getAsJsonObject(pet.petType.toUpperCase(Locale.ROOT))
+							.get("max_level")
+							.getAsInt();
 					}
 					for (int i = 0; i < lore.tagCount(); i++) {
 						if (i == lore.tagCount() - 2) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/TwoKeyCache.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/TwoKeyCache.java
@@ -1,0 +1,15 @@
+package io.github.moulberry.notenoughupdates.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class TwoKeyCache<K1, K2, V> {
+
+	private final Map<K1, Map<K2, V>> cache = new HashMap<>();
+
+	public V getOrPut(K1 key1, K2 key2, Supplier<V> valueSupplier) {
+		Map<K2, V> innerMap = Utils.getOrPut(cache, key1, HashMap::new);
+		return Utils.getOrPut(innerMap, key2, valueSupplier);
+	}
+}

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
@@ -99,8 +99,10 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -2419,5 +2421,14 @@ public class Utils {
 			renderText = lastSaveTime.format(DateTimeFormatter.ofPattern("dd-MM-yyyy"));
 		}
 		return renderText;
+	}
+
+	public static <K, V> V getOrPut(Map<K, V> map, K key, Supplier<V> defaultValueSupplier) {
+		V value = map.get(key);
+		if (value == null) {
+			value = defaultValueSupplier.get();
+			map.put(key, value);
+		}
+		return value;
 	}
 }

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/recipes/KatRecipe.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/recipes/KatRecipe.kt
@@ -58,7 +58,7 @@ data class KatRecipe(
     val levelSlider = GuiElementSlider(0, 0, 100, 1F, 100F, 1F, inputLevel.toFloat()) { inputLevel = it.toInt() }
     val coinsAdjustedForLevel: Int
         get() = (coins.toInt() * (1 - 0.003F * (getOutputPetForCurrentLevel()?.petLevel?.currentLevel ?: 0))).toInt()
-    private val basicIngredients = items.toSet() + setOf(inputPet, Ingredient.coinIngredient(manager, coins.toInt()))
+    private val basicIngredients = items.toSet() + setOf(inputPet, Ingredient.coinIngredient(coins.toInt()))
     override fun getIngredients(): Set<Ingredient> = basicIngredients
 
     override fun getOutputs(): Set<Ingredient> {
@@ -111,10 +111,7 @@ data class KatRecipe(
     override fun getSlots(): List<RecipeSlot> {
         val advancedIngredients = items.map { it.itemStack } + listOf(
             ItemUtils.createPetItemstackFromPetInfo(getInputPetForCurrentLevel()),
-            Ingredient.coinIngredient(
-                manager,
-                coinsAdjustedForLevel
-            ).itemStack
+            Ingredient.coinIngredient(coinsAdjustedForLevel).itemStack
         )
         return advancedIngredients.mapIndexed { index, itemStack ->
             val (x, y) = positionOnCircle(index, advancedIngredients.size)
@@ -148,9 +145,9 @@ data class KatRecipe(
         fun parseRecipe(manager: NEUManager, recipe: JsonObject, output: JsonObject): NeuRecipe {
             return KatRecipe(
                 manager,
-                Ingredient(manager, recipe["input"].asString),
-                Ingredient(manager, recipe["output"].asString),
-                recipe["items"]?.asJsonArray?.map { Ingredient(manager, it.asString) } ?: emptyList(),
+                Ingredient.ingredient(recipe["input"].asString),
+                Ingredient.ingredient(recipe["output"].asString),
+                recipe["items"]?.asJsonArray?.map { Ingredient.ingredient(it.asString) } ?: emptyList(),
                 recipe["coins"].asLong,
                 Duration.ofSeconds(recipe["time"].asLong)
             )

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/recipes/generators/ItemShopExporter.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/recipes/generators/ItemShopExporter.kt
@@ -106,7 +106,7 @@ class ItemShopExporter : RepoExporter {
             }
         }
         return ItemShopRecipe(
-            null, costList, Ingredient(context.manager, resultName, stack.stackSize.toDouble()), null
+            null, costList, Ingredient.ingredient(resultName, stack.stackSize.toDouble()), null
         )
     }
 
@@ -117,16 +117,16 @@ class ItemShopExporter : RepoExporter {
         val coinMatch = coinRegex.matchEntire(loreLine)
         if (coinMatch != null) {
             val amount = coinMatch.groupValues[1].replace(",", "").toInt()
-            return Ingredient.coinIngredient(context.manager, amount)
+            return Ingredient.coinIngredient(amount)
         }
         val itemMatch = itemRegex.matchEntire(loreLine)
         if (itemMatch != null) {
             val label = itemMatch.groups["name"]!!.value
             val amount = itemMatch.groups["amount"]?.value?.replace(",", "")?.toDouble() ?: 1.0
             if (context.manager.itemInformation.containsKey(label.uppercase())) {
-                return Ingredient(context.manager, label, amount)
+                Ingredient.ingredient(label, amount)
             }
-            return Ingredient(context.manager, context.findItemByName(label), amount)
+            Ingredient.ingredient(context.findItemByName(label), amount)
         }
         return null
     }


### PR DESCRIPTION
I have created the utils function `getOrPut` and utils class `TwoKeyCache`.
With those, I have reduced the amount of duplicate ingredient objects creation.
This should reduce memory consumption by a tiny bit.

<details>
<summary>Comparison</summary>
before:

![image](https://github.com/hannibal002/NotEnoughUpdates/assets/24389977/24192f83-4b16-4ed5-843d-98876ba29702)

after:

![image](https://github.com/hannibal002/NotEnoughUpdates/assets/24389977/8604d604-8007-4952-a974-8271fb87aee2)

</details>

Also added a cache for getCoinItemStack()