### PR TITLE
meta: edit mode improvements

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUManager.java
@@ -312,7 +312,7 @@ public class NEUManager {
 	 * loreWordMap. These maps are used in the searching algorithm.
 	 */
 	public void loadItem(String internalName) {
-		itemstackCache.remove(internalName);
+		removeItemFromCache(internalName);
 		try {
 			JsonObject json = getJsonFromFile(getItemFileForInternalName(internalName));
 			if (json == null) {
@@ -1689,5 +1689,10 @@ public class NEUManager {
 
 		displayNameCache.put(internalName, displayName);
 		return displayName;
+	}
+
+	public void removeItemFromCache(String internalName) {
+		itemstackCache.remove(internalName);
+		displayNameCache.remove(internalName);
 	}
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -40,6 +40,7 @@ import io.github.moulberry.notenoughupdates.miscfeatures.SunTzu;
 import io.github.moulberry.notenoughupdates.miscgui.NeuSearchCalculator;
 import io.github.moulberry.notenoughupdates.miscgui.itemcustomization.GuiItemCustomize;
 import io.github.moulberry.notenoughupdates.miscgui.pricegraph.GuiPriceGraph;
+import io.github.moulberry.notenoughupdates.options.separatesections.ApiData;
 import io.github.moulberry.notenoughupdates.recipes.CraftingRecipe;
 import io.github.moulberry.notenoughupdates.util.Calculator;
 import io.github.moulberry.notenoughupdates.util.Constants;
@@ -1156,12 +1157,21 @@ public class NEUOverlay extends Gui {
 					Utils.pushGuiScale(-1);
 				}
 				if (internalname.get() != null) {
+					ApiData apiData = NotEnoughUpdates.INSTANCE.config.apiData;
 					if (itemstack.get() != null) {
-						if (NotEnoughUpdates.INSTANCE.config.apiData.repositoryEditing && Keyboard.getEventCharacter() == 'k') {
+						if (apiData.repositoryEditing && Keyboard.getEventKey() == apiData.repositoryEditingKeybind) {
 							Minecraft.getMinecraft().displayGuiScreen(new NEUItemEditor(
 								internalname.get(),
 								manager.getJsonForItem(itemstack.get())
 							));
+							return true;
+						}
+						if (apiData.repositoryEditing && Keyboard.getEventKey() == apiData.instantEditKeybind) {
+							if (NEUItemEditor.saveOnly(internalname.get(), manager.getJsonForItem(itemstack.get()))) {
+								Utils.addChatMessage("§aSaved " + internalname.get() + " to repository.");
+							} else {
+								Utils.addChatMessage("§cFailed to save " + internalname.get() + " to repository.");
+							}
 							return true;
 						}
 					}
@@ -1184,7 +1194,7 @@ public class NEUOverlay extends Gui {
 								Minecraft.getMinecraft().thePlayer.inventory.addItemStackToInventory(
 									manager.jsonToStack(item));
 							}
-						} else if (NotEnoughUpdates.INSTANCE.config.apiData.repositoryEditing &&
+						} else if (apiData.repositoryEditing &&
 							keyPressed == Keyboard.KEY_K) {
 							if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)) {
 								var externalEditorCommand = NotEnoughUpdates.INSTANCE.config.hidden.externalEditor;

--- a/src/main/java/io/github/moulberry/notenoughupdates/itemeditor/NEUItemEditor.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/itemeditor/NEUItemEditor.java
@@ -234,6 +234,7 @@ public class NEUItemEditor extends GuiScreen {
 		if (infoA.length == 0 || infoA[0].isEmpty()) {
 			infoA = new String[0];
 		}
+		NotEnoughUpdates.INSTANCE.manager.removeItemFromCache(internalName.get());
 		return NotEnoughUpdates.INSTANCE.manager.writeItemJson(
 			item,
 			internalName.get(),

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/ApiData.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/ApiData.java
@@ -24,8 +24,10 @@ import io.github.moulberry.moulconfig.annotations.ConfigAccordionId;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorAccordion;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorButton;
+import io.github.moulberry.moulconfig.annotations.ConfigEditorKeybind;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorText;
 import io.github.moulberry.moulconfig.annotations.ConfigOption;
+import org.lwjgl.input.Keyboard;
 
 public class ApiData {
 
@@ -109,6 +111,24 @@ public class ApiData {
 	)
 	@ConfigEditorBoolean
 	public boolean repositoryEditing = false;
+
+	@Expose
+	@ConfigAccordionId(id = 0)
+	@ConfigOption(
+		name = "Edit Mode Keybind",
+		desc = "Keybind to open the item editor GUI"
+	)
+	@ConfigEditorKeybind(defaultKey = Keyboard.KEY_K)
+	public int repositoryEditingKeybind = Keyboard.KEY_K;
+
+	@Expose
+	@ConfigAccordionId(id = 0)
+	@ConfigOption(
+		name = "Instant Edit Keybind",
+		desc = "Edits the item without opening the GUI"
+	)
+	@ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
+	public int instantEditKeybind = Keyboard.KEY_NONE;
 
 	@Expose
 	@ConfigOption(


### PR DESCRIPTION
closes #1318 

- add keybind option to editing item
- add keybind to edit item without opening gui
- remove item from cache when the item is saved so it updates in the item list