### PR TITLE
Fix world memory leak

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/util/brigadier/NEUBrigadierHook.kt
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/brigadier/NEUBrigadierHook.kt
@@ -30,7 +30,6 @@ import net.minecraft.util.ChatComponentText
 import net.minecraft.util.EnumChatFormatting.YELLOW
 import java.util.concurrent.CompletableFuture
 import java.util.function.Predicate
-import java.lang.ref.WeakReference
 
 /**
  * Hook for converting brigadier commands to normal legacy Minecraft commands (string array style).
@@ -66,7 +65,7 @@ class NEUBrigadierHook(
     private fun getText(args: Array<out String>) = "${commandNode.name} ${args.joinToString(" ")}"
 
     override fun processCommand(sender: ICommandSender, args: Array<out String>) {
-        val results = brigadierRoot.parseText.apply(WeakReference(sender) to getText(args).trim())
+        val results = brigadierRoot.parseText(sender to getText(args).trim())
         if (beforeCommand?.test(results) == false)
             return
         try {
@@ -93,7 +92,7 @@ class NEUBrigadierHook(
         }
         if (lc == null) {
             lastCompletion?.cancel(true)
-            val results = brigadierRoot.parseText.apply(WeakReference(sender) to originalText)
+            val results = brigadierRoot.parseText(sender to originalText)
             lc = brigadierRoot.dispatcher.getCompletionSuggestions(results)
         }
         lastCompletion = lc

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/brigadier/NEUBrigadierHook.kt
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/brigadier/NEUBrigadierHook.kt
@@ -30,6 +30,7 @@ import net.minecraft.util.ChatComponentText
 import net.minecraft.util.EnumChatFormatting.YELLOW
 import java.util.concurrent.CompletableFuture
 import java.util.function.Predicate
+import java.lang.ref.WeakReference
 
 /**
  * Hook for converting brigadier commands to normal legacy Minecraft commands (string array style).
@@ -65,7 +66,7 @@ class NEUBrigadierHook(
     private fun getText(args: Array<out String>) = "${commandNode.name} ${args.joinToString(" ")}"
 
     override fun processCommand(sender: ICommandSender, args: Array<out String>) {
-        val results = brigadierRoot.parseText.apply(sender to getText(args).trim())
+        val results = brigadierRoot.parseText.apply(WeakReference(sender) to getText(args).trim())
         if (beforeCommand?.test(results) == false)
             return
         try {
@@ -92,7 +93,7 @@ class NEUBrigadierHook(
         }
         if (lc == null) {
             lastCompletion?.cancel(true)
-            val results = brigadierRoot.parseText.apply(sender to originalText)
+            val results = brigadierRoot.parseText.apply(WeakReference(sender) to originalText)
             lc = brigadierRoot.dispatcher.getCompletionSuggestions(results)
         }
         lastCompletion = lc

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/util/brigadier/BrigadierRoot.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/util/brigadier/BrigadierRoot.kt
@@ -25,22 +25,23 @@ import com.mojang.brigadier.tree.ArgumentCommandNode
 import com.mojang.brigadier.tree.CommandNode
 import io.github.moulberry.notenoughupdates.autosubscribe.NEUAutoSubscribe
 import io.github.moulberry.notenoughupdates.events.RegisterBrigadierCommandEvent
-import io.github.moulberry.notenoughupdates.util.LRUCache
 import net.minecraft.command.ICommandSender
 import net.minecraftforge.client.ClientCommandHandler
 import java.lang.RuntimeException
 import java.util.*
-import java.lang.ref.WeakReference
 
 @NEUAutoSubscribe
 object BrigadierRoot {
     private val help: MutableMap<CommandNode<DefaultSource>, String> = IdentityHashMap()
     var dispatcher = CommandDispatcher<DefaultSource>()
         private set
-    val parseText =
-        LRUCache.memoize<Pair<WeakReference<ICommandSender>, String>, ParseResults<DefaultSource>>({ (sender, text) ->
-            dispatcher.parse(text, sender.get())
-        }, 1)
+
+    private val parseCache =
+        Collections.synchronizedMap(WeakHashMap<Pair<ICommandSender, String>, ParseResults<DefaultSource>>())
+
+    val parseText: (Pair<ICommandSender, String>) -> ParseResults<DefaultSource> = { (sender, text) ->
+        parseCache.computeIfAbsent(sender to text) { dispatcher.parse(text, sender) }
+    }
 
     fun getHelpForNode(node: CommandNode<DefaultSource>): String? {
         return help[node]
@@ -53,7 +54,6 @@ object BrigadierRoot {
         help[node] = helpText
     }
 
-
     fun getAllUsages(
         path: String,
         node: CommandNode<ICommandSender>,
@@ -63,7 +63,7 @@ object BrigadierRoot {
         visited.add(node)
         val redirect = node.redirect
         if (redirect != null) {
-            yieldAll(getAllUsages(path, node.redirect, visited))
+            yieldAll(getAllUsages(path, redirect, visited))
             visited.remove(node)
             return@sequence
         }
@@ -79,7 +79,6 @@ object BrigadierRoot {
         visited.remove(node)
     }
 
-
     fun updateHooks() = registerHooks(ClientCommandHandler.instance)
 
     fun registerHooks(handler: ClientCommandHandler) {
@@ -90,7 +89,7 @@ object BrigadierRoot {
         }
         dispatcher = CommandDispatcher()
         help.clear()
-        parseText.clearCache()
+        parseCache.clear()
         val event = RegisterBrigadierCommandEvent(this)
         event.post()
         event.hooks.forEach {
@@ -102,3 +101,4 @@ object BrigadierRoot {
         }
     }
 }
+

--- a/src/main/kotlin/io/github/moulberry/notenoughupdates/util/brigadier/BrigadierRoot.kt
+++ b/src/main/kotlin/io/github/moulberry/notenoughupdates/util/brigadier/BrigadierRoot.kt
@@ -30,6 +30,7 @@ import net.minecraft.command.ICommandSender
 import net.minecraftforge.client.ClientCommandHandler
 import java.lang.RuntimeException
 import java.util.*
+import java.lang.ref.WeakReference
 
 @NEUAutoSubscribe
 object BrigadierRoot {
@@ -37,8 +38,8 @@ object BrigadierRoot {
     var dispatcher = CommandDispatcher<DefaultSource>()
         private set
     val parseText =
-        LRUCache.memoize<Pair<ICommandSender, String>, ParseResults<DefaultSource>>({ (sender, text) ->
-            dispatcher.parse(text, sender)
+        LRUCache.memoize<Pair<WeakReference<ICommandSender>, String>, ParseResults<DefaultSource>>({ (sender, text) ->
+            dispatcher.parse(text, sender.get())
         }, 1)
 
     fun getHelpForNode(node: CommandNode<DefaultSource>): String? {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e0785983-2376-4a0b-9ba3-bcfc2c02a511)

Fixes a world memory leak, which caused insuffurable lag due to many Old Garbage Collections after long gameplay sessions involving swapping lots of worlds, due to CommandSender (mostly EntityPlayerSP, ourselves) keeping a reference to the world they were in, even after changing to a new world.

A new EntityPlayerSP instance is created and the old one should be discarded but NEU kept a strong reference to it, and the player instance has a reference to world, and the world of course has references to everything inside it; chunks, entities, tile entities, etc. - which caused all the previous worlds you have been in to not be cleared from memory. The leak is not noticeable in effect at start before you swap worlds, and you probably wouldn't notice after a few swaps either. But if you play for a long session and swap lot of worlds, such as Dungeon instances, your memory will continue filling up and require a restart to get rid of 3 second plus Old Gen GC memory cleanup done by the JVM every few seconds (which is a Stop-The-World process, so the game will freeze during this memory cleanup performed by JVM, in simple terms.).

If I'm going to be honest, this fix is not the best, but it fixes the leak. Possible issues with the fix:
 - ~~WeakReference.get can return null, old code had a strong reference so it would never be null. Not sure if this could create an issue, but all NEU commands seem to work correctly still per my testing. Likely because .get is only ever called with the current player (due to it being impossible to send commands from a world you just left).~~
 -  ~~WeakReference object itself is still leaked even if the underlying CommandSender (and the World it's in) isn't. While this consumes much less memory than before (a whole world with all its entities, chunks, etc. being leaked vs a small wrapper object being leaked) it's still not a clean solution. A clean solution would be to use a Weak collection type that automatically discards cleared references, such as WeakHashMap from Java standard library. I am not sure we should be replacing the LRUCache though, as I didn't write this code I don't know if changing it to a WeakHashMap would introduce any further bugs or regressions.~~
 - ~~WeakReference.hashCode is likely different, we create a new WeakReference each time a CommandSender is put to the LRUCache, it probably doesn't return the underlying CommandSender's hashCode so this might break the purpose of the cache entirely. However LRUCache seems to be a NEU internal class and not a standard Java collection type so I don't know if it depends on .hashCode for its operations.~~
 - Not sure why the NEUBrigadierHook.kt file is in src/main/java instead of src/main/kotlin, but I didn't want to change that in an unrelated PR.
 - I have not tested other CommandSender implementations but I assume that's a very rare use case anyways (such as CommandBlockCommandSender in singleplayer)
 
Tested different NEU commands including tab completion and everything seems to work after the fix and no leak is present, with no Old GC occurring.

Input needed regarding Point no 2 and 3 about a possible change to WeakHashMap, which would both fix WeakReference wrapper objects still being leaked and the .hashCode issue. Moving the file from src/main/java to src/main/kotlin is out of scope in this PR, point no. 1 likely doesnt cause any issues, and point no 5. likely does not apply since I doubt NEU supports running it's commands from a command block at all.

PR marked as draft till possible change to WeakHashMap or ensuring WeakReference does not cause any of the possible listed issues.

Slight footnote: I have said world, but assume it's a BungeeCord server change in Hypixel. I haven't tested this, but the EntityPlayerSP is likely 1 static object if you are playing in a regular server or singleplayer even if you change worlds.