### PR TITLE
meta: Fix /neupronouns output to condense to a single line

### DIFF
--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/misc/MiscCommands.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/commands/misc/MiscCommands.kt
@@ -153,9 +153,7 @@ class MiscCommands {
             nc.printChatMessageWithOptionalDeletion(
                 ChatComponentText("§e[NEU] Pronouns for §b$user §eon §b$platform§e:"), id
             )
-            betterPronounChoice.render().forEach {
-                nc.printChatMessage(ChatComponentText("§e[NEU] §a$it"))
-            }
+            nc.printChatMessage(ChatComponentText("§e[NEU] §a${betterPronounChoice.render()}"))
             null
         }, MinecraftExecutor.OffThread)
 


### PR DESCRIPTION
Currently, running `/neupronouns <user>` will display the following output:
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/117035030/2db5b1cd-b86a-494e-a163-53483443f544)

This implementation is... fine. It gets the job done, albeit in an unorthodox way. The issue with having every character be proceeded by a newline is that if you use a mod/client that condenses chat messages, such as Patcher, the output can look confusing to downright illegible.
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/117035030/89d95a40-b0fb-412c-b06c-e7daabd6e051)
Instead, a much more logical solution would be to place the pronouns on a single chat message, fixing the compacted chat issue and saving some brainpower from piecing together each character.
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/117035030/926a881c-5ce2-4b73-9d07-a33f19b628ca)

