### PR TITLE
Fix etherwarp overlay for End Portal and Lily Pad blocks

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomItemEffects.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomItemEffects.java
@@ -309,7 +309,7 @@ public class CustomItemEffects {
 					Block block = etherwarpRaycast.state.getBlock();
 					if (!block.isCollidable() ||
 						//Don't allow teleport at this block
-						block == Blocks.carpet || block == Blocks.skull || block == Blocks.snow_layer ||
+						block == Blocks.carpet || block == Blocks.skull || block == Blocks.snow_layer || block == Blocks.end_portal ||
 						block.getCollisionBoundingBox(world, etherwarpRaycast.pos, etherwarpRaycast.state) == null &&
 							//Allow teleport at this block
 							block != Blocks.wall_sign && block != Blocks.standing_sign) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomItemEffects.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CustomItemEffects.java
@@ -309,7 +309,7 @@ public class CustomItemEffects {
 					Block block = etherwarpRaycast.state.getBlock();
 					if (!block.isCollidable() ||
 						//Don't allow teleport at this block
-						block == Blocks.carpet || block == Blocks.skull || block == Blocks.snow_layer || block == Blocks.end_portal ||
+						block == Blocks.carpet || block == Blocks.end_portal || block == Blocks.skull || block == Blocks.snow_layer || block == Blocks.waterlily ||
 						block.getCollisionBoundingBox(world, etherwarpRaycast.pos, etherwarpRaycast.state) == null &&
 							//Allow teleport at this block
 							block != Blocks.wall_sign && block != Blocks.standing_sign) {


### PR DESCRIPTION
Now correctly shows End Portal blocks (e.g. the island portal in the Hub) and Lily Pads as non-solid.

<!--

Thank you for choosing to contribute to NEU!

Please make sure to give your PR a descriptive title.

Your PR title will be used in our changelog and should look like one of those:

Add fleebleblub menu
Fix crash in the gorp overlay
Remove Herobrine
meta: Make documentation clearer

Use Add, Fix, or Remove at the start of your PR name.
If the change doesn't affect end-users, start your PR name with `meta:`, in which case the naming conventions above do not apply.

Do not end your PR title with a .

If your PR bundles two features, consider opening two PRs, one for each instead.

-->
