### PR TITLE
Fix message not showing in chat if you get mentioned

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/ChatListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/ChatListener.java
@@ -133,6 +133,7 @@ public class ChatListener {
 		}
 		if (chatClickCommand == null) return chatComponent;
 
+		if (targetedComponent.getChatStyle().getChatClickEvent() == null) return chatComponent;
 		String username = chatClickCommand.equals("/viewprofile") ?
 			Utils.getNameFromChatComponent(chatComponent) :
 			targetedComponent.getChatStyle().getChatClickEvent().getValue().substring(15);


### PR DESCRIPTION
[11:37:13] [main/ERROR] (FML) Exception caught during firing event net.minecraftforge.client.event.ClientChatReceivedEvent@1d0ef25f:
 java.lang.NullPointerException: null
	at io.github.moulberry.notenoughupdates.listener.ChatListener.replaceSocialControlsWithPV(ChatListener.java:141) ~[ChatListener.class:?]
	at io.github.moulberry.notenoughupdates.listener.ChatListener.onGuiChat(ChatListener.java:202) ~[ChatListener.class:?]
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_15_ChatListener_onGuiChat_ClientChatReceivedEvent.invoke(.dynamic) ~[?:?]