### PR TITLE
Add /neucheck command & check for enchant parsers

### DIFF
--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/dev/CheckCommand.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/dev/CheckCommand.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 NotEnoughUpdates contributors
+ *
+ * This file is part of NotEnoughUpdates.
+ *
+ * NotEnoughUpdates is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * NotEnoughUpdates is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.moulberry.notenoughupdates.commands.dev
+
+import io.github.moulberry.notenoughupdates.autosubscribe.NEUAutoSubscribe
+import io.github.moulberry.notenoughupdates.events.RegisterBrigadierCommandEvent
+import io.github.moulberry.notenoughupdates.miscfeatures.checks.EnchantsCheck
+import io.github.moulberry.notenoughupdates.util.brigadier.reply
+import io.github.moulberry.notenoughupdates.util.brigadier.thenLiteralExecute
+import io.github.moulberry.notenoughupdates.util.brigadier.withHelp
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@NEUAutoSubscribe
+class CheckCommand {
+
+    @SubscribeEvent
+    fun onCommands(event: RegisterBrigadierCommandEvent) {
+        event.command("neucheck") {
+            thenLiteralExecute("neuec") {
+                val check = EnchantsCheck()
+                val replies = check.getMessages()
+                replies.forEach { r ->
+                    reply(r)
+                }
+            }.withHelp("Checks for /neuec incompatibilities")
+        }
+    }
+}

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/checks/EnchantsCheck.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/checks/EnchantsCheck.kt
@@ -22,8 +22,8 @@ package io.github.moulberry.notenoughupdates.miscfeatures.checks
 import net.minecraft.event.ClickEvent
 import net.minecraft.event.HoverEvent
 import net.minecraft.util.ChatComponentText
-import net.minecraft.util.IChatComponent
 import net.minecraft.util.EnumChatFormatting.*
+import net.minecraft.util.IChatComponent
 import net.minecraftforge.fml.common.Loader
 
 class EnchantsCheck {
@@ -39,27 +39,33 @@ class EnchantsCheck {
             "${LIGHT_PURPLE}Enchant Parsing${YELLOW} -> ${RED}${BOLD}DISABLE"
     private val dsmHelp = "${LIGHT_PURPLE}/dsm${YELLOW} -> ${LIGHT_PURPLE}General${YELLOW} -> " +
             "${LIGHT_PURPLE}Golden ... Enchantments${YELLOW} -> ${RED}${BOLD}DISABLE"
-    private val sbeHelp = "${LIGHT_PURPLE}/sbe${YELLOW} -> ${LIGHT_PURPLE}Color Enchants${YELLOW} -> ${RED}${BOLD}DISABLE"
+    private val sbeHelp =
+        "${LIGHT_PURPLE}/sbe${YELLOW} -> ${LIGHT_PURPLE}Color Enchants${YELLOW} -> ${RED}${BOLD}DISABLE"
 
-    fun getMessages() : List<IChatComponent> {
-        val messages =  mutableListOf<IChatComponent>()
-        if(Loader.isModLoaded("skyblockaddons")) messages.add(modMessage(sbaMsg, sbaHelp, "/sba"))
-        if(Loader.isModLoaded("skyhanni")) messages.add(modMessage(shMsg, shHelp, "/sh enchant parsing"))
-        if(Loader.isModLoaded("Danker's Skyblock Mod")) messages.add(modMessage(dsmMsg, dsmHelp, "/dsm"))
-        if(Loader.isModLoaded("SkyblockExtras")) messages.add(modMessage(sbeMsg, sbeHelp, "/sbe"))
-        if(messages.isNotEmpty()) {
-            messages.addAll(listOf(
-                ChatComponentText(""),
-                ChatComponentText("${YELLOW}One or more mods conflicting with /neuec found!"),
-                ChatComponentText("${LIGHT_PURPLE}Hover${YELLOW} over the above messages to check the solutions."),
-                ChatComponentText("${LIGHT_PURPLE}Click${YELLOW} on the above messages to run the command mentioned.")))
+    fun getMessages(): List<IChatComponent> {
+        val messages = mutableListOf<IChatComponent>()
+        if (Loader.isModLoaded("skyblockaddons")) messages.add(modMessage(sbaMsg, sbaHelp, "/sba"))
+        if (Loader.isModLoaded("skyhanni")) messages.add(modMessage(shMsg, shHelp, "/sh enchant parsing"))
+        if (Loader.isModLoaded("Danker's Skyblock Mod")) messages.add(modMessage(dsmMsg, dsmHelp, "/dsm"))
+        if (Loader.isModLoaded("SkyblockExtras")) messages.add(modMessage(sbeMsg, sbeHelp, "/sbe"))
+        if (messages.isNotEmpty()) {
+            messages.addAll(
+                listOf(
+                    ChatComponentText(""),
+                    ChatComponentText("${YELLOW}One or more mods conflicting with /neuec found!"),
+                    ChatComponentText("${LIGHT_PURPLE}Hover${YELLOW} over the above messages to check the solutions."),
+                    ChatComponentText("${LIGHT_PURPLE}Click${YELLOW} on the above messages to run the command mentioned.")
+                )
+            )
         } else {
             val discordHover = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${BLUE}discord.gg/moulberry"))
             val discordClick = ClickEvent(ClickEvent.Action.OPEN_URL, "https://discord.gg/moulberry")
-            messages.addAll(listOf(
-                ChatComponentText("${GREEN}Your enchant colors should not be overriden by any mods!"),
-                ChatComponentText("${YELLOW}If any of your mods override them, please let us know on ${BLUE}NEU Discord")
-                    .also { it.chatStyle.setChatHoverEvent(discordHover).setChatClickEvent(discordClick) }))
+            messages.addAll(
+                listOf(
+                    ChatComponentText("${GREEN}Your enchant colors should not be overriden by any mods!"),
+                    ChatComponentText("${YELLOW}If any of your mods override them, please let us know on ${BLUE}NEU Discord")
+                        .also { it.chatStyle.setChatHoverEvent(discordHover).setChatClickEvent(discordClick) })
+            )
         }
         return messages
     }

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/checks/EnchantsCheck.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/checks/EnchantsCheck.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2024 NotEnoughUpdates contributors
+ *
+ * This file is part of NotEnoughUpdates.
+ *
+ * NotEnoughUpdates is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * NotEnoughUpdates is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NotEnoughUpdates. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.moulberry.notenoughupdates.miscfeatures.checks
+
+import net.minecraft.event.ClickEvent
+import net.minecraft.event.HoverEvent
+import net.minecraft.util.ChatComponentText
+import net.minecraft.util.IChatComponent
+import net.minecraft.util.EnumChatFormatting.*
+
+class EnchantsCheck {
+
+    private val sbaCheck = "codes.biscuit.skyblockaddons.SkyblockAddons"
+    private val shCheck = "at.hannibal2.skyhanni.SkyHanniMod"
+    private val dsmCheck = "me.Danker.DankersSkyblockMod"
+
+    private val sbaMsg = "SkyblockAddons is installed and might break NEU enchants!"
+    private val shMsg = "SkyHanni is installed and might break NEU enchants!"
+    private val dsmMsg = "DSM is installed and might break NEU enchants!"
+
+    private val sbaHelp = "${LIGHT_PURPLE}/sba${YELLOW} -> ${LIGHT_PURPLE}Parse Enchant Tooltips${YELLOW} -> " +
+            "${LIGHT_PURPLE}Second Page${YELLOW} -> ${LIGHT_PURPLE}Highlight Special Enchantments${YELLOW} -> ${RED}${BOLD}DISABLE"
+    private val shHelp = "${LIGHT_PURPLE}/sh enchant parsing${YELLOW} -> ${LIGHT_PURPLE}Inventory${YELLOW} -> " +
+            "${LIGHT_PURPLE}Enchant Parsing${YELLOW} -> ${RED}${BOLD}DISABLE"
+    private val dsmHelp = "${LIGHT_PURPLE}/dsm${YELLOW} -> ${LIGHT_PURPLE}General${YELLOW} -> " +
+            "${LIGHT_PURPLE}Golden ... Enchantments${YELLOW} -> ${RED}${BOLD}DISABLE"
+
+    fun getMessages() : List<IChatComponent> {
+        val messages =  mutableListOf<IChatComponent>()
+        if(isModInstalled(sbaCheck)) messages.add(modMessage(sbaMsg, sbaHelp, "/sba"))
+        if(isModInstalled(shCheck)) messages.add(modMessage(shMsg, shHelp, "/sh enchant parsing"))
+        if(isModInstalled(dsmCheck)) messages.add(modMessage(dsmMsg, dsmHelp, "/dsm"))
+        if(messages.isNotEmpty()) {
+            messages.addAll(listOf(
+                ChatComponentText(""),
+                ChatComponentText("${YELLOW}One or more mods conflicting with /neuec found!"),
+                ChatComponentText("${LIGHT_PURPLE}Hover${YELLOW} over the above messages to check the solutions."),
+                ChatComponentText("${LIGHT_PURPLE}Click${YELLOW} on the above messages to run the command mentioned.")))
+        } else {
+            val discordHover = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${BLUE}discord.gg/moulberry"))
+            val discordClick = ClickEvent(ClickEvent.Action.OPEN_URL, "https://discord.gg/moulberry")
+            messages.addAll(listOf(
+                ChatComponentText("${GREEN}Your enchant colors should not be overriden by any mods!"),
+                ChatComponentText("${YELLOW}If any of your mods override them, please let us know on ${BLUE}NEU Discord")
+                    .also { it.chatStyle.setChatHoverEvent(discordHover).setChatClickEvent(discordClick) }))
+        }
+        return messages
+    }
+
+    private fun isModInstalled(clazz: String): Boolean {
+        try {
+            Class.forName(clazz)
+        } catch (e: ClassNotFoundException) {
+            return false
+        }
+        return true
+    }
+
+    private fun modMessage(msg: String, help: String, cmd: String): IChatComponent {
+        val mainComponent = ChatComponentText("$RED$msg")
+        val hoverComponent = ChatComponentText(help)
+
+        val hoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, hoverComponent)
+        val clickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, cmd)
+        mainComponent.chatStyle.setChatHoverEvent(hoverEvent).setChatClickEvent(clickEvent)
+
+        return mainComponent
+    }
+}

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/checks/EnchantsCheck.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/checks/EnchantsCheck.kt
@@ -24,16 +24,14 @@ import net.minecraft.event.HoverEvent
 import net.minecraft.util.ChatComponentText
 import net.minecraft.util.IChatComponent
 import net.minecraft.util.EnumChatFormatting.*
+import net.minecraftforge.fml.common.Loader
 
 class EnchantsCheck {
-
-    private val sbaCheck = "codes.biscuit.skyblockaddons.SkyblockAddons"
-    private val shCheck = "at.hannibal2.skyhanni.SkyHanniMod"
-    private val dsmCheck = "me.Danker.DankersSkyblockMod"
 
     private val sbaMsg = "SkyblockAddons is installed and might break NEU enchants!"
     private val shMsg = "SkyHanni is installed and might break NEU enchants!"
     private val dsmMsg = "DSM is installed and might break NEU enchants!"
+    private val sbeMsg = "SBE is installed and might break NEU enchants!"
 
     private val sbaHelp = "${LIGHT_PURPLE}/sba${YELLOW} -> ${LIGHT_PURPLE}Parse Enchant Tooltips${YELLOW} -> " +
             "${LIGHT_PURPLE}Second Page${YELLOW} -> ${LIGHT_PURPLE}Highlight Special Enchantments${YELLOW} -> ${RED}${BOLD}DISABLE"
@@ -41,12 +39,14 @@ class EnchantsCheck {
             "${LIGHT_PURPLE}Enchant Parsing${YELLOW} -> ${RED}${BOLD}DISABLE"
     private val dsmHelp = "${LIGHT_PURPLE}/dsm${YELLOW} -> ${LIGHT_PURPLE}General${YELLOW} -> " +
             "${LIGHT_PURPLE}Golden ... Enchantments${YELLOW} -> ${RED}${BOLD}DISABLE"
+    private val sbeHelp = "${LIGHT_PURPLE}/sbe${YELLOW} -> ${LIGHT_PURPLE}Color Enchants${YELLOW} -> ${RED}${BOLD}DISABLE"
 
     fun getMessages() : List<IChatComponent> {
         val messages =  mutableListOf<IChatComponent>()
-        if(isModInstalled(sbaCheck)) messages.add(modMessage(sbaMsg, sbaHelp, "/sba"))
-        if(isModInstalled(shCheck)) messages.add(modMessage(shMsg, shHelp, "/sh enchant parsing"))
-        if(isModInstalled(dsmCheck)) messages.add(modMessage(dsmMsg, dsmHelp, "/dsm"))
+        if(Loader.isModLoaded("skyblockaddons")) messages.add(modMessage(sbaMsg, sbaHelp, "/sba"))
+        if(Loader.isModLoaded("skyhanni")) messages.add(modMessage(shMsg, shHelp, "/sh enchant parsing"))
+        if(Loader.isModLoaded("Danker's Skyblock Mod")) messages.add(modMessage(dsmMsg, dsmHelp, "/dsm"))
+        if(Loader.isModLoaded("SkyblockExtras")) messages.add(modMessage(sbeMsg, sbeHelp, "/sbe"))
         if(messages.isNotEmpty()) {
             messages.addAll(listOf(
                 ChatComponentText(""),
@@ -62,15 +62,6 @@ class EnchantsCheck {
                     .also { it.chatStyle.setChatHoverEvent(discordHover).setChatClickEvent(discordClick) }))
         }
         return messages
-    }
-
-    private fun isModInstalled(clazz: String): Boolean {
-        try {
-            Class.forName(clazz)
-        } catch (e: ClassNotFoundException) {
-            return false
-        }
-        return true
     }
 
     private fun modMessage(msg: String, help: String, cmd: String): IChatComponent {


### PR DESCRIPTION
Adds an **/neucheck** command boilerplate so we can notify user about incompatibilities with other mods. It mainly servers to reduce headaches in neu-support (we need jani to keep his sanity).
Also already implements **/neucheck neuec** that returns which mods are loaded and how to disable the enchant parsing in them.

This can be obviously modified to check for the actual setting if parsing is enabled & set it to the correct value.
But i am bad at kotlin reflections and I will have close to no free time next week so just wanted to push this out...

![obrazek](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/70163122/7fbe1467-367a-4068-bef2-a8099835cefb)
![obrazek](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/70163122/0f58f7b1-ddf3-4f50-95bb-d5a103268aa0)