### PR TITLE
Fix Dwarven Overlay showing incorrect rows if spacing between Commissions and Powder is disabled

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
@@ -395,7 +395,7 @@ public class MiningOverlay extends TextTabOverlay {
 								commissionProgress.put(split[0], progress);
 							} catch (Exception ignored) {
 							}
-						} else {
+						} else if (split[1].endsWith("DONE")) {
 							commissionProgress.put(split[0], 1.0f);
 						}
 					}

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/tablisttutorial/TablistAPI.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/tablisttutorial/TablistAPI.kt
@@ -57,8 +57,10 @@ object TablistAPI {
             }
 
             if (list.isNotEmpty()) {
-                // Empty line, the widget ends here.
-                if (entry == "§r") {
+                // Empty line
+                // Or there is no spacing between two widgets
+                // The widget ends here.
+                if (entry == "§r" || entry.startsWith("§r§")) {
                     break
                 }
 


### PR DESCRIPTION
Closes https://github.com/NotEnoughUpdates/NotEnoughUpdates/issues/1143