### PR TITLE
Fix rank priority in profile viewer

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/BasicPage.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/BasicPage.java
@@ -215,19 +215,12 @@ public class BasicPage extends GuiProfileViewerPage {
 				playerName = Utils.getElementAsString(profile.getHypixelProfile().get("prefix"), "") + " " +
 					entityPlayer.getName();
 			} else {
-				String rank = Utils.getElementAsString(
-					profile.getHypixelProfile().get("rank"),
-					Utils.getElementAsString(profile.getHypixelProfile().get("newPackageRank"), "NONE")
-				);
+				String rank = Utils.getElementAsString(profile.getHypixelProfile().get("rank"), "NORMAL");
 				if (rank.equals("NORMAL")) {
-					rank = Utils.getElementAsString(profile.getHypixelProfile().get("newPackageRank"), "NONE");
-				}
-				String monthlyPackageRank = Utils.getElementAsString(
-					profile.getHypixelProfile().get("monthlyPackageRank"),
-					"NONE"
-				);
-				if (!rank.equals("YOUTUBER") && !monthlyPackageRank.equals("NONE")) {
-					rank = monthlyPackageRank;
+					rank = Utils.getElementAsString(profile.getHypixelProfile().get("monthlyPackageRank"), "NONE");
+					if (rank.equals("NONE")) {
+						rank = Utils.getElementAsString(profile.getHypixelProfile().get("newPackageRank"), "NONE");
+					}
 				}
 				EnumChatFormatting rankPlusColorECF = EnumChatFormatting.getValueByName(
 					Utils.getElementAsString(profile.getHypixelProfile().get("rankPlusColor"), "RED")


### PR DESCRIPTION
<!--

Thank you for choosing to contribute to NEU!

Please make sure to give your PR a descriptive title.

Your PR title will be used in our changelog and should look like one of those:

Add fleebleblub menu
Fix crash in the gorp overlay
Remove Herobrine
meta: Make documentation clearer

Use Add, Fix, or Remove at the start of your PR name.
If the change doesn't affect end-users, start your PR name with `meta:`, in which case the naming conventions above do not apply.

Do not end your PR title with a .

If your PR bundles two features, consider opening two PRs, one for each instead.

-->
Fixes MVP++ taking priority over special ranks such as STAFF (other than YOUTUBE, which was already hardcoded), and in general cleans up the code around this.

See `/pv Plancke` for an example.