### PR TITLE
Fix snow layers in etherwarp overlay

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomItemEffects.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomItemEffects.java
@@ -309,7 +309,7 @@ public class CustomItemEffects {
 					Block block = etherwarpRaycast.state.getBlock();
 					if (!block.isCollidable() ||
 						//Don't allow teleport at this block
-						block == Blocks.carpet || block == Blocks.skull ||
+						block == Blocks.carpet || block == Blocks.skull || block == Blocks.snow_layer ||
 						block.getCollisionBoundingBox(world, etherwarpRaycast.pos, etherwarpRaycast.state) == null &&
 							//Allow teleport at this block
 							block != Blocks.wall_sign && block != Blocks.standing_sign) {


### PR DESCRIPTION
Snow layers are now correctly labelled as non-solid blocks in the etherwarp overlay (incredibly important and useful fix)