### PR TITLE
Add gemstone stats

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/ItemTooltipListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/ItemTooltipListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2024 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -51,7 +51,6 @@ import org.lwjgl.input.Keyboard;
 import java.awt.*;
 import java.awt.datatransfer.StringSelection;
 import java.text.DecimalFormat;
-import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -63,17 +62,37 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ItemTooltipListener {
-	public static final String petToolTipRegex =
-		"((Farming)|(Combat)|(Fishing)|(Mining)|(Foraging)|(Enchanting)|(Alchemy)) ((Mount)|(Pet)|(Morph)).*";
+	public static final Pattern petToolTipRegex =
+		Pattern.compile(
+			"((Farming)|(Combat)|(Fishing)|(Mining)|(Foraging)|(Enchanting)|(Alchemy)) ((Mount)|(Pet)|(Morph)).*");
+	public final Pattern gemstoneRegex =
+		Pattern.compile(
+			"(ROUGH|FLAWED|FINE|FLAWLESS|PERFECT)_(RUBY|AMBER|SAPPHIRE|JADE|AMETHYST|TOPAZ|JASPER|OPAL|AQUAMARINE|CITRINE|ONYX|PERIDOT)_GEM");
 	private final NotEnoughUpdates neu;
 	private final Pattern xpLevelPattern = Pattern.compile("(.*) (\\xA7e(.*)\\xA76/\\xA7e(.*))");
 	private final HashSet<String> percentStats = new HashSet<>();
 	DecimalFormat myFormatter = new DecimalFormat("#,###,###.###");
 	private String currentRarity = "COMMON";
+	private String currentGemstoneRarity = "COMMON";
 	private boolean copied = false;
 	private boolean showReforgeStoneStats = true;
+	private boolean showGemstoneStats = true;
 	private boolean pressedArrowLast = false;
 	private boolean pressedShiftLast = false;
+	private final HashMap<String, Integer> chiselBonusPercentage = new HashMap<String, Integer>() {{
+		put("ROUGH", 30);
+		put("FLAWED", 40);
+		put("FINE", 50);
+		put("FLAWLESS", 60);
+		put("PERFECT", 100);
+	}};
+	private final HashMap<String, Integer> gemstoneRemoveCosts = new HashMap<String, Integer>() {{
+		put("ROUGH", 1);
+		put("FLAWED", 100);
+		put("FINE", 10_000);
+		put("FLAWLESS", 100_000);
+		put("PERFECT", 500_000);
+	}};
 
 	public ItemTooltipListener(NotEnoughUpdates neu) {
 		this.neu = neu;
@@ -247,7 +266,7 @@ public class ItemTooltipListener {
 							newTooltip.add("");
 						}
 
-						newTooltip.add(EnumChatFormatting.BLUE + "Stats for " + rarityFormatted + "§9: [§l§m< §9Switch§l➡§9]");
+						newTooltip.add(EnumChatFormatting.BLUE + "Stats for " + rarityFormatted + "§9: [§l§m< §9Switch§l§m >§9]");
 
 						if (statsE != null && statsE.isJsonObject()) {
 							JsonObject stats = statsE.getAsJsonObject();
@@ -305,7 +324,96 @@ public class ItemTooltipListener {
 
 					continue;
 				}
+			} else if (gemstoneRegex.matcher(internalName).matches() &&
+				NotEnoughUpdates.INSTANCE.config.tooltipTweaks.showGemstoneStats) {
+				String[] splitInternal = internalName.split("_");
+				String gemstoneTier = splitInternal[0];
+				String gemstoneType = splitInternal[1];
 
+				JsonObject gemstones = Constants.GEMSTONES;
+				if (gemstones != null && gemstones.has(gemstoneType) &&
+					gemstones.getAsJsonObject(gemstoneType).getAsJsonObject("stats").has(gemstoneTier)) {
+					int lineToInject = event.toolTip.get(1).contains("Collection Item") ? 3 : 1;
+
+					if (k == lineToInject) {
+						boolean shift = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
+						if (!pressedShiftLast && shift) {
+							showGemstoneStats = !showGemstoneStats;
+						}
+						pressedShiftLast = shift;
+
+						if (!showGemstoneStats) {
+							newTooltip.add(EnumChatFormatting.DARK_GRAY + "[Press SHIFT to show extra info]");
+						} else {
+							newTooltip.add(EnumChatFormatting.DARK_GRAY + "[Press SHIFT to hide extra info]");
+						}
+
+						JsonObject gemstoneInfo = gemstones.getAsJsonObject(gemstoneType);
+						JsonObject statNums = gemstoneInfo.getAsJsonObject("stats").getAsJsonObject(gemstoneTier);
+
+						List<Map.Entry<String, JsonElement>> validRarities = new ArrayList<>(statNums.entrySet());
+						int rarityIndex = validRarities.size() - 1;
+						String rarity = validRarities.get(rarityIndex).getKey();
+						for (int i = 0; i < validRarities.size(); i++) {
+							String rar = validRarities.get(i).getKey();
+							if (rar.equalsIgnoreCase(currentGemstoneRarity)) {
+								rarity = rar;
+								rarityIndex = i;
+								break;
+							}
+						}
+
+						if (showGemstoneStats) {
+							boolean left = Keyboard.isKeyDown(Keyboard.KEY_LEFT);
+							boolean right = Keyboard.isKeyDown(Keyboard.KEY_RIGHT);
+							if (!pressedArrowLast && (left || right)) {
+								if (left) {
+									rarityIndex--;
+								} else {
+									rarityIndex++;
+								}
+								if (rarityIndex < 0) rarityIndex = 0;
+								if (rarityIndex >= validRarities.size()) rarityIndex = validRarities.size() - 1;
+								currentGemstoneRarity = validRarities.get(rarityIndex).getKey();
+								rarity = currentGemstoneRarity;
+							}
+							pressedArrowLast = left || right;
+
+							String rarityFormatted = Utils.rarityArrMap.getOrDefault(rarity, rarity);
+							String statName = gemstoneInfo.get("statName").getAsString();
+							double statNum = validRarities.get(rarityIndex).getValue().getAsDouble();
+
+							String formattedStatNum = "";
+							if (statNum == 0) formattedStatNum = "???";
+							else if (statNum % 1 == 0) formattedStatNum += Math.round(statNum);
+							else formattedStatNum += statNum;
+
+							if (gemstoneInfo.has("chiselBonus")) {
+								String chiselBonus = gemstoneInfo.get("chiselBonus").getAsString();
+								String formattedChiselBonus = chiselBonus.replace(
+									"{}",
+									chiselBonusPercentage.get(gemstoneTier).toString()
+								);
+
+								newTooltip.add("");
+								String text = EnumChatFormatting.BLUE + "Chisel bonus: " + formattedChiselBonus;
+								boolean first = true;
+								for (String s : Minecraft.getMinecraft().fontRendererObj.listFormattedStringToWidth(text, 150)) {
+									newTooltip.add((first ? "" : "  ") + s);
+									first = false;
+								}
+								newTooltip.add("");
+							}
+							newTooltip.add("§9Stats for " + rarityFormatted + "§9: [§l§m< §9Switch§l§m >§9]");
+							newTooltip.add("  §7" + statName + ": §a+" + formattedStatNum);
+							newTooltip.add("");
+							newTooltip.add(
+								"§9Removal Cost: §6" + StringUtils.formatNumber(gemstoneRemoveCosts.get(gemstoneTier)) + " coins");
+							newTooltip.add("§8Combinable in Gemstone Grinder or The Hex");
+							newTooltip.add("");
+						}
+					}
+				}
 			} else if (line.contains("\u00A7cR\u00A76a\u00A7ei\u00A7an\u00A7bb\u00A79o\u00A7dw\u00A79 Rune")) {
 				line = line.replace(
 					"\u00A7cR\u00A76a\u00A7ei\u00A7an\u00A7bb\u00A79o\u00A7dw\u00A79 Rune",
@@ -549,7 +657,7 @@ public class ItemTooltipListener {
 		//7 is just a random number i chose, prob no pets with less lines than 7
 		if (event.toolTip.size() < 7) return;
 		if (event.itemStack.getTagCompound().hasKey("NEUHIDEPETTOOLTIP")) return;
-		if (Utils.cleanColour(event.toolTip.get(1)).matches(petToolTipRegex)) {
+		if (petToolTipRegex.matcher(Utils.cleanColour(event.toolTip.get(1))).matches()) {
 			PetLeveling.PetLevel petLevel;
 
 			int xpLine = -1;
@@ -578,7 +686,8 @@ public class ItemTooltipListener {
 
 			event.toolTip.add(
 				xpLine + 1,
-				EnumChatFormatting.GRAY + "EXP: " + EnumChatFormatting.YELLOW + myFormatter.format(petLevel.getExpInCurrentLevel()) +
+				EnumChatFormatting.GRAY + "EXP: " + EnumChatFormatting.YELLOW +
+					myFormatter.format(petLevel.getExpInCurrentLevel()) +
 					EnumChatFormatting.GOLD + "/" + EnumChatFormatting.YELLOW +
 					myFormatter.format(petLevel.getExpRequiredForNextLevel())
 			);

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/TooltipTweaks.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/TooltipTweaks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2024 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -79,7 +79,8 @@ public class TooltipTweaks {
 			"\u00a7eInsta-Buys (Daily)",
 			"\u00a7eInsta-Sells (Daily)",
 			"\u00a7eInsta-Buys (Weekly)",
-			"\u00a7eInsta-Sells (Weekly)"}
+			"\u00a7eInsta-Sells (Weekly)"
+		}
 	)
 	@ConfigAccordionId(id = 0)
 	public List<Integer> priceInfoBaz = new ArrayList<>(Arrays.asList(0, 1, 2, 3, 4));
@@ -170,6 +171,14 @@ public class TooltipTweaks {
 
 	@Expose
 	@ConfigOption(
+		name = "Show gemstone stats",
+		desc = "Show statistics a gemstone will apply"
+	)
+	@ConfigEditorBoolean
+	public boolean showGemstoneStats = true;
+
+	@Expose
+	@ConfigOption(
 		name = "Hide default reforge stats",
 		desc = "Hides the reforge stats only for Legendary items that Hypixel adds to the Reforge stones"
 	)
@@ -209,7 +218,6 @@ public class TooltipTweaks {
 	)
 	@ConfigEditorBoolean
 	public boolean scrollableTooltips = false;
-
 
 	@Expose
 	@ConfigOption(
@@ -329,7 +337,6 @@ public class TooltipTweaks {
 	@ConfigEditorBoolean
 	@ConfigAccordionId(id = 2)
 	public boolean copperCoins = true;
-
 
 	@Expose
 	@ConfigOption(

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/Constants.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2024 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -86,6 +86,7 @@ public class Constants {
 	public static JsonObject BESTIARY;
 	public static JsonObject SACKS;
 	public static JsonObject HOPPITY;
+	public static JsonObject GEMSTONES;
 
 	private static final ReentrantLock lock = new ReentrantLock();
 
@@ -115,6 +116,7 @@ public class Constants {
 			BESTIARY = Utils.getConstant("bestiary", gson);
 			SACKS = Utils.getConstant("sacks", gson);
 			HOPPITY = Utils.getConstant("hoppity", gson);
+			GEMSTONES = Utils.getConstant("gemstones", gson);
 
 			parseEssenceCosts();
 		} catch (Exception ex) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/ItemUtils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/ItemUtils.java
@@ -396,7 +396,7 @@ public class ItemUtils {
 			NBTTagCompound display = tag.getCompoundTag("display");
 			if (display.hasKey("Lore", 9)) {
 				NBTTagList lore = display.getTagList("Lore", 8);
-				if (Utils.cleanColour(lore.getStringTagAt(0)).matches(ItemTooltipListener.petToolTipRegex) &&
+				if (ItemTooltipListener.petToolTipRegex.matcher(lore.getStringTagAt(0)).matches() &&
 					lore.tagCount() > 7) {
 
 					PetLeveling.PetLevel petLevel;
@@ -412,8 +412,11 @@ public class ItemUtils {
 					int maxLvl = 100;
 					if (Constants.PETS != null && Constants.PETS.has("custom_pet_leveling") &&
 						Constants.PETS.getAsJsonObject("custom_pet_leveling").has(pet.petType.toUpperCase(Locale.ROOT)) &&
-						Constants.PETS.getAsJsonObject("custom_pet_leveling").getAsJsonObject(pet.petType.toUpperCase(Locale.ROOT)).has(
-							"max_level")) {
+						Constants.PETS
+							.getAsJsonObject("custom_pet_leveling")
+							.getAsJsonObject(pet.petType.toUpperCase(Locale.ROOT))
+							.has(
+								"max_level")) {
 						maxLvl =
 							Constants.PETS
 								.getAsJsonObject("custom_pet_leveling")


### PR DESCRIPTION
Adds a feature similar to reforge stone stats that shows the user what bonuses does the gemstone give
![vijpZlJ](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/70163122/f763d185-8492-4c5f-b857-8a88141970d2)

Also depends on https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/pull/1247 for the constants file to exist
