### PR TITLE
Fix it/its pronouns in profile viewer

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/util/PronounDB.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/PronounDB.java
@@ -109,7 +109,7 @@ public class PronounDB {
 	@Getter
 	public enum Pronoun {
 		HE("he", "him"),
-		IT("it", "its"), // The object is "it" but common usage is "it/its"
+		IT("it", "its"), // The object is "it" but PronounDB displays it as "it/its", matching common usage
 		SHE("she", "her"),
 		THEY("they", "them"),
 		ANY("any", null, "Any pronouns"),

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/PronounDB.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/PronounDB.java
@@ -108,32 +108,29 @@ public class PronounDB {
 
 	@Getter
 	public enum Pronoun {
-		HE("he", "him", "his"),
-		IT("it", "it", "its"),
-		SHE("she", "her", "hers"),
-		THEY("they", "them", "theirs"),
-		ANY("any", "Any pronouns"),
-		OTHER("other", "Other"),
-		ASK("ask", "Ask for pronouns"),
-		AVOID("avoid", "Avoid pronouns");
+		HE("he", "him"),
+		IT("it", "its"), // The object is "it" but common usage is "it/its"
+		SHE("she", "her"),
+		THEY("they", "them"),
+		ANY("any", null, "Any pronouns"),
+		OTHER("other", null, "Other"),
+		ASK("ask", null, "Ask for pronouns"),
+		AVOID("avoid", null, "Avoid pronouns");
 
 		private final String id;
 		private final String object;
-		private final String possessive;
 		private final String override;
 
-		Pronoun(String id, String object, String possessive) {
+		Pronoun(String id, String object) {
 			this.id = id;
 			this.object = object;
-			this.possessive = possessive;
 			this.override = null;
 		}
 
-		Pronoun(String id, String override) {
+		Pronoun(String id, String object, String override) {
 			this.id = id;
+			this.object = object;
 			this.override = override;
-			this.object = null;
-			this.possessive = null;
 		}
 	}
 


### PR DESCRIPTION
Updated the `Pronoun` enum to remove the unused `possessive`, and changed it so that "it" pronouns display as "it/its" instead of "it/it".

While technically the object form *is* "it", we are only using this to render pronouns from PronounDB, which itself renders them as "it/its", matching common usage. Therefore I chose to not overcomplicate the code by adding a second type of override for this, instead I just added a comment about this in case somehow the enum gets used for other things where the distinction is important in the future.