### PR TITLE
meta: fix Missing Hat for armor set matching

### DIFF
--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/util/MuseumUtil.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/util/MuseumUtil.kt
@@ -104,6 +104,7 @@ object MuseumUtil {
             "TROUSERS",
             "TUNIC",
             "SLIPPERS",
+            "HAT",
         )
         val monochromeName = NEUManager.cleanForTitleMapSearch(displayName)
         val results = ItemResolutionQuery.findInternalNameCandidatesForDisplayName(displayName)


### PR DESCRIPTION
## Description

Fixes Party Set missing one piece.
> `PARTY` Set includes the following items `['PARTY_HAT', 'PARTY_NECKLACE', 'PARTY_CLOAK', 'PARTY_BELT', 'PARTY_GLOVES']`