### PR TITLE
meta: Increase max search bar length to 50 chars

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -229,6 +229,7 @@ public class NEUOverlay extends Gui {
 		this.manager = manager;
 		textField.setFocused(true);
 		textField.setCanLoseFocus(false);
+		textField.setMaxStringLength(50);
 
 		guiGroup = createGuiGroup();
 	}


### PR DESCRIPTION
not every item id could fit with 32 lol

 the text does sorta go out of the box but whatever