### PR TITLE
Add english locale to event countdowns

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/CalendarOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/CalendarOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2024 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -1699,11 +1699,16 @@ public class CalendarOverlay {
 	}
 
 	private List<String> addCountdownCalculatorToTooltip(long millis, List<String> tooltipToModify) {
-		if (NotEnoughUpdates.INSTANCE.config.misc.showWhenCountdownEnds == 1 || NotEnoughUpdates.INSTANCE.config.misc.showWhenCountdownEnds == 2) {
+		if (NotEnoughUpdates.INSTANCE.config.misc.showWhenCountdownEnds == 1 ||
+			NotEnoughUpdates.INSTANCE.config.misc.showWhenCountdownEnds == 2) {
 			String formatString = "EEEE, MMM d h:mm a";
-			if (NotEnoughUpdates.INSTANCE.config.misc.showWhenCountdownEnds == 2) { formatString = "EEEE, MMM d HH:mm"; }
-			tooltipToModify.add("§b" + DateTimeFormatter.ofPattern(formatString).format(ZonedDateTime.now().plusSeconds(((millis / 1000)))));
-
+			if (NotEnoughUpdates.INSTANCE.config.misc.showWhenCountdownEnds == 2) {
+				formatString = "EEEE, MMM d HH:mm";
+			}
+			DateTimeFormatter useFormatter = DateTimeFormatter.ofPattern(formatString);
+			if (NotEnoughUpdates.INSTANCE.config.misc.useEnglishCountdown)
+				useFormatter = useFormatter.withLocale(Locale.ENGLISH);
+			tooltipToModify.add("§b" + useFormatter.format(ZonedDateTime.now().plusSeconds(((millis / 1000)))));
 		}
 		return tooltipToModify;
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/Misc.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/Misc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2024 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -363,6 +363,14 @@ public class Misc {
 		values = {"Off", "AM/PM [1PM]", "24hr [13:00]"}
 	)
 	public int showWhenCountdownEnds = 1;
+
+	@Expose
+	@ConfigOption(
+		name = "Use english countdown",
+		desc = "Uses english language for countdown instead of your system's selected one"
+	)
+	@ConfigEditorBoolean
+	public boolean useEnglishCountdown = false;
 
 	@Expose
 	@ConfigOption(

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/CountdownCalculator.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/CountdownCalculator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 NotEnoughUpdates contributors
+ * Copyright (C) 2022-2024 NotEnoughUpdates contributors
  *
  * This file is part of NotEnoughUpdates.
  *
@@ -25,6 +25,7 @@ import net.minecraftforge.event.entity.player.ItemTooltipEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import java.util.*
 
 /*
    CountdownCalculator.kt
@@ -62,7 +63,10 @@ class CountdownCalculator {
         TIMELEFT("Time left:", "Ends at"),
         EVENTTIMELEFT("Event lasts for", "Ends at", isRelative = true),
         SHENSUCKS("Auction ends in:", "Auction ends at"),
-        TAMINGSIXTYWASAMISTAKE("Ends:", "Finishes at"), // There would be a more specific message here seeing as this is for pet XP, but knowing Hypixel it's probably safer to leave it like this in case they use the "Ends:" prefix elsewhere besides the pet training menus.
+        TAMINGSIXTYWASAMISTAKE(
+            "Ends:",
+            "Finishes at"
+        ), // There would be a more specific message here seeing as this is for pet XP, but knowing Hypixel it's probably safer to leave it like this in case they use the "Ends:" prefix elsewhere besides the pet training menus.
         CALENDARDETAILS(" (§e", "Starts at"), // calendar details
         COMMUNITYPROJECTSSUCK("Contribute again", "Come back at"), // nopo i just woke up i really hope this works
         CHOCOLATEFACTORY("Next Charge", "Available at");
@@ -88,10 +92,11 @@ class CountdownCalculator {
                 val hours = match.groups["hours"]?.value?.toLong() ?: 0L
                 val minutes = match.groups["minutes"]?.value?.toLong() ?: 0L
                 val seconds = match.groups["seconds"]?.value?.toLong() ?: 0L
-                val totalSeconds = (years * 31_536_000L) + (days * 86_400L) + (hours * 3_600L) + (minutes * 60L) + seconds
+                val totalSeconds =
+                    (years * 31_536_000L) + (days * 86_400L) + (hours * 3_600L) + (minutes * 60L) + seconds
                 if (totalSeconds == 0L) continue
                 if (years != 0L) formatterAsString = "${formatterAsString} yyyy"
-                val useFormatter = DateTimeFormatter.ofPattern(formatterAsString)!!
+                var useFormatter = DateTimeFormatter.ofPattern(formatterAsString)!!
                 val countdownTarget = if (countdownKind.isRelative) {
                     if (lastTimer == null) {
                         event.toolTip.add(
@@ -101,6 +106,9 @@ class CountdownCalculator {
                         continue
                     } else lastTimer.addTime(years, days, hours, minutes, seconds)
                 } else ZonedDateTime.now().addTime(years, days, hours, minutes, seconds)
+                if (NotEnoughUpdates.INSTANCE.config.misc.useEnglishCountdown) useFormatter = useFormatter.withLocale(
+                    Locale.ENGLISH
+                )
                 val countdownTargetFormatted = useFormatter.format(countdownTarget)
                 event.toolTip.add(
                     ++i,
@@ -111,7 +119,13 @@ class CountdownCalculator {
         }
     }
 
-    private fun ZonedDateTime.addTime(years: Long, days: Long, hours: Long, minutes: Long, seconds: Long): ZonedDateTime {
+    private fun ZonedDateTime.addTime(
+        years: Long,
+        days: Long,
+        hours: Long,
+        minutes: Long,
+        seconds: Long
+    ): ZonedDateTime {
         return this.plusYears(years).plusDays(days).plusHours(hours).plusMinutes(minutes).plusSeconds(seconds)
     }
 }


### PR DESCRIPTION
Adds a setting disabled by default that forces the locale of the datetime string to be in english as requested by numerous members from the discord.
