### PR TITLE
Fix Jacob's Contest Estimate giving incorrect values when the score number is cut off

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/FarmingSkillOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/FarmingSkillOverlay.java
@@ -146,10 +146,13 @@ public class FarmingSkillOverlay extends TextOverlay {
 			for (String line : SidebarUtil.readSidebarLines()) {
 				val matcher = CONTEST_AMOUNT_PATTERN.matcher(line);
 				if (matcher.matches()) {
-					String amount = matcher.group("amount").replace(",", "");
+					String amount = matcher.group("amount");
+					// account for when the scoreboard line is too long and last digit or two are cut off
+					int lastComma = amount.lastIndexOf(',');
+					int extraZeros = lastComma != -1 ? 4 + lastComma - amount.length() : 0;
 					try {
 						inJacobContest = true;
-						cropsFarmed = Integer.parseInt(amount);
+						cropsFarmed = Integer.parseInt(amount.replace(",", "")) * (int) Math.pow(10, extraZeros);
 					} catch (NumberFormatException e) {
 						e.printStackTrace();
 					}


### PR DESCRIPTION
Bug:
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/65848142/85e1c067-79b4-415f-8c1e-9cee8da83404)
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/65848142/ce6bb52c-2da2-4aed-8644-a48e09fc589d)

Fix:
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/65848142/8423828f-e2c4-46a9-a04b-f2d3193a0985)
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates/assets/65848142/9b8cf264-26d6-4380-9cd0-d342c043028d)

