### PR TITLE
Fix level 100 pet option working in bz search

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/SearchOverlayScreen.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/SearchOverlayScreen.java
@@ -186,7 +186,7 @@ public class SearchOverlayScreen extends GuiEditSign {
 		if (!searchStringExtra.isEmpty()) {
 			stringBuilder.append(searchStringExtra);
 		}
-		if (onlyLevel100) {
+		if (currentGuiType() == GuiType.AUCTION_HOUSE && onlyLevel100) {
 			stringBuilder.insert(0, "[Lvl 100] ");
 		}
 


### PR DESCRIPTION
closes #1349