### PR TITLE
Fix performance when NEU deals with item stacks

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUManager.java
@@ -1507,7 +1507,7 @@ public class NEUManager {
 	}
 
 	public ItemStack jsonToStack(JsonObject json, boolean useCache) {
-		return jsonToStack(json, useCache, true);
+		return jsonToStack(json, useCache, false);
 	}
 
 	public ItemStack jsonToStack(JsonObject json, boolean useCache, boolean useReplacements) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -2270,7 +2270,7 @@ public class NEUOverlay extends Gui {
 		JsonObject json = tooltipToDisplay.get();
 		if (json != null) {
 
-			ItemStack stack = manager.jsonToStack(json);
+			ItemStack stack = manager.jsonToStack(json, false, true);
 			{
 				NBTTagCompound tag = stack.getTagCompound();
 				tag.setBoolean("DisablePetExp", true);

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -568,7 +568,7 @@ public class NEUOverlay extends Gui {
 
 					extraScale = 1.3f;
 				} else if (manager.getItemInformation().containsKey(display)) {
-					render = manager.jsonToStack(manager.getItemInformation().get(display), true, true);
+					render = manager.jsonToStack(manager.getItemInformation().get(display), true, false);
 				} else {
 					Item item = Item.itemRegistry.getObject(new ResourceLocation(display.toLowerCase(Locale.ROOT)));
 					if (item != null) {
@@ -2443,10 +2443,15 @@ public class NEUOverlay extends Gui {
 				if (json == null) {
 					return;
 				}
-				ItemStack stack = manager.jsonToStack(json, true, true, false);
-				if (stack == null || !stack.hasEffect()) {
-					return;
+				boolean hasEnch = false;
+				if (json.has("nbttag")) {
+					String jsonString = json.get("nbttag").getAsJsonPrimitive().getAsString();
+					// scuffed way of doing it but improves performance significantly over the old method
+					if (jsonString.contains("ench:[") || jsonString.contains("CustomPotionEffects:[")) {
+							hasEnch = true;
+					}
 				}
+				if (!hasEnch) return;
 
 				GlStateManager.pushMatrix();
 				GlStateManager.enableRescaleNormal();
@@ -2601,7 +2606,7 @@ public class NEUOverlay extends Gui {
 					renderEntity(x + ITEM_SIZE / 2, y + ITEM_SIZE, scale, name, entities);
 				} else {
 					if (!items) return;
-					ItemStack stack = manager.jsonToStack(json, true, true, false);
+					ItemStack stack = manager.jsonToStack(json, true, false, false);
 					if (stack != null) {
 						if (glint) {
 							Utils.drawItemStack(stack, x, y);

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/NEUEventListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/NEUEventListener.java
@@ -117,7 +117,7 @@ public class NEUEventListener {
 				List<JsonObject> list = new ArrayList<>(neu.manager.getItemInformation().values());
 				for (JsonObject json : list) {
 					itemPreloader.submit(() -> {
-						ItemStack stack = neu.manager.jsonToStack(json, true, true);
+						ItemStack stack = neu.manager.jsonToStack(json, true, false);
 						if (stack.getItem() == Items.skull) toPreload.add(stack);
 					});
 				}

--- a/src/main/java/io/github/moulberry/notenoughupdates/recipes/Ingredient.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/recipes/Ingredient.java
@@ -96,7 +96,7 @@ public class Ingredient {
 			return ItemUtils.getCoinItemStack(count);
 		}
 		JsonObject itemInfo = manager.getItemInformation().get(internalItemId);
-		itemStack = manager.jsonToStack(itemInfo);
+		itemStack = manager.jsonToStack(itemInfo, false, true);
 		itemStack.stackSize = (int) count;
 		return itemStack;
 	}


### PR DESCRIPTION
Before the jsonToStack cache was disabled in 99% of uses

Both after ~10 seconds in the item list
Before
![image](https://github.com/user-attachments/assets/e6ea6428-d28b-4934-b5c2-41d94b374a4d)
After
![image](https://github.com/user-attachments/assets/84c2becf-55a6-4d5d-a427-972fb78ee94d)


Also changes the enchant glint stuff in the item list not to use jsonToStack