### PR TITLE
Fix CoreTaskLevel, Fairy Souls experience calculation

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/data/APIDataJson.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/data/APIDataJson.java
@@ -111,6 +111,7 @@ public class APIDataJson {
 
 	public static class FairySouls {
 		public int total_collected = 0;
+		public int unspent_souls = 0;
 	}
 
 	public @Nullable NetherData nether_island_player_data;

--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/level/task/CoreTaskLevel.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/level/task/CoreTaskLevel.java
@@ -106,7 +106,7 @@ public class CoreTaskLevel extends GuiTaskLevel {
 		// museum is not possible
 
 		// fairy soul
-		int sbXpGainedFairy = data.fairy_soul.total_collected / 5 * coreTask.get("fairy_souls_xp").getAsInt();
+		int sbXpGainedFairy = (data.fairy_soul.total_collected - data.fairy_soul.unspent_souls) / 5 * coreTask.get("fairy_souls_xp").getAsInt();
 
 		int sbXpCollection = -1;
 		int sbXpMinionTier = -1; // keeping at -1 here because cobblestone 1 minion XP isn't included for some reason?


### PR DESCRIPTION
## Description

Fixes the wrong Core Task SkyBlock XP calculation for Fairy Souls
Example: `DuckySoSkilled/Raspberry`

![image](https://github.com/user-attachments/assets/80636267-56b8-45e9-9f3c-e93e9fe532c0)
![image](https://github.com/user-attachments/assets/26b33feb-e868-49b2-91fc-5914bb19c303)
