### PR TITLE
Add more customization to Etherwarp Display

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomItemEffects.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomItemEffects.java
@@ -868,23 +868,23 @@ public class CustomItemEffects {
 					Minecraft.getMinecraft().theWorld,
 					etherwarpRaycast.pos
 				);
-				String color;
-				if (denyTpReason != null && NotEnoughUpdates.INSTANCE.config.itemOverlays.changeEtherwarpColorWhenFailed) {
-					color = NotEnoughUpdates.INSTANCE.config.itemOverlays.etherwarpFailHighlightColour;
-				} else color = NotEnoughUpdates.INSTANCE.config.itemOverlays.etherwarpHighlightColour;
+				String colour;
+				if (denyTpReason != null && NotEnoughUpdates.INSTANCE.config.itemOverlays.changeEtherwarpColourWhenFailed) {
+					colour = NotEnoughUpdates.INSTANCE.config.itemOverlays.etherwarpFailHighlightColour;
+				} else colour = NotEnoughUpdates.INSTANCE.config.itemOverlays.etherwarpHighlightColour;
 
 				AxisAlignedBB bb = box.expand(0.01D, 0.01D, 0.01D).offset(-d0, -d1, -d2);
 				drawFilledBoundingBox(
 					bb,
 					1f,
-					color
+					colour
 				);
 
 				GlStateManager.disableDepth();
 				drawOutlineBoundingBox(
 					bb,
 					2f,
-					color
+					colour
 				);
 				GlStateManager.enableDepth();
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomItemEffects.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomItemEffects.java
@@ -333,7 +333,7 @@ public class CustomItemEffects {
 				}
 
 				if (NotEnoughUpdates.INSTANCE.config.itemOverlays.enableEtherwarpHelperOverlay) {
-					if (denyTpReason != null) {
+					if (denyTpReason != null && !NotEnoughUpdates.INSTANCE.config.itemOverlays.hideEtherwarpFailText) {
 						ScaledResolution scaledResolution = new ScaledResolution(Minecraft.getMinecraft());
 						Utils.drawStringCentered(EnumChatFormatting.RED + "Can't TP: " + denyTpReason,
 							Minecraft.getMinecraft().fontRendererObj,
@@ -868,18 +868,23 @@ public class CustomItemEffects {
 					Minecraft.getMinecraft().theWorld,
 					etherwarpRaycast.pos
 				);
+				String color;
+				if (denyTpReason != null && NotEnoughUpdates.INSTANCE.config.itemOverlays.changeEtherwarpColorWhenFailed) {
+					color = NotEnoughUpdates.INSTANCE.config.itemOverlays.etherwarpFailHighlightColour;
+				} else color = NotEnoughUpdates.INSTANCE.config.itemOverlays.etherwarpHighlightColour;
+
 				AxisAlignedBB bb = box.expand(0.01D, 0.01D, 0.01D).offset(-d0, -d1, -d2);
 				drawFilledBoundingBox(
 					bb,
 					1f,
-					NotEnoughUpdates.INSTANCE.config.itemOverlays.etherwarpHighlightColour
+					color
 				);
 
 				GlStateManager.disableDepth();
 				drawOutlineBoundingBox(
 					bb,
 					2f,
-					NotEnoughUpdates.INSTANCE.config.itemOverlays.etherwarpHighlightColour
+					color
 				);
 				GlStateManager.enableDepth();
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/ItemOverlays.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/ItemOverlays.java
@@ -243,12 +243,39 @@ public class ItemOverlays {
 
 	@Expose
 	@ConfigOption(
+		name = "Hide fail text",
+		desc = "Dont display the text saying you can't TP to the block"
+	)
+	@ConfigEditorBoolean
+	@ConfigAccordionId(id = 4)
+	public boolean hideEtherwarpFailText = false;
+
+	@Expose
+	@ConfigOption(
+		name = "Change color when fail",
+		desc = "Show a different color when you can't TP to the block"
+	)
+	@ConfigEditorBoolean
+	@ConfigAccordionId(id = 4)
+	public boolean changeEtherwarpColorWhenFailed = false;
+
+	@Expose
+	@ConfigOption(
 		name = "Highlight Colour",
 		desc = "Change the colour of the etherwarp target block outline"
 	)
 	@ConfigEditorColour
 	@ConfigAccordionId(id = 4)
 	public String etherwarpHighlightColour = "00:70:156:8:96";
+
+	@Expose
+	@ConfigOption(
+		name = "Fail Highlight Color",
+		desc = "Change the color of the etherwarp target block outline when you can't TP to that block"
+	)
+	@ConfigEditorColour
+	@ConfigAccordionId(id = 4)
+	public String etherwarpFailHighlightColour = "00:70:220:40:40";
 
 	@ConfigOption(
 		name = "Bonemerang Overlay",

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/ItemOverlays.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/ItemOverlays.java
@@ -252,12 +252,12 @@ public class ItemOverlays {
 
 	@Expose
 	@ConfigOption(
-		name = "Change color when fail",
-		desc = "Show a different color when you can't TP to the block"
+		name = "Change colour when fail",
+		desc = "Show a different colour when you can't TP to the block"
 	)
 	@ConfigEditorBoolean
 	@ConfigAccordionId(id = 4)
-	public boolean changeEtherwarpColorWhenFailed = false;
+	public boolean changeEtherwarpColourWhenFailed = false;
 
 	@Expose
 	@ConfigOption(
@@ -270,8 +270,8 @@ public class ItemOverlays {
 
 	@Expose
 	@ConfigOption(
-		name = "Fail Highlight Color",
-		desc = "Change the color of the etherwarp target block outline when you can't TP to that block"
+		name = "Fail Highlight Colour",
+		desc = "Change the colour of the etherwarp target block outline when you can't TP to that block"
 	)
 	@ConfigEditorColour
 	@ConfigAccordionId(id = 4)


### PR DESCRIPTION
Adds options to hide the deny tp reason text, and also one to choose a different color for when you cant tp to the block