### PR TITLE
Fix networth in profile viewer loading infinitely

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/SkyblockProfiles.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/SkyblockProfiles.java
@@ -261,13 +261,11 @@ public class SkyblockProfiles {
 			});
 
 		long currentTime = System.currentTimeMillis();
-		if (ProfileViewerUtils.lastSoopyRequestTime.containsKey(uuid)) {
-			if (currentTime - ProfileViewerUtils.lastSoopyRequestTime.get(uuid) < 5 * 1000 * 60) {
-				if (ProfileViewerUtils.soopyDataCache.containsKey(uuid)) {
-					updateSoopyNetworth(ProfileViewerUtils.soopyDataCache.get(uuid));
-					callback.run();
-				}
-			}
+		if (ProfileViewerUtils.lastSoopyRequestTime.containsKey(uuid)
+			&& currentTime - ProfileViewerUtils.lastSoopyRequestTime.get(uuid) < 5 * 1000 * 60
+			&& ProfileViewerUtils.soopyDataCache.containsKey(uuid)) {
+			updateSoopyNetworth(ProfileViewerUtils.soopyDataCache.get(uuid));
+			callback.run();
 		} else {
 			ProfileViewerUtils.lastSoopyRequestTime.put(uuid, currentTime);
 			profileViewer.getManager().apiUtils


### PR DESCRIPTION
<!--

Thank you for choosing to contribute to NEU!

Please make sure to give your PR a descriptive title.

Your PR title will be used in our changelog and should look like one of those:

Add fleebleblub menu
Fix crash in the gorp overlay
Remove Herobrine
meta: Make documentation clearer

Use Add, Fix, or Remove at the start of your PR name.
If the change doesn't affect end-users, start your PR name with `meta:`, in which case the naming conventions above do not apply.

Do not end your PR title with a .

If your PR bundles two features, consider opening two PRs, one for each instead.

-->
If the profile is already cached but outdated, loadSoopyData returns without making a new request.