### PR TITLE
Fix pet overlay issues

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -883,7 +883,7 @@ public class PetInfoOverlay extends TextOverlay {
 						}
 					}
 					removeMap.keySet().retainAll(removeSet);
-				} else if (containerName.equals("Your Equipment")) {
+				} else if (containerName.startsWith("Your Equipment")) {
 					ItemStack petStack = lower.getStackInSlot(47);
 					if (petStack != null && petStack.getItem() == Items.skull) {
 						NBTTagCompound tag = petStack.getTagCompound();
@@ -911,7 +911,12 @@ public class PetInfoOverlay extends TextOverlay {
 								double petLevel = PetLeveling.getPetLevelingForPet(name, Rarity.valueOf(rarityString))
 																						 .getPetLevel(petXp)
 																						 .getCurrentLevel();
-								int index = getClosestPetIndex(name, rarity, "", (float) petLevel);
+
+								String petItem = "";
+								if (petInfoObject.has("heldItem")) {
+									petItem = petInfoObject.get("heldItem").getAsString();
+								}
+								int index = getClosestPetIndex(name, rarity, petItem, (float) petLevel);
 								if (index != config.selectedPet) {
 									clearPet();
 									setCurrentPet(index);

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -955,9 +955,13 @@ public class PetInfoOverlay extends TextOverlay {
 			String line = widgetLines.get(i);
 			String lineWithColours = line.replace("§r", "").trim();
 			line = Utils.cleanColour(line).trim().replace(",", "");
+
 			Matcher normalXPMatcher = TAB_LIST_XP.matcher(line);
 			Matcher overflowXPMatcher = TAB_LIST_XP_OVERFLOW.matcher(line);
+
 			Matcher petNameMatcher = TAB_LIST_PET_NAME.matcher(lineWithColours);
+			Matcher petItemMatcher = TAB_LIST_PET_ITEM.matcher(lineWithColours);
+
 			if (petNameMatcher.matches()) {
 				String petName = petNameMatcher.group(3);
 				int petLevel = 1;
@@ -973,9 +977,9 @@ public class PetInfoOverlay extends TextOverlay {
 						String petItem = "";
 						if (widgetLines.size() > i) {
 							String nextLine = widgetLines.get(i + 1).replace("§r", "").trim();
-							Matcher petItemMatcher = TAB_LIST_PET_ITEM.matcher(nextLine);
-							if (petItemMatcher.matches()) {
-								petItem = getInternalIdForPetItemDisplayName(petItemMatcher.group(0));
+							Matcher nextLinePetItemMatcher = TAB_LIST_PET_ITEM.matcher(nextLine);
+							if (nextLinePetItemMatcher.matches()) {
+								petItem = getInternalIdForPetItemDisplayName(nextLinePetItemMatcher.group(0));
 							}
 						}
 
@@ -984,7 +988,7 @@ public class PetInfoOverlay extends TextOverlay {
 						if (split.length > 0) {
 							internalName = split[0];
 						}
-						System.out.println(petItem);
+
 						setCurrentPet(getClosestPetIndex(internalName, rarity, petItem, petLevel));
 						lastPetCorrect = System.currentTimeMillis();
 					}
@@ -1001,6 +1005,23 @@ public class PetInfoOverlay extends TextOverlay {
 				}
 
 			}
+
+			if (petItemMatcher.matches()) {
+				String petItem = getInternalIdForPetItemDisplayName(petItemMatcher.group(0));
+				if (!Objects.equals(currentPet.petItem, petItem)) {
+					int closestPetIndex = getClosestPetIndex(
+						currentPet.petType,
+						currentPet.rarity.petId,
+						petItem,
+						currentPet.petLevel.getCurrentLevel()
+					);
+
+					if (config.selectedPet != closestPetIndex && closestPetIndex != -1) {
+						setCurrentPet(closestPetIndex);
+					}
+				}
+			}
+
 			if (normalXPMatcher.matches() || overflowXPMatcher.matches()) {
 				String xpString;
 				if (normalXPMatcher.matches()) xpString = normalXPMatcher.group(1);

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -989,7 +989,11 @@ public class PetInfoOverlay extends TextOverlay {
 							internalName = split[0];
 						}
 
-						setCurrentPet(getClosestPetIndex(internalName, rarity, petItem, petLevel));
+						int closestPetIndex = getClosestPetIndex(internalName, rarity, petItem, petLevel);
+						if (closestPetIndex != -1) {
+							//If it is -1 your petcache is probably outdated and you need to open /pets, but im sure they can work it out
+							setCurrentPet(closestPetIndex);
+						}
 						lastPetCorrect = System.currentTimeMillis();
 					}
 					break;

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -1016,7 +1016,7 @@ public class PetInfoOverlay extends TextOverlay {
 						averageXp += value;
 					}
 
-					if (!xpHourMap.isEmpty()) xpGainHour = (averageXp / xpHourMap.size()) * ((float) (60 * 60) / seconds);
+					if (!xpHourMap.isEmpty()) xpGainHour = (averageXp) * ((float) (60 * 60) / seconds);
 					else xpGainHour = 0;
 				} else {
 					lastPaused = System.currentTimeMillis();

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -363,6 +363,9 @@ public class PetInfoOverlay extends TextOverlay {
 	public float getLevelPercent(Pet pet) {
 		if (pet == null) return 0;
 		try {
+			if (pet.petLevel.getMaxLevel() == pet.petLevel.getCurrentLevel()) {
+				return 100;
+			}
 			return Float.parseFloat(StringUtils.formatToTenths(Math.min(
 				pet.petLevel.getPercentageToNextLevel() * 100f,
 				100f
@@ -387,13 +390,20 @@ public class PetInfoOverlay extends TextOverlay {
 		String lvlString = null;
 
 		if (levelPercent != 100 || !NotEnoughUpdates.INSTANCE.config.petOverlay.hidePetLevelProgress) {
-			lvlStringShort = EnumChatFormatting.AQUA + "" + roundFloat(levelXp) + "/" +
-				roundFloat(currentPet.petLevel.getExpRequiredForNextLevel())
+			long xpForNextLevel = currentPet.petLevel.getExpRequiredForNextLevel();
+			float visualXp = levelXp;
+			if (levelPercent == 100) {
+				if (xpForNextLevel > levelXp) {
+					visualXp = xpForNextLevel;
+				}
+			}
+			lvlStringShort = EnumChatFormatting.AQUA + "" + roundFloat(visualXp) + "/" +
+				roundFloat(xpForNextLevel)
 				+ EnumChatFormatting.YELLOW + " (" + levelPercent + "%)";
 
 			lvlString = EnumChatFormatting.AQUA + "" +
-				Utils.shortNumberFormat(Math.min(levelXp, currentPet.petLevel.getExpRequiredForNextLevel()), 0) + "/" +
-				Utils.shortNumberFormat(currentPet.petLevel.getExpRequiredForNextLevel(), 0)
+				Utils.shortNumberFormat(Math.min(visualXp, xpForNextLevel), 0) + "/" +
+				Utils.shortNumberFormat(xpForNextLevel, 0)
 				+ EnumChatFormatting.YELLOW + " (" + levelPercent + "%)";
 		}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -1223,13 +1223,16 @@ public class PetInfoOverlay extends TextOverlay {
 		return defaultName;
 	}
 
+	private static boolean hasRepoPopupped = false;
+
 	private static String getInternalIdForPetItemDisplayName(String displayName) {
 		JsonObject pets = Constants.PETS;
 		String defaultName = displayName.replace(" ", "_").replace("-", "_").toUpperCase(Locale.ROOT);
 		defaultName = Utils.cleanColour(defaultName).trim();
 		if (pets == null) return defaultName;
 		if (!pets.has("pet_item_display_name_to_id")) {
-			Utils.showOutdatedRepoNotification("pets.json pet_item_display_name_to_id");
+			if (!hasRepoPopupped) Utils.showOutdatedRepoNotification("pets.json pet_item_display_name_to_id");
+			hasRepoPopupped = true;
 			return defaultName;
 		}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -407,7 +407,7 @@ public class PetInfoOverlay extends TextOverlay {
 		String xpGainString = EnumChatFormatting.AQUA + "XP/h: " +
 			EnumChatFormatting.YELLOW + roundFloat(xpGain);
 		if (!secondPet && xpGain > 0 &&
-			(levelXp != levelXpLast || System.currentTimeMillis() - lastXpUpdateNonZero > 3500)) {
+			(levelXp != levelXpLast || System.currentTimeMillis() - lastXpUpdateNonZero > 4500)) {
 			if (pauseCountdown <= 0) {
 				xpGainString += EnumChatFormatting.RED + " (PAUSED)";
 			} else {
@@ -1038,7 +1038,7 @@ public class PetInfoOverlay extends TextOverlay {
 						}
 					}
 
-					if (totalGain != 0 || System.currentTimeMillis() - lastXpUpdate > 3500) {
+					if (totalGain != 0 || System.currentTimeMillis() - lastXpUpdate > 4500) {
 						xpHourMap.put(System.currentTimeMillis(), totalGain);
 						lastXpUpdate = System.currentTimeMillis();
 					}


### PR DESCRIPTION
requires https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/pull/1393

Fixes xp/h being way too low
Makes it so autopet factors in pet item hopefully resulting in more accurate selected pet
Fixed gathering pet info from the equipment menu + factoring in pet item there
Made it so if the tablist and what the pet overlay thinks is selected are different it trys to swap the pet (uses both name and pet item)
Fixes hide xp at max level requiring level 101 instead of 100