### PR TITLE
Fix pickaxe cooldown handling

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/ItemCooldowns.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/ItemCooldowns.java
@@ -21,6 +21,8 @@ package io.github.moulberry.notenoughupdates.miscfeatures;
 
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.autosubscribe.NEUAutoSubscribe;
+import io.github.moulberry.notenoughupdates.miscfeatures.customblockzones.LocationChangeEvent;
+import io.github.moulberry.notenoughupdates.util.SBInfo;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.init.Blocks;
@@ -160,10 +162,15 @@ public class ItemCooldowns {
 	}
 
 	@SubscribeEvent
+	public void onLocationChange(LocationChangeEvent event) {
+		if ("mineshaft".equals(event.newLocation) && pickaxeCooldown > 0) {
+			pickaxeUseCooldownMillisRemaining = 0;
+		}
+	}
+
+	@SubscribeEvent
 	public void onWorldLoad(WorldEvent.Load event) {
 		blocksClicked.clear();
-		if (pickaxeCooldown > 0) pickaxeUseCooldownMillisRemaining = 60 * 1000;
-		pickaxeCooldown = -1;
 	}
 
 	@SubscribeEvent

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/ItemCooldowns.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/ItemCooldowns.java
@@ -22,7 +22,6 @@ package io.github.moulberry.notenoughupdates.miscfeatures;
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.autosubscribe.NEUAutoSubscribe;
 import io.github.moulberry.notenoughupdates.miscfeatures.customblockzones.LocationChangeEvent;
-import io.github.moulberry.notenoughupdates.util.SBInfo;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.init.Blocks;


### PR DESCRIPTION
The cooldown is now persisted across lobbies, and set to zero when entering a mineshaft.

<!--

Thank you for choosing to contribute to NEU!

Please make sure to give your PR a descriptive title.

Your PR title will be used in our changelog and should look like one of those:

Add fleebleblub menu
Fix crash in the gorp overlay
Remove Herobrine
meta: Make documentation clearer

Use Add, Fix, or Remove at the start of your PR name.
If the change doesn't affect end-users, start your PR name with `meta:`, in which case the naming conventions above do not apply.

Do not end your PR title with a .

If your PR bundles two features, consider opening two PRs, one for each instead.

-->
