### PR TITLE
Remove unnecessary .intern() call

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/util/ItemResolutionQuery.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/ItemResolutionQuery.java
@@ -106,7 +106,7 @@ public class ItemResolutionQuery {
 		if (resolvedName == null) {
 			resolvedName = resolveContextualName();
 		} else {
-			switch (resolvedName.intern()) {
+			switch (resolvedName) {
 				case "PET":
 					resolvedName = resolvePetName();
 					break;


### PR DESCRIPTION
Equal to PR https://github.com/hannibal002/SkyHanni/pull/4474 from SH

It's not necessary in Java either as switch() on a String compiles down to a .hashCode integer switch and then a .equals check to rule out any hash code collisions automatically in Java 7 or above, and < Java 7 didn't support switching on a String in the first place, so not even sure why it was put there originally to be honest, but this PR gets rid of it.

Potential benefits: Less memory usage and more room for other constant strings to be put into the string pool. No significiant known downside that I can think of (maybe a little more allocation rate due to no forced string deduplication, but that's JIT/JVM's job to worry about), while MC 1.8 technically supports and is compiled with Java 6, NEU is already built with Java 8 and the string switch is a compile time syntatic sugar feature meaning in runtime its no different than integer switching on the string's hashCode and then doing a manual equals check afterwards to rule out hash collisions.

-XX:+UseStringDeduplication JVM argument can be used to let JVM automatically put commonly used String's that survive at least 3 GC's into the shared string pool. String#intern() should not be called manually much like how System#gc() should not be called manually. This JVM's job to handle.