### PR TITLE
Fix accessories not being detected in helper

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
@@ -127,6 +127,10 @@ public class RenderListener {
 	private long buttonHoveredMillis = 0;
 	private int inventoryLoadedTicks = 0;
 	private String loadedInvName = "";
+	private int lastTickCount = 0;
+	private int ticksStable = 0;
+	private static final int REQUIRED_STABLE_TICKS = 5;
+
 	//NPC parsing
 
 	private boolean inDungeonPage = false;
@@ -198,32 +202,36 @@ public class RenderListener {
 		if (Minecraft.getMinecraft().currentScreen instanceof GuiChest) {
 			GuiChest chest = (GuiChest) Minecraft.getMinecraft().currentScreen;
 			ContainerChest cc = (ContainerChest) chest.inventorySlots;
+			String name = cc.getLowerChestInventory().getDisplayName().getUnformattedText();
 
-			if (!loadedInvName.equals(cc.getLowerChestInventory().getDisplayName().getUnformattedText())) {
-				loadedInvName = cc.getLowerChestInventory().getDisplayName().getUnformattedText();
+			// check if the chest name has changed
+			if (!loadedInvName.equals(name)) {
+				loadedInvName = name;
 				inventoryLoaded = false;
-				inventoryLoadedTicks = 3;
+				lastTickCount = 0;
+				ticksStable = 0;
 			}
 
-			if (!inventoryLoaded) {
-				if (cc.getLowerChestInventory().getStackInSlot(cc.getLowerChestInventory().getSizeInventory() - 1) != null) {
-					inventoryLoaded = true;
-				} else {
-					for (ItemStack stack : chest.inventorySlots.getInventory()) {
-						if (stack != null) {
-							if (--inventoryLoadedTicks <= 0) {
-								inventoryLoaded = true;
-							}
-							break;
-						}
-					}
-				}
+			// sum items that are non-null
+			int nonNullCount = 0;
+			for (int i = 0; i < cc.getLowerChestInventory().getSizeInventory(); i++) {
+				if (cc.getLowerChestInventory().getStackInSlot(i) != null) nonNullCount++;
 			}
+
+			if (nonNullCount == lastTickCount) {
+				ticksStable++;
+			} else {
+				ticksStable = 0;
+			}
+			lastTickCount = nonNullCount;
+
+			// if stable for N ticks in a row, we're loaded
+			inventoryLoaded = ticksStable >= 2;
 		} else {
 			inventoryLoaded = false;
-			inventoryLoadedTicks = 3;
+			ticksStable = 0;
+			lastTickCount = 0;
 		}
-
 	}
 
 	@SubscribeEvent

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
@@ -125,7 +125,6 @@ public class RenderListener {
 	private boolean doInventoryButtons = false;
 	private NEUConfig.InventoryButton buttonHovered = null;
 	private long buttonHoveredMillis = 0;
-	private int inventoryLoadedTicks = 0;
 	private String loadedInvName = "";
 	private int lastTickCount = 0;
 	private int ticksStable = 0;
@@ -226,7 +225,7 @@ public class RenderListener {
 			lastTickCount = nonNullCount;
 
 			// if stable for N ticks in a row, we're loaded
-			inventoryLoaded = ticksStable >= 2;
+			inventoryLoaded = ticksStable >= REQUIRED_STABLE_TICKS;
 		} else {
 			inventoryLoaded = false;
 			ticksStable = 0;
@@ -257,7 +256,6 @@ public class RenderListener {
 
 		BetterContainers.reset();
 		inventoryLoaded = false;
-		inventoryLoadedTicks = 3;
 
 		//OPEN
 		if (Minecraft.getMinecraft().currentScreen == null && event.gui instanceof GuiContainer) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/listener/RenderListener.java
@@ -128,7 +128,7 @@ public class RenderListener {
 	private String loadedInvName = "";
 	private int lastTickCount = 0;
 	private int ticksStable = 0;
-	private static final int REQUIRED_STABLE_TICKS = 5;
+	private static final int REQUIRED_STABLE_TICKS = 10;
 
 	//NPC parsing
 
@@ -211,17 +211,17 @@ public class RenderListener {
 				ticksStable = 0;
 			}
 
+			if (inventoryLoaded) return;
+
 			// sum items that are non-null
 			int nonNullCount = 0;
 			for (int i = 0; i < cc.getLowerChestInventory().getSizeInventory(); i++) {
 				if (cc.getLowerChestInventory().getStackInSlot(i) != null) nonNullCount++;
 			}
 
-			if (nonNullCount == lastTickCount) {
-				ticksStable++;
-			} else {
-				ticksStable = 0;
-			}
+			if (nonNullCount == lastTickCount && nonNullCount != 0) ticksStable++;
+			else ticksStable = 0;
+
 			lastTickCount = nonNullCount;
 
 			// if stable for N ticks in a row, we're loaded

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/AccessoryBagOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/AccessoryBagOverlay.java
@@ -605,6 +605,7 @@ public class AccessoryBagOverlay {
 						String first = containerName.trim().split("\\(")[1].split("/")[0];
 						Integer currentPageNumber = Integer.parseInt(first);
 						boolean hasStack = false;
+						boolean noAcessories = true;
 						if (Minecraft.getMinecraft().thePlayer.openContainer instanceof ContainerChest) {
 							IInventory inv =
 								((ContainerChest) Minecraft.getMinecraft().thePlayer.openContainer).getLowerChestInventory();
@@ -623,7 +624,10 @@ public class AccessoryBagOverlay {
 												break;
 											}
 										}
-										if (toAdd) accessoryStacks.add(stack);
+										if (toAdd) {
+											accessoryStacks.add(stack);
+											noAcessories = false;
+										}
 									}
 								}
 							}
@@ -632,6 +636,15 @@ public class AccessoryBagOverlay {
 						if (hasStack) pagesVisited.add(currentPageNumber);
 
 						String second = containerName.trim().split("/")[1].split("\\)")[0];
+						int secondInt = Integer.parseInt(second);
+						if (noAcessories) {
+							// add all remaining page numbers to visited
+							for (int i = currentPageNumber + 1; i <= secondInt; i++) {
+								if (pagesVisited.contains(i))) continue;
+								pagesVisited.add(i);
+							}
+						}
+
 						//System.out.println(second + ":" + pagesVisited.size());
 						if (Integer.parseInt(second) > pagesVisited.size()) {
 							GlStateManager.color(1, 1, 1, 1);

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/AccessoryBagOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/AccessoryBagOverlay.java
@@ -61,6 +61,7 @@ import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 
 import java.awt.*;
+import java.io.Console;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -605,7 +606,6 @@ public class AccessoryBagOverlay {
 						String first = containerName.trim().split("\\(")[1].split("/")[0];
 						Integer currentPageNumber = Integer.parseInt(first);
 						boolean hasStack = false;
-						boolean newAccessories = false;
 						if (Minecraft.getMinecraft().thePlayer.openContainer instanceof ContainerChest) {
 							IInventory inv =
 								((ContainerChest) Minecraft.getMinecraft().thePlayer.openContainer).getLowerChestInventory();
@@ -625,7 +625,6 @@ public class AccessoryBagOverlay {
 											}
 										}
 										if (toAdd) {
-											newAccessories = true;
 											accessoryStacks.add(stack);
 										}
 									}
@@ -633,13 +632,18 @@ public class AccessoryBagOverlay {
 							}
 						}
 
-						if (hasStack) pagesVisited.add(currentPageNumber);
-
 						String second = containerName.trim().split("/")[1].split("\\)")[0];
 						int secondInt = Integer.parseInt(second);
+						if (hasStack) pagesVisited.add(currentPageNumber);
+						else if (!pagesVisited.isEmpty() && !pagesVisited.contains(secondInt)) {
+							pagesVisited.clear();
+							for (int i = 1; i < secondInt; i++) {
+								pagesVisited.add(i);
+							}
+						}
 
 						//System.out.println(second + ":" + pagesVisited.size());
-						if (secondInt > pagesVisited.size() && !newAccessories) {
+						if (secondInt > pagesVisited.size()) {
 							GlStateManager.color(1, 1, 1, 1);
 							Minecraft.getMinecraft().getTextureManager().bindTexture(accessory_bag_overlay);
 							GlStateManager.disableLighting();

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/AccessoryBagOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/AccessoryBagOverlay.java
@@ -605,7 +605,7 @@ public class AccessoryBagOverlay {
 						String first = containerName.trim().split("\\(")[1].split("/")[0];
 						Integer currentPageNumber = Integer.parseInt(first);
 						boolean hasStack = false;
-						boolean noAcessories = true;
+						boolean newAccessories = false;
 						if (Minecraft.getMinecraft().thePlayer.openContainer instanceof ContainerChest) {
 							IInventory inv =
 								((ContainerChest) Minecraft.getMinecraft().thePlayer.openContainer).getLowerChestInventory();
@@ -625,8 +625,8 @@ public class AccessoryBagOverlay {
 											}
 										}
 										if (toAdd) {
+											newAccessories = true;
 											accessoryStacks.add(stack);
-											noAcessories = false;
 										}
 									}
 								}
@@ -637,16 +637,9 @@ public class AccessoryBagOverlay {
 
 						String second = containerName.trim().split("/")[1].split("\\)")[0];
 						int secondInt = Integer.parseInt(second);
-						if (noAcessories) {
-							// add all remaining page numbers to visited
-							for (int i = currentPageNumber + 1; i <= secondInt; i++) {
-								if (pagesVisited.contains(i)) continue;
-								pagesVisited.add(i);
-							}
-						}
 
 						//System.out.println(second + ":" + pagesVisited.size());
-						if (Integer.parseInt(second) > pagesVisited.size()) {
+						if (secondInt > pagesVisited.size() && !newAccessories) {
 							GlStateManager.color(1, 1, 1, 1);
 							Minecraft.getMinecraft().getTextureManager().bindTexture(accessory_bag_overlay);
 							GlStateManager.disableLighting();

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/AccessoryBagOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/AccessoryBagOverlay.java
@@ -56,6 +56,7 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.lwjgl.Sys;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
@@ -612,7 +613,7 @@ public class AccessoryBagOverlay {
 							for (int i = 0; i < inv.getSizeInventory(); i++) {
 								ItemStack stack = inv.getStackInSlot(i);
 								if (stack != null) {
-									hasStack = true;
+									hasStack = hasStack || (i < 45);
 									if (isAccessory(stack)) {
 										boolean toAdd = true;
 										for (ItemStack accessoryStack : accessoryStacks) {
@@ -624,9 +625,7 @@ public class AccessoryBagOverlay {
 												break;
 											}
 										}
-										if (toAdd) {
-											accessoryStacks.add(stack);
-										}
+										if (toAdd) accessoryStacks.add(stack);
 									}
 								}
 							}
@@ -634,15 +633,15 @@ public class AccessoryBagOverlay {
 
 						String second = containerName.trim().split("/")[1].split("\\)")[0];
 						int secondInt = Integer.parseInt(second);
+
 						if (hasStack) pagesVisited.add(currentPageNumber);
 						else if (!pagesVisited.isEmpty() && !pagesVisited.contains(secondInt)) {
 							pagesVisited.clear();
-							for (int i = 1; i <= secondInt; i++) {
-								pagesVisited.add(i);
-							}
+							pagesVisited = new HashSet<Integer>() {{
+								for (int i = 1; i <= secondInt; i++) add(i);
+							}};
 						}
 
-						//System.out.println(second + ":" + pagesVisited.size());
 						if (secondInt > pagesVisited.size()) {
 							GlStateManager.color(1, 1, 1, 1);
 							Minecraft.getMinecraft().getTextureManager().bindTexture(accessory_bag_overlay);

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/AccessoryBagOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/AccessoryBagOverlay.java
@@ -56,13 +56,11 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.lwjgl.Sys;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 
 import java.awt.*;
-import java.io.Console;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/AccessoryBagOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/AccessoryBagOverlay.java
@@ -637,7 +637,7 @@ public class AccessoryBagOverlay {
 						if (hasStack) pagesVisited.add(currentPageNumber);
 						else if (!pagesVisited.isEmpty() && !pagesVisited.contains(secondInt)) {
 							pagesVisited.clear();
-							for (int i = 1; i < secondInt; i++) {
+							for (int i = 1; i <= secondInt; i++) {
 								pagesVisited.add(i);
 							}
 						}

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscgui/AccessoryBagOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscgui/AccessoryBagOverlay.java
@@ -640,7 +640,7 @@ public class AccessoryBagOverlay {
 						if (noAcessories) {
 							// add all remaining page numbers to visited
 							for (int i = currentPageNumber + 1; i <= secondInt; i++) {
-								if (pagesVisited.contains(i))) continue;
+								if (pagesVisited.contains(i)) continue;
 								pagesVisited.add(i);
 							}
 						}


### PR DESCRIPTION
Fixes the occasional case where the accessory helper would fail to load all active accessories. Tested across ~40 different servers, with 100% success.