### PR TITLE
Add update popup notification

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/Notifications.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/Notifications.java
@@ -24,19 +24,10 @@ import io.github.moulberry.moulconfig.annotations.ConfigAccordionId;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorAccordion;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorColour;
-import io.github.moulberry.moulconfig.annotations.ConfigEditorDropdown;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorSlider;
 import io.github.moulberry.moulconfig.annotations.ConfigOption;
 
 public class Notifications {
-	@Expose
-	@ConfigOption(
-		name = "Update Messages",
-		desc = "Give a notification in chat whenever a new version of NEU is released"
-	)
-	@ConfigEditorDropdown(values = {"Off", "Releases", "Pre-Releases"})
-	public int updateChannel = 1;
-
 	@Expose
 	@ConfigOption(
 		name = "Missing repo warning",

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/updater/AutoUpdater.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/updater/AutoUpdater.kt
@@ -24,10 +24,17 @@ import io.github.moulberry.notenoughupdates.autosubscribe.NEUAutoSubscribe
 import io.github.moulberry.notenoughupdates.events.RegisterBrigadierCommandEvent
 import io.github.moulberry.notenoughupdates.util.ApiUtil
 import io.github.moulberry.notenoughupdates.util.MinecraftExecutor
+import io.github.moulberry.notenoughupdates.util.NotificationHandler
+import io.github.moulberry.notenoughupdates.util.Utils
 import io.github.moulberry.notenoughupdates.util.brigadier.thenExecute
-import moe.nea.libautoupdate.*
+import moe.nea.libautoupdate.CurrentVersion
+import moe.nea.libautoupdate.PotentialUpdate
+import moe.nea.libautoupdate.UpdateContext
+import moe.nea.libautoupdate.UpdateTarget
+import moe.nea.libautoupdate.UpdateUtils
 import net.minecraft.client.Minecraft
 import net.minecraft.event.ClickEvent
+import net.minecraft.event.HoverEvent
 import net.minecraft.launchwrapper.Launch
 import net.minecraft.util.ChatComponentText
 import net.minecraftforge.common.MinecraftForge
@@ -115,7 +122,14 @@ object AutoUpdater {
                                     "/neuinternalupdatenow"
                                 )
                             )
+                            this.chatStyle.setChatHoverEvent(
+                                HoverEvent(
+                                    HoverEvent.Action.SHOW_TEXT,
+                                    ChatComponentText("§aClick to install the update")
+                                )
+                            )
                         })
+                    NotificationHandler.displayNotification(listOf("§7NEU found an update: §a${it.update.versionName}", "  §7Run /neu and click on \"Download update\" to install this update  "), true)
                     }
                 }
             }, MinecraftExecutor.OnThread)
@@ -124,13 +138,16 @@ object AutoUpdater {
     fun queueUpdate() {
         if (updateState != UpdateState.AVAILABLE) {
             logger.error("Trying to enqueue an update while another one is already downloaded or none is present")
+            return
         }
         updateState = UpdateState.QUEUED
         activePromise = CompletableFuture.supplyAsync {
             logger.info("Update download started")
+            Utils.addChatMessage("§e[NEU] §aUpdate download started")
             potentialUpdate!!.prepareUpdate()
         }.thenAcceptAsync({
             logger.info("Update download completed, setting exit hook")
+            Utils.addChatMessage("§e[NEU] §aUpdate download completed. Restart Minecraft to apply")
             updateState = UpdateState.DOWNLOADED
             potentialUpdate!!.executePreparedUpdate()
         }, MinecraftExecutor.OnThread)

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/updater/AutoUpdater.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/updater/AutoUpdater.kt
@@ -129,7 +129,7 @@ object AutoUpdater {
                                 )
                             )
                         })
-                    NotificationHandler.displayNotification(listOf("§7NEU found an update: §a${it.update.versionName}", "  §7Run /neu and click on \"Download update\" to install this update  "), true)
+                    NotificationHandler.displayNotification(listOf("§7NEU has found a new update: §a${it.update.versionName}", "  §7Run /neu and click \"Download update\" to install.  "), true)
                     }
                 }
             }, MinecraftExecutor.OnThread)


### PR DESCRIPTION
stops you from downloading multiple updates
adds chat feedback when you hover and click on the message
removes unused config
closes #1329 

![image](https://github.com/user-attachments/assets/c3665cdd-25a1-4d55-a9a7-be460c54abd3)
 