### PR TITLE
Fix Skyblock location not being reset when leaving skyblock

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
@@ -53,6 +53,7 @@ import io.github.moulberry.notenoughupdates.options.NEUConfig;
 import io.github.moulberry.notenoughupdates.overlays.OverlayManager;
 import io.github.moulberry.notenoughupdates.profileviewer.ProfileViewer;
 import io.github.moulberry.notenoughupdates.recipes.RecipeGenerator;
+import io.github.moulberry.notenoughupdates.util.SBInfo;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import io.github.moulberry.notenoughupdates.util.brigadier.BrigadierRoot;
 import io.github.moulberry.notenoughupdates.util.hypixelapi.HypixelItemAPI;
@@ -269,7 +270,8 @@ public class NotEnoughUpdates {
 				config.profileViewer.pageLayout.add(13);
 			}
 
-			if ((config.apiData.repoUser.isEmpty() || config.apiData.repoName.isEmpty() || config.apiData.repoBranch.isEmpty()) && config.apiData.autoupdate_new) {
+			if ((config.apiData.repoUser.isEmpty() || config.apiData.repoName.isEmpty() ||
+				config.apiData.repoBranch.isEmpty()) && config.apiData.autoupdate_new) {
 				config.apiData.repoUser = "NotEnoughUpdates";
 				config.apiData.repoName = "NotEnoughUpdates-REPO";
 				config.apiData.repoBranch = "master";
@@ -482,6 +484,7 @@ public class NotEnoughUpdates {
 		if (mc != null && mc.theWorld != null && mc.thePlayer != null) {
 			if (mc.isSingleplayer() || mc.thePlayer.getClientBrand() == null ||
 				!mc.thePlayer.getClientBrand().toLowerCase(Locale.ROOT).contains("hypixel")) {
+				SBInfo.getInstance().setScoreboardLocation("");
 				hasSkyblockScoreboard = false;
 				return;
 			}
@@ -498,6 +501,7 @@ public class NotEnoughUpdates {
 				}
 			}
 
+			SBInfo.getInstance().setScoreboardLocation("");
 			hasSkyblockScoreboard = false;
 		}
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
@@ -484,7 +484,7 @@ public class NotEnoughUpdates {
 		if (mc != null && mc.theWorld != null && mc.thePlayer != null) {
 			if (mc.isSingleplayer() || mc.thePlayer.getClientBrand() == null ||
 				!mc.thePlayer.getClientBrand().toLowerCase(Locale.ROOT).contains("hypixel")) {
-				SBInfo.getInstance().setScoreboardLocation("");
+				SBInfo.getInstance().resetScoreboardLocation();
 				hasSkyblockScoreboard = false;
 				return;
 			}
@@ -501,7 +501,7 @@ public class NotEnoughUpdates {
 				}
 			}
 
-			SBInfo.getInstance().setScoreboardLocation("");
+			SBInfo.getInstance().resetScoreboardLocation();
 			hasSkyblockScoreboard = false;
 		}
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CrystalMetalDetectorSolver.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CrystalMetalDetectorSolver.java
@@ -362,7 +362,7 @@ public class CrystalMetalDetectorSolver {
 		int beaconRGB = 0x1fd8f1;
 
 		if (SBInfo.getInstance().getLocation() != null && SBInfo.getInstance().getLocation().equals("crystal_hollows") &&
-			SBInfo.getInstance().location.equals("Mines of Divan")) {
+			SBInfo.getInstance().getScoreboardLocation().equals("Mines of Divan")) {
 
 			if (possibleBlocks.size() == 1) {
 				BlockPos block = possibleBlocks.iterator().next();

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/DwarvenMinesWaypoints.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/DwarvenMinesWaypoints.java
@@ -230,7 +230,7 @@ public class DwarvenMinesWaypoints {
 				}
 			}
 		}
-		String skyblockLocation = SBInfo.getInstance().location.toLowerCase(Locale.ROOT);
+		String skyblockLocation = SBInfo.getInstance().getScoreboardLocation().toLowerCase(Locale.ROOT);
 		if (locWaypoint >= 1) {
 			for (Map.Entry<String, Vector3f> entry : waypointsMap.entrySet()) {
 				if (locWaypoint >= 2) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/CrystalHollowOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/CrystalHollowOverlay.java
@@ -374,17 +374,17 @@ public class CrystalHollowOverlay extends TextOverlay {
 	private boolean automatonCheck() {
 		return NotEnoughUpdates.INSTANCE.config.mining.crystalHollowAutomatonLocation == 0 ||
 			NotEnoughUpdates.INSTANCE.config.mining.crystalHollowAutomatonLocation == 1 &&
-				SBInfo.getInstance().location.equals("Precursor Remnants") ||
+				SBInfo.getInstance().getScoreboardLocation().equals("Precursor Remnants") ||
 			NotEnoughUpdates.INSTANCE.config.mining.crystalHollowAutomatonLocation >= 1 &&
-				SBInfo.getInstance().location.equals("Lost Precursor City");
+				SBInfo.getInstance().getScoreboardLocation().equals("Lost Precursor City");
 	}
 
 	private boolean divanCheck() {
 		return NotEnoughUpdates.INSTANCE.config.mining.crystalHollowDivanLocation == 0 ||
 			NotEnoughUpdates.INSTANCE.config.mining.crystalHollowDivanLocation == 1 &&
-				SBInfo.getInstance().location.equals("Mithril Deposits") ||
+				SBInfo.getInstance().getScoreboardLocation().equals("Mithril Deposits") ||
 			NotEnoughUpdates.INSTANCE.config.mining.crystalHollowDivanLocation >= 1 &&
-				SBInfo.getInstance().location.equals("Mines of Divan");
+				SBInfo.getInstance().getScoreboardLocation().equals("Mines of Divan");
 	}
 
 	private boolean crystalCheck() {

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/SlayerOverlay.java
@@ -72,7 +72,7 @@ public class SlayerOverlay extends TextOverlay {
 			return true;
 		}
 
-		String scoreboardLocation = SBInfo.getInstance().location;
+		String scoreboardLocation = SBInfo.getInstance().getScoreboardLocation();
 		String locrawLocation = SBInfo.getInstance().getLocation();
 		if ("None".equals(scoreboardLocation)) {
 			scoreboardLocation = SBInfo.getInstance().getLastScoreboardLocation();

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
@@ -79,8 +79,8 @@ public class SBInfo {
 	public IChatComponent footer;
 	public IChatComponent header;
 
-	public @NotNull String location = "";
-	public @NotNull String lastLocation = "";
+	private @NotNull String location = "";
+	private @NotNull String lastLocation = "";
 	public String date = "";
 	public String time = "";
 	public String objective = "";
@@ -295,6 +295,10 @@ public class SBInfo {
 	 */
 	public @NotNull String getScoreboardLocation() {
 		return location;
+	}
+
+	public void setScoreboardLocation(String location) {
+		this.location = location;
 	}
 
 	/**

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
@@ -297,8 +297,8 @@ public class SBInfo {
 		return location;
 	}
 
-	public void setScoreboardLocation(String location) {
-		this.location = location;
+	public void resetScoreboardLocation() {
+		this.location = "";
 	}
 
 	/**


### PR DESCRIPTION
Reset scoreboard location when leaving skyblock. 
Use the proper getter methods for scoreboard locations.
