### PR TITLE
Remove Titanium Alert

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinNetHandlerPlayClient.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/mixins/MixinNetHandlerPlayClient.java
@@ -120,7 +120,6 @@ public class MixinNetHandlerPlayClient {
 
 	@Inject(method = "handleBlockChange", at = @At("HEAD"))
 	public void handleBlockChange(S23PacketBlockChange packetIn, CallbackInfo ci) {
-		MiningStuff.processBlockChangePacket(packetIn);
 		ItemCooldowns.processBlockChangePacket(packetIn);
 		CrystalHollowChestHighlighter.processBlockChangePacket(packetIn);
 	}

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/Mining.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/separatesections/Mining.java
@@ -951,22 +951,6 @@ public class Mining {
 	@ConfigEditorBoolean
 	public boolean puzzlerSolver = true;
 
-	@Expose
-	@ConfigOption(
-		name = "Titanium Alert",
-		desc = "Show an alert whenever titanium appears nearby"
-	)
-	@ConfigEditorBoolean
-	public boolean titaniumAlert = true;
-
-	@Expose
-	@ConfigOption(
-		name = "Titanium must touch air",
-		desc = "Only show an alert if the Titanium touches air. (kinda sus)"
-	)
-	@ConfigEditorBoolean
-	public boolean titaniumAlertMustBeVisible = false;
-
 	@ConfigOption(
 		name = "Custom Textures",
 		desc = ""

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
@@ -267,7 +267,6 @@ public class MiningOverlay extends TextTabOverlay {
 
 		if (!NotEnoughUpdates.INSTANCE.config.mining.dwarvenOverlay &&
 			NotEnoughUpdates.INSTANCE.config.mining.emissaryWaypoints == 0 &&
-			!NotEnoughUpdates.INSTANCE.config.mining.titaniumAlert &&
 			NotEnoughUpdates.INSTANCE.config.mining.locWaypoints == 0
 			&& NotEnoughUpdates.INSTANCE.config.mining.tunnelWaypoints.get() != Mining.GlaciteTunnelWaypointBehaviour.NONE
 			&& HotmDesires.wantsPowderInfo()) {
@@ -275,7 +274,7 @@ public class MiningOverlay extends TextTabOverlay {
 		}
 
 		// Get commission and forge info even if the overlay isn't going to be rendered since it is used elsewhere
-		//thanks to "Pure Genie#7250" for helping with this (makes tita alert and waypoints work without mine overlay)
+		//thanks to "Pure Genie#7250" for helping with this (makes waypoints work without mine overlay)
 		if (SBInfo.getInstance().getLocation() == null) return;
 		if (SBInfo.getInstance().getLocation().equals("mining_3") ||
 			SBInfo.getInstance().getLocation().equals("crystal_hollows")


### PR DESCRIPTION
This feature is quite frankly useless, besides for griefing, and it's also ESP, even with the "titanium must touch air" option, so I think the best course of action is to simply remove it.

(If the maintainers disagree, I will just fix it to not be ESP instead.)