### PR TITLE
Fix pet overlay sometimes picking the wrong pet from autopet

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -1199,11 +1199,14 @@ public class PetInfoOverlay extends TextOverlay {
 					List<IChatComponent> siblings = event.message.getChatStyle().getChatHoverEvent().getValue().getSiblings();
 					String petItem = "";
 					if (siblings.size() > 6) {
-						IChatComponent iChatComponent = siblings.get(siblings.size()-1);
-						String formattedText = iChatComponent.getChatStyle().getColor() + iChatComponent.getUnformattedText();
-						System.out.println(formattedText);
-						petItem = getInternalIdForPetItemDisplayName(formattedText);
-						System.out.println(petItem);
+						int i = -1;
+						for (IChatComponent sibling : siblings) {
+							i++;
+							if (!sibling.getUnformattedText().startsWith("Held Item:")) continue;
+							IChatComponent iChatComponent = siblings.get(i+1);
+							String formattedText = iChatComponent.getChatStyle().getColor() + iChatComponent.getUnformattedText();
+							petItem = getInternalIdForPetItemDisplayName(formattedText);
+						}
 					} else {
 						//this *should* make it only match with only pets without items
 						petItem = null;

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -1201,7 +1201,9 @@ public class PetInfoOverlay extends TextOverlay {
 					if (siblings.size() > 6) {
 						IChatComponent iChatComponent = siblings.get(siblings.size()-1);
 						String formattedText = iChatComponent.getChatStyle().getColor() + iChatComponent.getUnformattedText();
+						System.out.println(formattedText);
 						petItem = getInternalIdForPetItemDisplayName(formattedText);
+						System.out.println(petItem);
 					} else {
 						//this *should* make it only match with only pets without items
 						petItem = null;

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -1199,7 +1199,7 @@ public class PetInfoOverlay extends TextOverlay {
 					List<IChatComponent> siblings = event.message.getChatStyle().getChatHoverEvent().getValue().getSiblings();
 					String petItem = "";
 					if (siblings.size() > 6) {
-						IChatComponent iChatComponent = siblings.get(6);
+						IChatComponent iChatComponent = siblings.get(siblings.size()-1);
 						String formattedText = iChatComponent.getChatStyle().getColor() + iChatComponent.getUnformattedText();
 						petItem = getInternalIdForPetItemDisplayName(formattedText);
 					} else {


### PR DESCRIPTION
<!--

Thank you for choosing to contribute to NEU!

Please make sure to give your PR a descriptive title.

Your PR title will be used in our changelog and should look like one of those:

Add fleebleblub menu
Fix crash in the gorp overlay
Remove Herobrine
meta: Make documentation clearer

Use Add, Fix, or Remove at the start of your PR name.
If the change doesn't affect end-users, start your PR name with `meta:`, in which case the naming conventions above do not apply.

Do not end your PR title with a .

If your PR bundles two features, consider opening two PRs, one for each instead.

-->
