### PR TITLE
meta: Fix modrinth action being stupid

### DIFF
--- a/.github/workflows/push-to-modrinth.yaml
+++ b/.github/workflows/push-to-modrinth.yaml
@@ -13,6 +13,7 @@ jobs:
           regex: true
           file: ".*\\.jar"
           token: ${{ secrets.GITHUB_TOKEN }}
+          target: .
       - run: |
           printf %s "$CHANGELOG" > CHANGELOG.md
         env:


### PR DESCRIPTION
" i found out that we also need to set the target: . in the modrinth file downloading action, otherwise it downloads to a folder named after the regex:
https://github.com/dsaltares/fetch-gh-release-asset/blob/aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7/index.ts#L157
https://github.com/dsaltares/fetch-gh-release-asset/blob/aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7/index.ts#L141" ~ nea