### PR TITLE
meta: Remove PR name prefix enforcement for meta PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,9 +8,11 @@ Your PR title will be used in our changelog and should look like one of those:
 
 Add fleebleblub menu
 Fix crash in the gorp overlay
-meta: Remove outdated documentation in CONTRIBUTING.md
+Remove Herobrine
+meta: Make documentation clearer
 
-Use the meta prefix for things that don't affect users and use Add, Fix, or Remove for the rest of your PR.
+Use Add, Fix, or Remove at the start of your PR name.
+If the change doesn't affect end-users, start your PR name with `meta:`, in which case the naming conventions above do not apply.
 
 Do not end your PR title with a .
 

--- a/.github/workflows/enforce-pr-name.yml
+++ b/.github/workflows/enforce-pr-name.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
-          regex: '(?:(?:meta:)|(?:Add|Fix|Remove)) .+[^\.]'
+          regex: '(?:meta:|Add|Fix|Remove) .+[^\.]'
           prefix_case_sensitive: true
           github_token: ${{ github.token }}

--- a/.github/workflows/enforce-pr-name.yml
+++ b/.github/workflows/enforce-pr-name.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
-          regex: '(meta: )?(Add|Fix|Remove) .+[^\\.]'
+          regex: '(?:(?:meta:)|(?:Add|Fix|Remove)) .+[^\.]'
           prefix_case_sensitive: true
           github_token: ${{ github.token }}


### PR DESCRIPTION
Makes it no longer necessary to use Add/Fix/Remove in meta PR names