### PR TITLE
Fix Dwarven Overlay not showing a tip for Maniac Slayer while being in a Mineshaft

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
@@ -688,6 +688,7 @@ public class MiningOverlay extends TextTabOverlay {
 			if (name.equals("Aquamarine Gemstone Collector")) return "Break aqua glass";
 			if (name.equals("Peridot Gemstone Collector")) return "Break dark green glass";
 			if (name.equals("Citrine Gemstone Collector")) return "Break brown glass";
+			if (name.equals("Maniac Slayer")) return "Kill mobs in a Glacite Mineshaft";
 		}
 
 		return null;


### PR DESCRIPTION


<!--

Thank you for choosing to contribute to NEU!

Please make sure to give your PR a descriptive title.

Your PR title will be used in our changelog and should look like one of those:

Add fleebleblub menu
Fix crash in the gorp overlay
Remove Herobrine
meta: Make documentation clearer

Use Add, Fix, or Remove at the start of your PR name.
If the change doesn't affect end-users, start your PR name with `meta:`, in which case the naming conventions above do not apply.

Do not end your PR title with a .

If your PR bundles two features, consider opening two PRs, one for each instead.

-->
