### PR TITLE
Fix recipe search button showing while disabled and also showing inside the player inventory

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/RecipeSearchOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/RecipeSearchOverlay.java
@@ -25,6 +25,7 @@ import io.github.moulberry.notenoughupdates.events.ReplaceItemEvent;
 import io.github.moulberry.notenoughupdates.events.SlotClickEvent;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntitySign;
@@ -67,7 +68,7 @@ public class RecipeSearchOverlay extends SearchOverlayScreen {
 
 	@SubscribeEvent
 	public void slotReplace(ReplaceItemEvent event) {
-		if (event.getSlotNumber() != 32 || !Utils.getOpenChestName().equals("Craft Item")) return;
+		if (!NotEnoughUpdates.INSTANCE.config.recipeTweaks.enableSearchOverlay || event.getInventory() instanceof InventoryPlayer || event.getSlotNumber() != 32 || !Utils.getOpenChestName().equals("Craft Item")) return;
 		event.replaceWith(recipeSearchStack);
 	}
 


### PR DESCRIPTION
I don't know if it's only me, but when I have the recipe search overlay enabled and open /craft there's another copy of the ItemStack replaced inside the player inventory.
I've checked the PRs, issues, commits and didn't find anything related to that bug.
Screenshots of the bug: https://imgur.com/a/9BO503k

<!--

Thank you for choosing to contribute to NEU!

Please make sure to give your PR a descriptive title.

Your PR title will be used in our changelog and should look like one of those:

Add fleebleblub menu
Fix crash in the gorp overlay
Remove Herobrine
meta: Make documentation clearer

Use Add, Fix, or Remove at the start of your PR name.
If the change doesn't affect end-users, start your PR name with `meta:`, in which case the naming conventions above do not apply.

Do not end your PR title with a .

If your PR bundles two features, consider opening two PRs, one for each instead.

-->
