### PR TITLE
meta: add suppor for prismatic in name query

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/util/ItemResolutionQuery.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/ItemResolutionQuery.java
@@ -329,6 +329,8 @@ public class ItemResolutionQuery {
 	private static String turboCheck(String text) {
 		if (text.equals("Turbo-Cocoa")) return "Turbo-Coco";
 		if (text.equals("Turbo-Cacti")) return "Turbo-Cactus";
+		if (text.equals("Prismatic")) return "Pristine";
+		if (text.equals("Dragon Tracer")) return "Aiming";
 
 		return text;
 	}


### PR DESCRIPTION
<!--

Thank you for choosing to contribute to NEU!

Please make sure to give your PR a descriptive title.

Your PR title will be used in our changelog and should look like one of those:

Add fleebleblub menu
Fix crash in the gorp overlay
Remove Herobrine
meta: Make documentation clearer

Use Add, Fix, or Remove at the start of your PR name.
If the change doesn't affect end-users, start your PR name with `meta:`, in which case the naming conventions above do not apply.

Do not end your PR title with a .

If your PR bundles two features, consider opening two PRs, one for each instead.

-->
