### PR TITLE
Fix bugs with pet overlay due to pet skins

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -1028,7 +1028,7 @@ public class PetInfoOverlay extends TextOverlay {
 							internalName = split[0];
 						}
 
-						if (((currentPet.petItem != null && !petItem.isEmpty() && !currentPet.petItem.equals(petItem))) || currentPet.rarity.petId != rarity ||
+						if ((currentPet.petItem != null && !petItem.isEmpty() && !currentPet.petItem.equals(petItem)) || currentPet.rarity.petId != rarity ||
 							currentPet.petLevel.getCurrentLevel() != petLevel) {
 							int closestPetIndex = getClosestPetIndex(internalName, rarity, petItem, petLevel);
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -403,8 +403,7 @@ public class PetInfoOverlay extends TextOverlay {
 			if (skinJson != null) {
 				String displayName = NotEnoughUpdates.INSTANCE.manager.jsonToStack(skinJson).getDisplayName();
 				String colourSt = Character.toString(Utils.getPrimaryColourCode(displayName));
-				EnumChatFormatting rarity = getRarityByColor(colourSt).chatFormatting;
-				petName += rarity + " ✦";
+				petName += "§" + colourSt + " ✦";
 			}
 		}
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -1014,7 +1014,7 @@ public class PetInfoOverlay extends TextOverlay {
 					if (lastPetCorrect == -1 || lastPetCorrect > 0 && System.currentTimeMillis() - lastPetCorrect > 6000) {
 						int rarity = getRarityByColor(petNameMatcher.group(2)).petId;
 						String petItem = "";
-						if (widgetLines.size() > i) {
+						if (widgetLines.size() > i + 1) {
 							String nextLine = widgetLines.get(i + 1).replace("§r", "").trim();
 							Matcher nextLinePetItemMatcher = TAB_LIST_PET_ITEM.matcher(nextLine);
 							if (nextLinePetItemMatcher.matches()) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -1194,6 +1194,9 @@ public class PetInfoOverlay extends TextOverlay {
 						IChatComponent iChatComponent = siblings.get(6);
 						String formattedText = iChatComponent.getChatStyle().getColor() + iChatComponent.getUnformattedText();
 						petItem = getInternalIdForPetItemDisplayName(formattedText);
+					} else {
+						//this *should* make it only match with only pets without items
+						petItem = null;
 					}
 					setCurrentPet(getClosestPetIndex(pet, rarity.petId, petItem, lastLevelHovered));
 					if (PetInfoOverlay.config.selectedPet == -1) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -84,7 +84,7 @@ public class PetInfoOverlay extends TextOverlay {
 	private static final Pattern TAB_LIST_XP = Pattern.compile(
 		"([0-9,]+\\.?[0-9]*)/([0-9,]+\\.?[0-9]*)[kM]? XP \\(\\d+\\.?\\d*%\\)");
 	private static final Pattern TAB_LIST_XP_OVERFLOW = Pattern.compile("\\+([0-9,]+\\.?[0-9]*) XP");
-	private static final Pattern TAB_LIST_PET_NAME = Pattern.compile("§.\\[Lvl (\\d+)\\] §(.)(.+)");
+	private static final Pattern TAB_LIST_PET_NAME = Pattern.compile("§.\\[Lvl (\\d+)\\](?: §8\\[§6\\d+§8§.✦§8])? §(.)(.+)");
 	private static final Pattern TAB_LIST_PET_ITEM = Pattern.compile("§[fa956d4][a-zA-Z- ]+");
 
 	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -1028,7 +1028,7 @@ public class PetInfoOverlay extends TextOverlay {
 							internalName = split[0];
 						}
 
-						if ((currentPet.petItem != null && !currentPet.petItem.equals(petItem)) || currentPet.rarity.petId != rarity ||
+						if (((currentPet.petItem != null && !petItem.isEmpty() && !currentPet.petItem.equals(petItem))) || currentPet.rarity.petId != rarity ||
 							currentPet.petLevel.getCurrentLevel() != petLevel) {
 							int closestPetIndex = getClosestPetIndex(internalName, rarity, petItem, petLevel);
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -194,6 +194,7 @@ public class PetInfoOverlay extends TextOverlay {
 		xpGainHourLast = -1;
 		xpGainHour = -1;
 		config.selectedPet = index;
+		lastPetCorrect = System.currentTimeMillis();
 	}
 
 	public static Pet getCurrentPet() {
@@ -975,7 +976,7 @@ public class PetInfoOverlay extends TextOverlay {
 	private long lastXpUpdate = -1;
 	private long lastXpUpdateNonZero = -1;
 	private long lastPaused = -1;
-	private long lastPetCorrect = -1;
+	private static long lastPetCorrect = -1;
 
 	public void updatePetLevels() {
 		float totalGain = 0;

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -928,8 +928,7 @@ public class PetInfoOverlay extends TextOverlay {
 								int rarity = Utils.getRarityFromLore(jsonStack.get("lore").getAsJsonArray());
 								String rarityString = Utils.getRarityFromInt(rarity);
 
-								String name = StringUtils.cleanColour(petStack.getDisplayName());
-								name = name.substring(name.indexOf(']') + 1).trim().replace(' ', '_').toUpperCase(Locale.ROOT);
+								String name = petInfoObject.get("type").getAsString();
 
 								float petXp = petInfoObject.get("exp").getAsFloat();
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -1055,7 +1055,7 @@ public class PetInfoOverlay extends TextOverlay {
 
 			if (petItemMatcher.matches()) {
 				String petItem = getInternalIdForPetItemDisplayName(petItemMatcher.group(0));
-				if (!Objects.equals(currentPet.petItem, petItem)) {
+				if (!Objects.equals(currentPet.petItem, petItem) && currentPet.petItem != null && !currentPet.petItem.isEmpty()) {
 					int closestPetIndex = getClosestPetIndex(
 						currentPet.petType,
 						currentPet.rarity.petId,


### PR DESCRIPTION
fixes the skin rarity icon showing white
fixes the tablist not recognising g drag with skin
makes it so swapping pet resets the timer from tablist
makes it so it doesn't swap due to different pet item if the pet item is missing from the tablist
fixes opening /eq with a skinned pet hiding the overlay
attempt to make autopet only match pets without a pet item if it doesn't have a pet item
fix crash (that somehow only one person got?)