### PR TITLE
Fix Dungeon Win Overlay not working in Master Mode The Catacombs

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/dungeons/DungeonWin.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/dungeons/DungeonWin.java
@@ -228,7 +228,7 @@ public class DungeonWin {
 					seenDungeonWinOverlayThisRun = true;
 				} else {
 					if (unformatted.trim().length() > 0 && !seenDungeonWinOverlayThisRun) {
-						if (unformatted.contains("The Catacombs") || unformatted.contains("Master Mode Catacombs") ||
+						if (unformatted.contains("The Catacombs") || unformatted.contains("Master Mode The Catacombs") ||
 							unformatted.contains("Team Score") || unformatted.contains("Defeated") || unformatted.contains(
 							"Total Damage")
 							|| unformatted.contains("Ally Healing") || unformatted.contains("Enemies Killed") || unformatted.contains(


### PR DESCRIPTION
<!--

Thank you for choosing to contribute to NEU!

Please make sure to give your PR a descriptive title.

Your PR title will be used in our changelog and should look like one of those:

Add fleebleblub menu
Fix crash in the gorp overlay
Remove Herobrine
meta: Make documentation clearer

Use Add, Fix, or Remove at the start of your PR name.
If the change doesn't affect end-users, start your PR name with `meta:`, in which case the naming conventions above do not apply.

Do not end your PR title with a .

If your PR bundles two features, consider opening two PRs, one for each instead.

-->
