### PR TITLE
Fix filter chat level hiding your own messages

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/ChatListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/ChatListener.java
@@ -284,7 +284,9 @@ public class ChatListener {
 		if (LvlMatcher.matches()) {
 			if (Integer.parseInt(LvlMatcher.group(1)) < NotEnoughUpdates.INSTANCE.config.misc.filterChatLevel &&
 				NotEnoughUpdates.INSTANCE.config.misc.filterChatLevel != 0) {
-				e.setCanceled(true);
+				if (!unformatted.contains(Minecraft.getMinecraft().thePlayer.getName())) {
+					e.setCanceled(true);
+				}
 			}
 		}
 


### PR DESCRIPTION
stopped filter chat messages by level hiding your own messages if below that level.
also allows all messages mentioning the player through as hypixel plays a sound anyway so may as well include them
