### PR TITLE
Fix stack overrides for the search overlays

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
@@ -602,6 +602,9 @@ public class NEUConfig extends Config {
 		@Expose
 		public String externalEditor = null;
 
+		@Expose
+		public boolean disableClientSideSearch = false;
+
 	}
 
 	public static ArrayList<String> createDefaultEnchantColours() {

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/AHTweaks.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/AHTweaks.java
@@ -36,7 +36,7 @@ public class AHTweaks {
 
 	@Expose
 	@ConfigOption(
-		name = "Enable Search GUI",
+		name = "Enable Auction Search GUI",
 		desc = "Use the advanced search GUI with autocomplete and history instead of the normal sign GUI\n\u00a7eStar Selection Texture: Johnny#4567"
 	)
 	@ConfigEditorBoolean

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/BazaarTweaks.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/BazaarTweaks.java
@@ -37,7 +37,7 @@ public class BazaarTweaks {
 
 		@Expose
 		@ConfigOption(
-			name = "Enable Search GUI",
+			name = "Enable Bazaar Search GUI",
 			desc = "Use the advanced search GUI with autocomplete and history instead of the normal sign GUI"
 		)
 		@ConfigEditorBoolean

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/RecipeTweaks.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/RecipeTweaks.java
@@ -37,12 +37,22 @@ public class RecipeTweaks {
 
 	@Expose
 	@ConfigOption(
-		name = "Enable Search GUI",
-		desc = "Use the advanced search GUI with autocomplete and history instead of the normal sign GUI"
+		name = "Add Button in /recipes",
+		desc = "Replaces the sign gui with an advanced search GUI for recipes\n" +
+		"You can also use /recipe to open the GUI"
 	)
 	@ConfigEditorBoolean
 	@ConfigAccordionId(id = 0)
 	public boolean enableSearchOverlay = true;
+
+	@Expose
+	@ConfigOption(
+		name = "Add Button In Crafting Table",
+		desc = "Adds a button in /craft to open the recipe search overlay"
+	)
+	@ConfigEditorBoolean
+	@ConfigAccordionId(id = 0)
+	public boolean addPickaxeStack = true;
 
 	@Expose
 	@ConfigOption(

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/AuctionSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/AuctionSearchOverlay.java
@@ -97,6 +97,8 @@ public class AuctionSearchOverlay extends SearchOverlayScreen {
 	@SubscribeEvent
 	public void onSlotClick(SlotClickEvent event) {
 		if (!enableSearchOverlay()) return;
+		if (NotEnoughUpdates.INSTANCE.config.hidden.disableClientSideSearch) return;
+		if (event.clickedButton == 1 && event.clickType == 0) return;
 		if (!CookieWarning.hasActiveBoosterCookie()) return;
 		if (!Utils.getOpenChestName().startsWith("Auctions")) return;
 		ItemStack stack = event.slot.getStack();

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/AuctionSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/AuctionSearchOverlay.java
@@ -110,12 +110,13 @@ public class AuctionSearchOverlay extends SearchOverlayScreen {
 	}
 
 	@SubscribeEvent
-	public void onSignDrawn(GuiScreenEvent.DrawScreenEvent.Post event) {
+	public void onSignDrawn(GuiScreenEvent.DrawScreenEvent.Pre event) {
 		if (!isinAhSign() || !(event.gui instanceof GuiEditSign) || event.gui instanceof SearchOverlayScreen)
 			return;
 		GuiEditSign guiEditSign = (GuiEditSign) event.gui;
 		TileEntitySign tileSign = ((AccessorGuiEditSign) guiEditSign).getTileSign();
 		if (tileSign != null) {
+			event.setCanceled(true);
 			Minecraft.getMinecraft().displayGuiScreen(new AuctionSearchOverlay(tileSign));
 		}
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/AuctionSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/AuctionSearchOverlay.java
@@ -97,7 +97,7 @@ public class AuctionSearchOverlay extends SearchOverlayScreen {
 	@SubscribeEvent
 	public void onSlotClick(SlotClickEvent event) {
 		if (!enableSearchOverlay()) return;
-		if (NotEnoughUpdates.INSTANCE.config.hidden.disableClientSideSearch) return;
+		if (disableClientSideGUI()) return;
 		if (event.clickedButton == 1 && event.clickType == 0) return;
 		if (!CookieWarning.hasActiveBoosterCookie()) return;
 		if (!Utils.getOpenChestName().startsWith("Auctions")) return;

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/AuctionSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/AuctionSearchOverlay.java
@@ -104,6 +104,7 @@ public class AuctionSearchOverlay extends SearchOverlayScreen {
 		ItemStack stack = event.slot.getStack();
 		if (event.slot.slotNumber == 48 && stack != null && stack.hasDisplayName() && stack.getItem() == Items.sign && stack.getDisplayName().equals("§aSearch")) {
 			event.setCanceled(true);
+			Minecraft.getMinecraft().currentScreen = null;
 			NotEnoughUpdates.INSTANCE.openGui = new AuctionSearchOverlay();
 		}
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/BazaarSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/BazaarSearchOverlay.java
@@ -25,6 +25,7 @@ import io.github.moulberry.notenoughupdates.autosubscribe.NEUAutoSubscribe;
 import io.github.moulberry.notenoughupdates.events.SlotClickEvent;
 import io.github.moulberry.notenoughupdates.miscfeatures.CookieWarning;
 import io.github.moulberry.notenoughupdates.mixins.AccessorGuiEditSign;
+import io.github.moulberry.notenoughupdates.util.ItemUtils;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiEditSign;
@@ -36,6 +37,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 
 @NEUAutoSubscribe
 public class BazaarSearchOverlay extends SearchOverlayScreen {
@@ -97,10 +99,16 @@ public class BazaarSearchOverlay extends SearchOverlayScreen {
 	public void onSlotClick(SlotClickEvent event) {
 		if (!enableSearchOverlay()) return;
 		if (disableClientSideGUI()) return;
-		if (event.clickedButton == 1 && event.clickType == 0) return;
+		ItemStack stack = event.slot.getStack();
+		if (event.clickedButton == 1 && event.clickType == 0 && stack != null) {
+		    List<String> lore = ItemUtils.getLore(stack);
+		    String clearLine = lore.size() > 4 ? lore.get(4) : null;
+		    if (clearLine != null && clearLine.equals("§bRight-Click to clear!")) {
+		        return;
+		    }
+		}
 		if (!CookieWarning.hasActiveBoosterCookie()) return;
 		if (!Utils.getOpenChestName().startsWith("Bazaar ➜")) return;
-		ItemStack stack = event.slot.getStack();
 		if (event.slot.slotNumber == 45 && stack != null && stack.hasDisplayName() && stack.getItem() == Items.sign && stack.getDisplayName().equals("§aSearch")) {
 			event.setCanceled(true);
 			Minecraft.getMinecraft().currentScreen = null;
@@ -109,12 +117,13 @@ public class BazaarSearchOverlay extends SearchOverlayScreen {
 	}
 
 	@SubscribeEvent
-	public void onSignDrawn(GuiScreenEvent.DrawScreenEvent.Post event) {
+	public void onSignDrawn(GuiScreenEvent.DrawScreenEvent.Pre event) {
 		if (!isinBzSign() || !(event.gui instanceof GuiEditSign) || event.gui instanceof SearchOverlayScreen)
 			return;
 		GuiEditSign guiEditSign = (GuiEditSign) event.gui;
 		TileEntitySign tileSign = ((AccessorGuiEditSign) guiEditSign).getTileSign();
 		if (tileSign != null) {
+			event.setCanceled(true);
 			Minecraft.getMinecraft().displayGuiScreen(new BazaarSearchOverlay(tileSign));
 		}
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/BazaarSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/BazaarSearchOverlay.java
@@ -95,7 +95,9 @@ public class BazaarSearchOverlay extends SearchOverlayScreen {
 
 	@SubscribeEvent
 	public void onSlotClick(SlotClickEvent event) {
-		if (!NotEnoughUpdates.INSTANCE.config.bazaarTweaks.enableSearchOverlay) return;
+		if (!enableSearchOverlay()) return;
+		if (NotEnoughUpdates.INSTANCE.config.hidden.disableClientSideSearch) return;
+		if (event.clickedButton == 1 && event.clickType == 0) return;
 		if (!CookieWarning.hasActiveBoosterCookie()) return;
 		if (!Utils.getOpenChestName().startsWith("Bazaar ➜")) return;
 		ItemStack stack = event.slot.getStack();

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/BazaarSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/BazaarSearchOverlay.java
@@ -103,6 +103,7 @@ public class BazaarSearchOverlay extends SearchOverlayScreen {
 		ItemStack stack = event.slot.getStack();
 		if (event.slot.slotNumber == 45 && stack != null && stack.hasDisplayName() && stack.getItem() == Items.sign && stack.getDisplayName().equals("§aSearch")) {
 			event.setCanceled(true);
+			Minecraft.getMinecraft().currentScreen = null;
 			NotEnoughUpdates.INSTANCE.openGui = new BazaarSearchOverlay();
 		}
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/BazaarSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/BazaarSearchOverlay.java
@@ -96,7 +96,7 @@ public class BazaarSearchOverlay extends SearchOverlayScreen {
 	@SubscribeEvent
 	public void onSlotClick(SlotClickEvent event) {
 		if (!enableSearchOverlay()) return;
-		if (NotEnoughUpdates.INSTANCE.config.hidden.disableClientSideSearch) return;
+		if (disableClientSideGUI()) return;
 		if (event.clickedButton == 1 && event.clickType == 0) return;
 		if (!CookieWarning.hasActiveBoosterCookie()) return;
 		if (!Utils.getOpenChestName().startsWith("Bazaar ➜")) return;

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/RecipeSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/RecipeSearchOverlay.java
@@ -25,7 +25,9 @@ import io.github.moulberry.notenoughupdates.events.ReplaceItemEvent;
 import io.github.moulberry.notenoughupdates.events.SlotClickEvent;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import net.minecraft.client.Minecraft;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntitySign;
 import net.minecraft.util.EnumChatFormatting;
@@ -47,7 +49,7 @@ public class RecipeSearchOverlay extends SearchOverlayScreen {
 
 	@SubscribeEvent
 	public void onSlotClick(SlotClickEvent event) {
-		if (!NotEnoughUpdates.INSTANCE.config.recipeTweaks.enableSearchOverlay) return;
+		if (!enableSearchOverlay()) return;
 		ItemStack stack = event.slot.getStack();
 		if ((event.slot.slotNumber == 50 || event.slot.slotNumber == 51) && stack != null && stack.hasDisplayName() && stack.getItem() == Items.sign && stack.getDisplayName().equals("§aSearch Recipes")) {
 			event.setCanceled(true);
@@ -67,7 +69,9 @@ public class RecipeSearchOverlay extends SearchOverlayScreen {
 
 	@SubscribeEvent
 	public void slotReplace(ReplaceItemEvent event) {
+		if (!enableSearchOverlay()) return;
 		if (event.getSlotNumber() != 32 || !Utils.getOpenChestName().equals("Craft Item")) return;
+		if (event.getOriginal() == null || event.getOriginal().getItem() != Item.getItemFromBlock(Blocks.stained_glass_pane)) return;
 		event.replaceWith(recipeSearchStack);
 	}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/RecipeSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/RecipeSearchOverlay.java
@@ -49,13 +49,12 @@ public class RecipeSearchOverlay extends SearchOverlayScreen {
 
 	@SubscribeEvent
 	public void onSlotClick(SlotClickEvent event) {
-		if (!enableSearchOverlay()) return;
 		ItemStack stack = event.slot.getStack();
-		if ((event.slot.slotNumber == 50 || event.slot.slotNumber == 51) && stack != null && stack.hasDisplayName() && stack.getItem() == Items.sign && stack.getDisplayName().equals("§aSearch Recipes")) {
+		if (enableSearchOverlay() && (event.slot.slotNumber == 50 || event.slot.slotNumber == 51) && stack != null && stack.hasDisplayName() && stack.getItem() == Items.sign && stack.getDisplayName().equals("§aSearch Recipes")) {
 			event.setCanceled(true);
 			NotEnoughUpdates.INSTANCE.openGui = new RecipeSearchOverlay();
 		}
-		if (event.slot.slotNumber == 32 && Utils.getOpenChestName().equals("Craft Item")) {
+		if (shouldAddPickaxe() && event.slot.slotNumber == 32 && Utils.getOpenChestName().equals("Craft Item")) {
 			event.setCanceled(true);
 			NotEnoughUpdates.INSTANCE.openGui = new RecipeSearchOverlay();
 		}
@@ -69,16 +68,21 @@ public class RecipeSearchOverlay extends SearchOverlayScreen {
 
 	@SubscribeEvent
 	public void slotReplace(ReplaceItemEvent event) {
-		if (!enableSearchOverlay()) return;
+		if (!shouldAddPickaxe()) return;
 		if (event.getSlotNumber() != 32 || !Utils.getOpenChestName().equals("Craft Item")) return;
-		if (event.getOriginal() == null || event.getOriginal().getItem() != Item.getItemFromBlock(Blocks.stained_glass_pane)) return;
+		if (event.getOriginal() == null || event.getOriginal().getItem() != Item.getItemFromBlock(Blocks.stained_glass_pane) ||
+		!event.getOriginal().getDisplayName().equals(" ")) return;
 		event.replaceWith(recipeSearchStack);
 	}
 
 
 	@Override
-	public boolean enableSearchOverlay() {
+	public boolean enableSearchOverlay() { // enables the button in /recipes, not the whole overlay
 		return NotEnoughUpdates.INSTANCE.config.recipeTweaks.enableSearchOverlay;
+	}
+
+	public boolean shouldAddPickaxe() {
+		return NotEnoughUpdates.INSTANCE.config.recipeTweaks.addPickaxeStack;
 	}
 
 	@Override

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/SearchOverlayScreen.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/SearchOverlayScreen.java
@@ -39,6 +39,7 @@ import net.minecraft.network.play.client.C12PacketUpdateSign;
 import net.minecraft.tileentity.TileEntitySign;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.Loader;
 import org.apache.commons.lang3.StringUtils;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
@@ -737,6 +738,10 @@ public class SearchOverlayScreen extends GuiEditSign {
 
 	public boolean keepPreviousSearch() {
 		return false;
+	}
+
+	public boolean disableClientSideGUI() {
+		return Loader.isModLoaded("skyblockcatia") || NotEnoughUpdates.INSTANCE.config.hidden.disableClientSideSearch;
 	}
 
 	public GuiType currentGuiType() {


### PR DESCRIPTION
closes #1330 

also adds hidden option to disable client side GUI
makes it so you can right click the sign stack to clear again
also adds a separate option for the button in /recipes and the button in /craft
fixes setting names to be clearer with the search overlays
fixes sbc closing the GUI (well I have to assume)