### PR TITLE
Fix goblin holdout typo in MiningOverlay

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
@@ -647,7 +647,7 @@ public class MiningOverlay extends TextTabOverlay {
 			if (name.equals("Hard Stone Miner")) return "Break 1,000 Hard Stone";
 
 			String jungle = " §a(Jungle)";
-			String goblin = " §6(Golbin Holdout)";
+			String goblin = " §6(Goblin Holdout)";
 			String mithril = " §b(Mithril Deposits)";
 			String precursor = " §8(Precursor Remenants)";
 			String magma = " §c(Magma Fields)";


### PR DESCRIPTION
Fixes a typo in the mining overlay
Fixes issue [#1294](https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/issues/1294)