### PR TITLE
Fix performance when hovering over items

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/profileviewer/ProfileViewer.java
@@ -529,7 +529,7 @@ public class ProfileViewer {
 
 		manager.apiUtils
 			.request()
-			.url("https://api.mojang.com/users/profiles/minecraft/" + nameLower)
+			.url("https://api.minecraftservices.com/minecraft/profile/lookup/name/" + nameLower)
 			.requestJson()
 			.thenAccept(jsonObject -> {
 				if (jsonObject.has("id") && jsonObject.get("id").isJsonPrimitive() &&


### PR DESCRIPTION
Every frame when hovering over a tooltip, the `museum.json` constants file was being parsed, which is not ideal.
I added a cache so the file is only read once and not again. Fixed my performance from going 400 -> 250 to about 400 -> 380, which is acceptable.

Also idk why it added the two commits before but eh who cares
