### PR TITLE
meta: Make the calender disable itself automatically

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
@@ -309,8 +309,6 @@ public class RenderListener {
 		}
 	}
 
-	boolean storageTurnedOffTheCalendar = false;
-
 	/**
 	 * Sets hoverInv and focusInv variables, representing whether the NEUOverlay should render behind the inventory when
 	 * (hoverInv == true) and whether mouse/kbd inputs shouldn't be sent to NEUOverlay (focusInv == true).
@@ -427,14 +425,10 @@ public class RenderListener {
 		boolean storageOverlayActive = StorageManager.getInstance().shouldRenderStorageOverlay(containerName);
 
 		if (storageOverlayActive) {
-			storageTurnedOffTheCalendar = true;
-			CalendarOverlay.ableToClickCalendar = false;
+			CalendarOverlay.suppressCalendarClicks();
 			StorageOverlay.getInstance().render();
 			event.setCanceled(true);
 			return;
-		} else if (storageTurnedOffTheCalendar) {
-			CalendarOverlay.ableToClickCalendar = true;
-			storageTurnedOffTheCalendar = false;
 		}
 
 		if (tradeWindowActive) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
@@ -425,7 +425,6 @@ public class RenderListener {
 		boolean storageOverlayActive = StorageManager.getInstance().shouldRenderStorageOverlay(containerName);
 
 		if (storageOverlayActive) {
-			CalendarOverlay.suppressCalendarClicks();
 			StorageOverlay.getInstance().render();
 			event.setCanceled(true);
 			return;

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/CalendarOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/CalendarOverlay.java
@@ -91,7 +91,9 @@ public class CalendarOverlay {
 
 	private static boolean enabled = false;
 
-	public static boolean ableToClickCalendar = true;
+	private static boolean ableToClickCalendar = true;
+	private boolean isTimerRendered = false;
+
 	long thunderStormEpoch = 1692826500000L;
 	long oringoEpoch = 1583153700000L;
 	long oringoInterval = 223200000L;
@@ -126,6 +128,10 @@ public class CalendarOverlay {
 	List<Tuple<Long, SBEvent>> specialEvents = new ArrayList<>();
 
 	private boolean drawTimerForeground = false;
+
+	public static void suppressCalendarClicks() {
+		ableToClickCalendar = true;
+	}
 
 	private static long spookyStart = 0;
 
@@ -691,7 +697,6 @@ public class CalendarOverlay {
 
 		//Daily Events
 		int index = 0;
-		out:
 		for (Map.Entry<Long, Set<SBEvent>> sbEvents : eventMap.entrySet()) {
 			for (SBEvent sbEvent : sbEvents.getValue()) {
 				long timeUntilMillis = sbEvents.getKey() - currentTime;
@@ -1020,7 +1025,7 @@ public class CalendarOverlay {
 
 				guiLeft = (width - xSize) / 2;
 				guiTop = 5;
-				if (mouseX >= guiLeft && mouseX <= guiLeft + xSize && ableToClickCalendar) {
+				if (mouseX >= guiLeft && mouseX <= guiLeft + xSize && isTimerRendered) {
 					if (mouseY >= guiTop && mouseY <= guiTop + ySize) {
 						ClientCommandHandler.instance.executeCommand(Minecraft.getMinecraft().thePlayer, "/neucalendar");
 					}
@@ -1375,6 +1380,7 @@ public class CalendarOverlay {
 
 	@SubscribeEvent
 	public void onGuiScreenDrawTimer(GuiScreenEvent.DrawScreenEvent.Post event) {
+		isTimerRendered = false;
 		if (drawTimerForeground) {
 			drawTimer();
 		}
@@ -1466,6 +1472,7 @@ public class CalendarOverlay {
 				boolean toastRendered = renderToast(nextEvent, timeUntilNext);
 				GlStateManager.translate(0, 0, -50);
 				if (!toastRendered && !enabled && NotEnoughUpdates.INSTANCE.config.calendar.showEventTimerInInventory) {
+					isTimerRendered = true;
 					List<String> tooltipToDisplay = null;
 					FontRenderer fr = Minecraft.getMinecraft().fontRendererObj;
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/CalendarOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/CalendarOverlay.java
@@ -91,7 +91,6 @@ public class CalendarOverlay {
 
 	private static boolean enabled = false;
 
-	private static boolean ableToClickCalendar = true;
 	private boolean isTimerRendered = false;
 
 	long thunderStormEpoch = 1692826500000L;
@@ -128,10 +127,6 @@ public class CalendarOverlay {
 	List<Tuple<Long, SBEvent>> specialEvents = new ArrayList<>();
 
 	private boolean drawTimerForeground = false;
-
-	public static void suppressCalendarClicks() {
-		ableToClickCalendar = true;
-	}
 
 	private static long spookyStart = 0;
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/hex/GuiCustomHex.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/hex/GuiCustomHex.java
@@ -252,13 +252,7 @@ public class GuiCustomHex extends Gui {
 		return INSTANCE;
 	}
 
-	boolean hexTurnedOffTheCalendar = false;
-
 	public boolean shouldOverride(String containerName) {
-		if (hexTurnedOffTheCalendar) {
-			CalendarOverlay.ableToClickCalendar = true;
-			hexTurnedOffTheCalendar = false;
-		}
 		if (containerName == null) {
 			shouldOverrideET = false;
 			shouldOverrideFast = false;
@@ -313,9 +307,8 @@ public class GuiCustomHex extends Gui {
 		ItemStack hexStack = cc.getLowerChestInventory().getStackInSlot(50);
 		ItemStack bookStack = cc.getLowerChestInventory().getStackInSlot(32);
 		boolean shouldDisableCalendar = !(shouldOverrideET || shouldOverrideFast || shouldOverrideGemstones || shouldOverrideXp);
-		if (!shouldDisableCalendar && CalendarOverlay.ableToClickCalendar) {
-			CalendarOverlay.ableToClickCalendar = false;
-			hexTurnedOffTheCalendar = true;
+		if (!shouldDisableCalendar) {
+			CalendarOverlay.suppressCalendarClicks();
 		}
 		if (bookStack != null && bookStack.getItem() == Items.book) {
 			shouldOverrideGemstones = false;

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/hex/GuiCustomHex.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/hex/GuiCustomHex.java
@@ -306,10 +306,6 @@ public class GuiCustomHex extends Gui {
 		ContainerChest cc = (ContainerChest) chest.inventorySlots;
 		ItemStack hexStack = cc.getLowerChestInventory().getStackInSlot(50);
 		ItemStack bookStack = cc.getLowerChestInventory().getStackInSlot(32);
-		boolean shouldDisableCalendar = !(shouldOverrideET || shouldOverrideFast || shouldOverrideGemstones || shouldOverrideXp);
-		if (!shouldDisableCalendar) {
-			CalendarOverlay.suppressCalendarClicks();
-		}
 		if (bookStack != null && bookStack.getItem() == Items.book) {
 			shouldOverrideGemstones = false;
 		}


### PR DESCRIPTION
closes #1213 
However, instead of adding an event or similar it seemed easier to just check if the timer in the inventory was actually being rendered before allowing any clicks. 

The only time it needs to be disabled is in custom GUIs, in which case the timer does not even get rendered in the first place.
<!--

Thank you for choosing to contribute to NEU!

Please make sure to give your PR a descriptive title.

Your PR title will be used in our changelog and should look like one of those:

Add fleebleblub menu
Fix crash in the gorp overlay
meta: Remove outdated documentation in CONTRIBUTING.md

Use the meta prefix for things that don't affect users and use Add, Fix, or Remove for the rest of your PR.

Do not end your PR title with a .

If your PR bundles two features, consider opening two PRs, one for each instead.

-->
