### PR TITLE
meta: Fix ProfileDataLoadedEvent never firing if you have minion helper off

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/minionhelper/loaders/MinionHelperApiLoader.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/minionhelper/loaders/MinionHelperApiLoader.java
@@ -22,6 +22,7 @@ package io.github.moulberry.notenoughupdates.miscgui.minionhelper.loaders;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.core.util.StringUtils;
 import io.github.moulberry.notenoughupdates.events.ProfileDataLoadedEvent;
 import io.github.moulberry.notenoughupdates.miscgui.minionhelper.ApiData;
@@ -70,6 +71,7 @@ public class MinionHelperApiLoader {
 
 	@SubscribeEvent
 	public void onApiDataLoaded(ProfileDataLoadedEvent event) {
+		if (!NotEnoughUpdates.INSTANCE.config.minionHelper.gui) return;
 		JsonObject data = event.getData();
 		if (data == null) {
 			invalidApiKey = true;


### PR DESCRIPTION
idk if we want this in the change log

I guess it fixes the power stone something display 
but it also fixes the skyhanni features to steal data from pv