### PR TITLE
meta: Add empty line to update notification to make it not look bald

### DIFF
--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/updater/AutoUpdater.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/miscfeatures/updater/AutoUpdater.kt
@@ -129,7 +129,13 @@ object AutoUpdater {
                                 )
                             )
                         })
-                    NotificationHandler.displayNotification(listOf("§7NEU has found a new update: §a${it.update.versionName}", "  §7Run /neu and click \"Download update\" to install.  "), true)
+                        NotificationHandler.displayNotification(
+                            listOf(
+                                "",
+                                "§7NEU has found a new update: §a${it.update.versionName}",
+                                "  §7Run /neu and click \"Download update\" to install.  "
+                            ), true
+                        )
                     }
                 }
             }, MinecraftExecutor.OnThread)


### PR DESCRIPTION
This pr hopefully makes notification not look like this:
![grafik](https://github.com/user-attachments/assets/49988083-c1a0-4d45-a41f-055853aaed23)