### PR TITLE
Fix crafting text being too small when the text is long

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/recipes/CraftingRecipe.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/recipes/CraftingRecipe.java
@@ -37,8 +37,8 @@ public class CraftingRecipe implements NeuRecipe {
 	public static final ResourceLocation BACKGROUND = new ResourceLocation("notenoughupdates",
 		"textures/gui/crafting_table_tall.png");
 
-	private static final int EXTRA_STRING_X = 132;
-	private static final int EXTRA_STRING_Y = 50;
+	private static final int EXTRA_STRING_X = 90;
+	private static final int EXTRA_STRING_Y = 35;
 
 	private final NEUManager manager;
 	private final Ingredient[] inputs;
@@ -116,7 +116,7 @@ public class CraftingRecipe implements NeuRecipe {
 		String craftingText = getCraftText();
 		if (craftingText != null)
 			Utils.drawStringCenteredScaledMaxWidth(craftingText,
-				gui.guiLeft + EXTRA_STRING_X, gui.guiTop + EXTRA_STRING_Y, false, 75, 0x404040
+				gui.guiLeft + EXTRA_STRING_X, gui.guiTop + EXTRA_STRING_Y, false, 85, 0x404040
 			);
 	}
 


### PR DESCRIPTION
The title is just for the action, this pr just moves the crafttext
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/69345714/135f018f-5bfe-4328-ae5a-c701f38c56fe)
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/69345714/30457039-6119-4117-b9d7-3565a9dd701a)

